### PR TITLE
toggle metric units

### DIFF
--- a/src/Aircraft.cpp
+++ b/src/Aircraft.cpp
@@ -24,11 +24,11 @@
 
 Aircraft::Aircraft(QObject *parent) : QObject(parent) {
     _cruiseSpeedInKT = settings.value("Aircraft/cruiseSpeedInKTS", 0.0).toDouble();
-    if ((_cruiseSpeedInKT < minAircraftSpeed) || (_cruiseSpeedInKT > maxAircraftSpeed))
+    if ((_cruiseSpeedInKT < minAircraftSpeedInKT) || (_cruiseSpeedInKT > maxAircraftSpeedInKT))
         _cruiseSpeedInKT = qQNaN();
 
     _descentSpeedInKT = settings.value("Aircraft/descentSpeedInKTS", 0.0).toDouble();
-    if ((_descentSpeedInKT < minAircraftSpeed) || (_descentSpeedInKT > maxAircraftSpeed))
+    if ((_descentSpeedInKT < minAircraftSpeedInKT) || (_descentSpeedInKT > maxAircraftSpeedInKT))
         _descentSpeedInKT = qQNaN();
 
     _fuelConsumptionInLPH = settings.value("Aircraft/fuelConsumptionInLPH", 0.0).toDouble();
@@ -36,26 +36,54 @@ Aircraft::Aircraft(QObject *parent) : QObject(parent) {
         _fuelConsumptionInLPH = qQNaN();
 }
 
-void Aircraft::setCruiseSpeedInKT(double speedInKTS) {
-    if ((speedInKTS < minAircraftSpeed) || (speedInKTS > maxAircraftSpeed))
-        speedInKTS = qQNaN();
+double Aircraft::cruiseSpeedInKT() const {
+    return _cruiseSpeedInKT;
+}
 
-    if (!qFuzzyCompare(speedInKTS, _cruiseSpeedInKT)) {
-        _cruiseSpeedInKT = speedInKTS;
+void Aircraft::setCruiseSpeedInKT(double speedInKT) {
+    if ((speedInKT < minAircraftSpeedInKT) || (speedInKT > maxAircraftSpeedInKT))
+        speedInKT = qQNaN();
+
+    if (!qFuzzyCompare(speedInKT, _cruiseSpeedInKT)) {
+        _cruiseSpeedInKT = speedInKT;
         settings.setValue("Aircraft/cruiseSpeedInKTS", _cruiseSpeedInKT);
         emit valChanged();
     }
 }
 
-void Aircraft::setDescentSpeedInKT(double speedInKTS) {
-    if ((speedInKTS < minAircraftSpeed) || (speedInKTS > maxAircraftSpeed))
-        speedInKTS = qQNaN();
+double Aircraft::cruiseSpeedInKMH() const {
+    auto speed = AviationUnits::Speed::fromKT(_cruiseSpeedInKT);
+    return speed.toKMH();
+}
 
-    if (!qFuzzyCompare(speedInKTS, _descentSpeedInKT)) {
-        _descentSpeedInKT = speedInKTS;
+void Aircraft::setCruiseSpeedInKMH(double speedInKMH) {
+    auto speed = AviationUnits::Speed::fromKMH(speedInKMH);
+    setCruiseSpeedInKT(speed.toKT());
+}
+
+double Aircraft::descentSpeedInKT() const {
+    return _descentSpeedInKT;
+}
+
+void Aircraft::setDescentSpeedInKT(double speedInKT) {
+    if ((speedInKT < minAircraftSpeedInKT) || (speedInKT > maxAircraftSpeedInKT))
+        speedInKT = qQNaN();
+
+    if (!qFuzzyCompare(speedInKT, _descentSpeedInKT)) {
+        _descentSpeedInKT = speedInKT;
         settings.setValue("Aircraft/descentSpeedInKTS", _descentSpeedInKT);
         emit valChanged();
     }
+}
+
+double Aircraft::descentSpeedInKMH() const {
+    auto speed = AviationUnits::Speed::fromKT(_descentSpeedInKT);
+    return speed.toKMH();
+}
+
+void Aircraft::setDescentSpeedInKMH(double speedInKMH) {
+    auto speed = AviationUnits::Speed::fromKMH(speedInKMH);
+    setDescentSpeedInKT(speed.toKT());
 }
 
 void Aircraft::setFuelConsumptionInLPH(double fuelConsumptionInLPH) {

--- a/src/Aircraft.h
+++ b/src/Aircraft.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <QSettings>
+#include "AviationUnits.h"
+
 
 /*! \brief This extremely simple class holds a few numbers that describe an
     aircraft */
@@ -48,14 +50,13 @@ public:
      * double number that lies in the interval [minAircraftSpeed,
      * maxAircraftSpeed] or NaN if the cruise speed has not been set.
      */
-    Q_PROPERTY(
-            double cruiseSpeedInKT READ cruiseSpeedInKT WRITE setCruiseSpeedInKT NOTIFY valChanged)
+    Q_PROPERTY(double cruiseSpeedInKT READ cruiseSpeedInKT WRITE setCruiseSpeedInKT NOTIFY valChanged)
 
     /*! \brief Getter function for property of the same name
      *
      * @returns Property cruise speed
      */
-    double cruiseSpeedInKT() const { return _cruiseSpeedInKT; }
+    double cruiseSpeedInKT() const;
 
     /*! \brief Setter function for property of the same name
      *
@@ -66,6 +67,30 @@ public:
      * @param speedInKT Property cruise speed
      */
     void setCruiseSpeedInKT(double speedInKT);
+
+    /*! \brief Cruise Speed
+     *
+     * This property holds the cruise speed of the aircraft. This is a
+     * double number that lies in the interval [minAircraftSpeed,
+     * maxAircraftSpeed] or NaN if the cruise speed has not been set.
+     */
+    Q_PROPERTY(double cruiseSpeedInKMH READ cruiseSpeedInKMH WRITE setCruiseSpeedInKMH NOTIFY valChanged)
+
+    /*! \brief Getter function for property of the same name
+     *
+     * @returns Property cruise speed
+     */
+    double cruiseSpeedInKMH() const;
+
+    /*! \brief Setter function for property of the same name
+     *
+     * This method saves the new value in a QSetting object. If speedInKT is
+     * outside of the interval [minAircraftSpeed, maxAircraftSpeed], the
+     * property will be set to NaN.
+     *
+     * @param speedInKT Property cruise speed
+     */
+    void setCruiseSpeedInKMH(double speedInKT);
 
     /*! \brief Decent Speed
      *
@@ -79,7 +104,7 @@ public:
      *
      * @returns Property descentSpeedInKT
      */
-    double descentSpeedInKT() const { return _descentSpeedInKT; }
+    double descentSpeedInKT() const;
 
     /*! \brief Setter function for property of the same name
      *
@@ -90,6 +115,30 @@ public:
      * @param speedInKT Descent speed in knots
      */
     void setDescentSpeedInKT(double speedInKT);
+
+    /*! \brief Decent Speed
+     *
+     * This property holds the descent speed of the aircraft. This is a
+     * number that lies in the interval [minAircraftSpeed, maxAircraftSpeed]
+     * or NaN if the cruise speed has not been set.
+     */
+    Q_PROPERTY(double descentSpeedInKMH READ descentSpeedInKMH WRITE setDescentSpeedInKMH NOTIFY valChanged)
+
+    /*! \brief Getter function for property of the same name
+     *
+     * @returns Property descentSpeedInKMH
+     */
+    double descentSpeedInKMH() const;
+
+    /*! \brief Setter function for property of the same name
+     *
+     * This method saves the new value in a QSetting object. If speedInKT is
+     * outside of the interval [minAircraftSpeed, maxAircraftSpeed], the
+     * property will be set to NaN.
+     *
+     * @param speedInKT Descent speed in knots
+     */
+    void setDescentSpeedInKMH(double speedInKT);
 
     /*! \brief Fuel Consumption
      *
@@ -115,11 +164,17 @@ public:
      */
     void setFuelConsumptionInLPH(double fuelConsumptionInLPH);
 
-    /*! \brief Minimal speed of the aircraft that is considered valid */
-    Q_PROPERTY(double minAircraftSpeed MEMBER minAircraftSpeed CONSTANT)
+    /*! \brief Minimal speed of the aircraft that is considered valid in kt*/
+    Q_PROPERTY(double minAircraftSpeedInKT MEMBER minAircraftSpeedInKT CONSTANT)
 
-    /*! \brief Maximal speed of the aircraft that is considered valid */
-    Q_PROPERTY(double maxAircraftSpeed MEMBER maxAircraftSpeed CONSTANT)
+    /*! \brief Minimal speed of the aircraft that is considered valid in km/h*/
+    Q_PROPERTY(double minAircraftSpeedInKMH MEMBER minAircraftSpeedInKMH CONSTANT)
+
+    /*! \brief Maximal speed of the aircraft that is considered valid in kt*/
+    Q_PROPERTY(double maxAircraftSpeedInKT MEMBER maxAircraftSpeedInKT CONSTANT)
+
+    /*! \brief Maximal speed of the aircraft that is considered valid in km/h*/
+    Q_PROPERTY(double maxAircraftSpeedInKMH MEMBER maxAircraftSpeedInKMH CONSTANT)
 
     /*! \brief Minimal fuel consumption that is considered valid */
     Q_PROPERTY(double minFuelConsuption MEMBER minFuelConsuption CONSTANT)
@@ -134,8 +189,10 @@ signals:
 private:
     Q_DISABLE_COPY_MOVE(Aircraft)
 
-    static constexpr double minAircraftSpeed = 40.0;
-    static constexpr double maxAircraftSpeed = 400.0;
+    static constexpr double minAircraftSpeedInKT  = 40.0;
+    static constexpr double minAircraftSpeedInKMH = minAircraftSpeedInKT * AviationUnits::Speed::KMH_per_KT;
+    static constexpr double maxAircraftSpeedInKT  = 400.0;
+    static constexpr double maxAircraftSpeedInKMH = maxAircraftSpeedInKT * AviationUnits::Speed::KMH_per_KT;
     static constexpr double minFuelConsuption = 5.0;
     static constexpr double maxFuelConsuption = 100.0;
 

--- a/src/AviationUnits.h
+++ b/src/AviationUnits.h
@@ -234,6 +234,12 @@ public:
          */
         double toM() const { return _distanceInM; }
 
+        /*! \brief Convert to meters
+         *
+         * @returns distance in meters
+         */
+        double toKM() const { return _distanceInM / 1000.; }
+
         /*! \brief Convert to feet
          *
          * @returns distance in feet

--- a/src/AviationUnits.h
+++ b/src/AviationUnits.h
@@ -279,6 +279,18 @@ public:
             return result;
         }
 
+        /*! \brief Constructs a speed
+         *
+         * @param speedInKMH  speed in km/h
+         *
+         * @returns speed
+         */
+        static Speed fromKMH(double speedInKMH) {
+            Speed result;
+            result._speedInMPS = speedInKMH / KMH_per_MPS;
+            return result;
+        }
+
         /*! \brief Checks if the speed is valid
          *
          * @returns True is the distance is a finite number
@@ -315,9 +327,25 @@ public:
          */
         double toKT() const { return _speedInMPS * KT_per_MPS; }
 
-    private:
+        /*! \brief Convert to knots
+         *
+         * @returns speed in knots (=Nautical miles per hour)
+         */
+        double toKMH() const { return _speedInMPS * KMH_per_MPS; }
+
+        /*! \brief Unitless constant: one knot / meters per second
+         */
         static constexpr double KT_per_MPS = 1.943844;
 
+        /*! \brief Unitless constant: one km/h / meters per second
+         */
+        static constexpr double KMH_per_MPS = 3.6;
+
+        /*! \brief Unitless constant: one km/h / knot
+         */
+        static constexpr double KMH_per_KT = KMH_per_MPS / KT_per_MPS;
+
+    private:
         // Speed in meters per second
         double _speedInMPS{qQNaN()};
     };

--- a/src/FlightRoute.cpp
+++ b/src/FlightRoute.cpp
@@ -251,7 +251,17 @@ QString FlightRoute::suggestedFilename() const
 }
 
 
-QString FlightRoute::summary() const
+QString FlightRoute::summary() const {
+    return makeSummary(false);
+}
+
+
+QString FlightRoute::summaryMetric() const {
+    return makeSummary(true);
+}
+
+
+QString FlightRoute::makeSummary(bool inMetricUnits) const
 {
     if (_legs.empty())
         return {};
@@ -270,7 +280,11 @@ QString FlightRoute::summary() const
         }
     }
 
-    result += QString("Total: %1&nbsp;NM").arg(dist.toNM(), 0, 'f', 1);
+    if (inMetricUnits) {
+        result += QString("Total: %1&nbsp;km").arg(dist.toKM(), 0, 'f', 1);
+    } else {
+        result += QString("Total: %1&nbsp;NM").arg(dist.toNM(), 0, 'f', 1);
+    }
     if (time.isFinite())
         result += QString(" • %1&nbsp;h").arg(time.toHoursAndMinutes());
     if (qIsFinite(fuelInL))

--- a/src/FlightRoute.h
+++ b/src/FlightRoute.h
@@ -252,6 +252,15 @@ public:
      */
     QString summary() const;
 
+    /*! \brief Human-readable summary of the flight route in metric values*/
+    Q_PROPERTY(QString summaryMetric READ summaryMetric NOTIFY summaryChanged)
+
+    /*! \brief Getter function for the property with the same name
+     *
+     * @returns Property summaryMetric
+     */
+    QString summaryMetric() const;
+
     /*! \brief Exports to route to GeoJSON
      *
      * This method serialises the current flight route as a GeoJSON
@@ -323,6 +332,9 @@ private:
 
     // Helper function for method toGPX
     QString gpxElements(const QString& indent, const QString& tag) const;
+
+    // Helper function for creating the flight route summary
+    QString makeSummary(bool inMetricUnits) const;
 
     // File name where the flight route is loaded upon startup are stored.  This
     // member is filled in in the constructor to

--- a/src/FlightRoute_Leg.cpp
+++ b/src/FlightRoute_Leg.cpp
@@ -116,11 +116,27 @@ bool FlightRoute::Leg::isValid() const
 
 QString FlightRoute::Leg::description() const
 {
+    return makeDescription(false);
+}
+
+
+QString FlightRoute::Leg::descriptionMetric() const
+{
+    return makeDescription(true);
+}
+
+
+QString FlightRoute::Leg::makeDescription(bool useMetricUnits) const
+{
     if (!isValid())
         return QString();
 
     QString result;
-    result += QString("%1 NM").arg(distance().toNM(), 0, 'f', 1);
+    if (useMetricUnits) {
+        result += QString("%1 km").arg(distance().toKM(), 0, 'f', 1);
+    } else {
+        result += QString("%1 NM").arg(distance().toNM(), 0, 'f', 1);
+    }
     auto _time = Time();
     if (_time.isFinite())
         result += QString(" • %1 h").arg(_time.toHoursAndMinutes());

--- a/src/FlightRoute_Leg.h
+++ b/src/FlightRoute_Leg.h
@@ -41,7 +41,7 @@ public:
    * @param start Pointer to the starting point
    *
    * @param end Pointer to the end point
-   * 
+   *
    * @param aircraft Pointer to aircraft info that is used in route
    * computations. It is possible to set a nullptr here or delete the object anytime, but then wind computations will no longer work.
    *
@@ -50,91 +50,100 @@ public:
    * @param parent The standard QObject parent pointer.
    */
   explicit Leg(const Waypoint* start, const Waypoint *end, Aircraft *aircraft, Wind *wind, QObject *parent = nullptr);
-  
+
   // Standard destructor
   ~Leg() override = default;
-  
+
   /*! \brief Length of the leg */
   Q_PROPERTY(AviationUnits::Distance distance READ distance CONSTANT)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property distance
    */
   AviationUnits::Distance distance() const;
-  
+
   /*! \brief Fuel
    *
    * This property holds the fuel consumption for the leg, in liters. It holds
    * NaN if the leg is invalid or if the fuel consumption cannot be computed.
    */
   Q_PROPERTY(double Fuel READ Fuel NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property Fuel
    */
   double Fuel() const;
-  
+
   /*! \brief Ground speed
    *
    * This property holds the ground speed for the leg, in meters per second. It
    * holds NaN if the leg is invalid or if the ground speed cannot be computed.
    */
   Q_PROPERTY(AviationUnits::Speed GS READ GS NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property GS
    */
   AviationUnits::Speed GS() const;
-  
+
   /*! \brief True course
    *
    * This property holds the true course for the leg. It holds NaN if the leg is
    * invalid or shorter than 100m
    */
   Q_PROPERTY(AviationUnits::Angle TC READ TC NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property TC
    */
   AviationUnits::Angle TC() const;
-  
-  /*! \brief Time required for this leg. 
+
+  /*! \brief Time required for this leg.
    *
    * Set to NaN if the time cannot be computed.
    */
   Q_PROPERTY(AviationUnits::Time Time READ Time NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property Time
    */
   AviationUnits::Time Time() const{ return distance()/GS(); }
-  
+
   /*! \brief True heading.
    *
    * Set to NaN if a TH cannot be computed.
    */
   Q_PROPERTY(AviationUnits::Angle TH READ TH CONSTANT)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property TH
    */
   AviationUnits::Angle TH() const { return TC()+WCA(); }
-  
+
   /*! \brief Human-readable description of the leg */
   Q_PROPERTY(QString description READ description NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
    *
    * @returns Property description
    */
   QString description() const;
-  
+
+  /*! \brief Human-readable description of the leg */
+  Q_PROPERTY(QString descriptionMetric READ descriptionMetric NOTIFY valChanged)
+
+  /*! \brief Getter function for property of the same name
+   *
+   * @returns Property descriptionMetric
+   */
+  QString descriptionMetric() const;
+
   /*! \brief Validity
    *
    * A leg is considered invalid of either start or endpoint are invalid.
@@ -142,26 +151,29 @@ public:
    * @returns True if the leg is valid
    */
   bool isValid() const;
-  
+
   /*! \brief Wind correction angle.
    *
    * @returns Wind correction angle, or NaN if a WCA cannot be computed
    */
   AviationUnits::Angle WCA() const;
-  
+
 signals:
   /*! \brief Notification signal */
   void valChanged();
-  
+
 private:
   Q_DISABLE_COPY_MOVE(Leg)
 
   // Necessary data for computation of wind triangle?
   bool hasDataForWindTriangle() const;
-  
+
+  // Helper function for creating the text in the flight route
+  QString makeDescription(bool useMetricValues) const;
+
   // Minimum length of the leg in meters. If shorter, no courses are computed.
   static constexpr double minLegLength  =  100.0;
-  
+
   QPointer<Waypoint> _start {nullptr};
   QPointer<Waypoint> _end {nullptr};
   QPointer<Aircraft> _aircraft {nullptr};

--- a/src/GlobalSettings.cpp
+++ b/src/GlobalSettings.cpp
@@ -76,6 +76,15 @@ void GlobalSettings::setLastWhatsNewHash(uint lwnh)
 }
 
 
+void GlobalSettings::setUseMetricUnits(bool unitHorrizKmh)
+{
+    if (unitHorrizKmh == useMetricUnits())
+        return;
+
+    settings.setValue("System/useMetricUnits", unitHorrizKmh);
+    emit useMetricUnitsChanged();
+}
+
 void GlobalSettings::setPreferEnglish(bool preferEng)
 {
     if (preferEng == preferEnglish())

--- a/src/GlobalSettings.h
+++ b/src/GlobalSettings.h
@@ -115,6 +115,23 @@ public:
     void setHideUpperAirspaces(bool hide);
 
     /*! \brief Set to true is app should be shown in English rather than the system language */
+    Q_PROPERTY(bool useMetricUnits READ useMetricUnits WRITE setUseMetricUnits NOTIFY useMetricUnitsChanged)
+
+    /*! \brief Getter function for property of the same name
+     *
+     * @returns Property useMetricUnits
+     */
+    bool useMetricUnits() const { return settings.value("System/useMetricUnits", false).toBool(); }
+
+    /*! \brief Setter function for property of the same name
+     *
+     * Setting this property will switch the horrizontal speed unit to km/h instead of kt.
+     *
+     * @param unitHorrizKmh Property unitHorrizKmh
+     */
+    void setUseMetricUnits(bool unitHorrizKmh);
+
+    /*! \brief Set to true is app should be shown in English rather than the system language */
     Q_PROPERTY(bool preferEnglish READ preferEnglish WRITE setPreferEnglish NOTIFY preferEnglishChanged)
 
     /*! \brief Getter function for property of the same name
@@ -143,9 +160,13 @@ signals:
 
     /*! Notifier signal */
     void preferEnglishChanged();
+
+    /*! Notifier signal */
+    void useMetricUnitsChanged();
+
 private:
     Q_DISABLE_COPY_MOVE(GlobalSettings)
-    
+
     // Removes/Installs global application translators, according to the settings value "System/preferEnglish"
     void installTranslators();
 

--- a/src/ScaleQuickItem.cpp
+++ b/src/ScaleQuickItem.cpp
@@ -38,12 +38,12 @@ void ScaleQuickItem::paint(QPainter *painter)
         return;
 
     // Pre-compute a few numbers that will be used when drawing
-    qreal pixelPerNM        = _pixelPer10km*0.1852;
-    qreal widthInNM         = (width()-10.0)/pixelPerNM;
-    qreal scaleUnitInNM     = pow(10.0, floor(log10(widthInNM)));
-    int   widthOfUnitInPix  = qRound(scaleUnitInNM*pixelPerNM);
-    qreal widthOfScaleInNM  = floor(widthInNM/scaleUnitInNM)*scaleUnitInNM;
-    int   widthOfScaleInPix = qRound(widthOfScaleInNM*pixelPerNM);
+    qreal pixelPerUnit        = _useMetricUnits ? _pixelPer10km * 0.1 : _pixelPer10km * 0.1852;
+    qreal widthInUnit         = (width()-10.0)/pixelPerUnit;
+    qreal scaleUnitInUnit     = pow(10.0, floor(log10(widthInUnit)));
+    int   widthOfUnitInPix    = qRound(scaleUnitInUnit*pixelPerUnit);
+    qreal widthOfScaleInUnit  = floor(widthInUnit/scaleUnitInUnit)*scaleUnitInUnit;
+    int   widthOfScaleInPix   = qRound(widthOfScaleInUnit*pixelPerUnit);
 
     // Compute size of text. Set font to somewhat smaller than standard size.
     QFont font = painter->font();
@@ -52,7 +52,7 @@ void ScaleQuickItem::paint(QPainter *painter)
     else
         font.setPixelSize(qRound(font.pixelSize()*0.8));
     painter->setFont(font);
-    QString text = QString("%1 nm").arg(widthOfScaleInNM);
+    QString text = QString(_useMetricUnits ? "%1 km" : "%1 NM").arg(widthOfScaleInUnit);
     int textWidth = painter->fontMetrics().horizontalAdvance(text);
 
     // Draw only if width() is large enough
@@ -71,14 +71,14 @@ void ScaleQuickItem::paint(QPainter *painter)
     painter->drawLine(baseX, baseY, baseX+widthOfScaleInPix, baseY);
     painter->drawLine(baseX, baseY+3, baseX, baseY-3);
     painter->drawLine(baseX+widthOfScaleInPix, baseY+3, baseX+widthOfScaleInPix, baseY-3);
-    for(int i=1; i*scaleUnitInNM<widthOfScaleInNM; i+= 1)
+    for(int i=1; i*scaleUnitInUnit<widthOfScaleInUnit; i+= 1)
         painter->drawLine(baseX + i*widthOfUnitInPix, baseY, baseX + i*widthOfUnitInPix, baseY+3);
 
     painter->setPen(QPen(Qt::black, 1));
     painter->drawLine(baseX, baseY, baseX+widthOfScaleInPix, baseY);
     painter->drawLine(baseX, baseY+3, baseX, baseY-3);
     painter->drawLine(baseX+widthOfScaleInPix, baseY+3, baseX+widthOfScaleInPix, baseY-3);
-    for(int i=1; i*scaleUnitInNM<widthOfScaleInNM; i+= 1)
+    for(int i=1; i*scaleUnitInUnit<widthOfScaleInUnit; i+= 1)
         painter->drawLine(baseX + i*widthOfUnitInPix, baseY, baseX + i*widthOfUnitInPix, baseY+3);
 
     // Draw text
@@ -94,4 +94,14 @@ void ScaleQuickItem::setPixelPer10km(qreal _pxp10k)
     _pixelPer10km = _pxp10k;
     update();
     emit pixelPer10kmChanged();
+}
+
+
+void ScaleQuickItem::setUseMetricUnits(bool useMetricUnits)
+{
+    if (_useMetricUnits == useMetricUnits)
+        return;
+
+    _useMetricUnits = useMetricUnits;
+    update();
 }

--- a/src/ScaleQuickItem.h
+++ b/src/ScaleQuickItem.h
@@ -38,7 +38,7 @@ class ScaleQuickItem : public QQuickPaintedItem
   Q_OBJECT
 
 public:
-  /*! \brief Standard constructor 
+  /*! \brief Standard constructor
 
     @param parent The standard QObject parent pointer
   */
@@ -48,19 +48,28 @@ public:
   Q_PROPERTY(qreal pixelPer10km READ pixelPer10km WRITE setPixelPer10km NOTIFY pixelPer10kmChanged)
 
   /*! \brief Getter function for the property with the same name
-    
+
     @returns Property pixelPer10km
   */
   qreal pixelPer10km() const {return _pixelPer10km;}
 
   /*! \brief Setter function for the property with the same name
-    
+
     @param _pxp10k  Property pixelPer10km
   */
   void setPixelPer10km(qreal _pxp10k);
-  
+
+  /*! \brief Number of pixel that represent a distance of 10km on the map */
+  Q_PROPERTY(bool useMetricUnits WRITE setUseMetricUnits)
+
+  /*! \brief Setter function for the property with the same name
+
+    @param _pxp10k  Property useMetricUnits
+  */
+  void setUseMetricUnits(bool useMetricUnits);
+
   /*! \brief Re-implemented from QQuickPaintedItem to implement painting
-    
+
     @param painter Pointer to the QPainter used for painting
   */
   void paint(QPainter *painter) override;
@@ -73,4 +82,5 @@ private:
   Q_DISABLE_COPY_MOVE(ScaleQuickItem)
 
   qreal _pixelPer10km {0.0};
+  bool _useMetricUnits {false};
 };

--- a/src/Waypoint.cpp
+++ b/src/Waypoint.cpp
@@ -158,10 +158,16 @@ QJsonObject Waypoint::toJSON() const
 }
 
 
-QString Waypoint::wayFrom(const QGeoCoordinate& position) const
+QString Waypoint::wayFrom(const QGeoCoordinate& position, bool useMetricUnits) const
 {
     auto dist = AviationUnits::Distance::fromM(position.distanceTo(_coordinate));
     auto TC = qRound(position.azimuthTo(_coordinate));
 
-    return QString("%1 NM • TC %2°").arg(dist.toNM(), 0, 'f', 1).arg(TC);
+    QString result;
+    if (useMetricUnits) {
+        result += QString("%1 km • TC %2°").arg(dist.toKM(), 0, 'f', 1).arg(TC);
+    } else {
+        result += QString("%1 NM • TC %2°").arg(dist.toNM(), 0, 'f', 1).arg(TC);
+    }
+    return result;
 }

--- a/src/Waypoint.h
+++ b/src/Waypoint.h
@@ -175,10 +175,11 @@ public:
     /*! \brief Description of the way from a given position to the waypoint
 
     @param position Position
+    @param useMetricUnits if true, render distance in km, else in NM
 
     @returns a string of the form "65.2 NM • TC 276°"
   */
-    Q_INVOKABLE QString wayFrom(const QGeoCoordinate& position) const;
+    Q_INVOKABLE QString wayFrom(const QGeoCoordinate& position, bool useMetricUnits) const;
 
 private:
     Q_DISABLE_COPY_MOVE(Waypoint)

--- a/src/Wind.cpp
+++ b/src/Wind.cpp
@@ -27,7 +27,7 @@ Wind::Wind(QObject *parent)
     : QObject(parent)
 {
     _windSpeedInKT = settings.value("Wind/windSpeedInKT", -1.0).toDouble();
-    if ((_windSpeedInKT < minWindSpeed) || (_windSpeedInKT > maxWindSpeed))
+    if ((_windSpeedInKT < minWindSpeedInKT) || (_windSpeedInKT > maxWindSpeedInKT))
         _windSpeedInKT = qQNaN();
 
     _windDirectionInDEG = settings.value("Wind/windDirectionInDEG", -1.0).toDouble();
@@ -36,16 +36,37 @@ Wind::Wind(QObject *parent)
 }
 
 
-void Wind::setWindSpeedInKT(double speedInKTS)
+double Wind::windSpeedInKT() const
 {
-    if ((speedInKTS < minWindSpeed) || (speedInKTS > maxWindSpeed))
-        speedInKTS = qQNaN();
+    return _windSpeedInKT;
+}
 
-    if (!qFuzzyCompare(speedInKTS, _windSpeedInKT)) {
-        _windSpeedInKT = speedInKTS;
+
+void Wind::setWindSpeedInKT(double speedInKT)
+{
+    if ((speedInKT < minWindSpeedInKT) || (speedInKT > maxWindSpeedInKT))
+        speedInKT = qQNaN();
+
+    if (!qFuzzyCompare(speedInKT, _windSpeedInKT)) {
+        _windSpeedInKT = speedInKT;
         settings.setValue("Wind/windSpeedInKT", _windSpeedInKT);
         emit valChanged();
     }
+}
+
+
+double Wind::windSpeedInKMH() const
+{
+    auto speed = AviationUnits::Speed::fromKT(_windSpeedInKT);
+    return speed.toKMH();
+}
+
+
+void Wind::setWindSpeedInKMH(double speedInKMH)
+{
+    setWindSpeedInKT(
+        AviationUnits::Speed::fromKMH(speedInKMH).toKT()
+    );
 }
 
 

--- a/src/Wind.h
+++ b/src/Wind.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <QSettings>
+#include "AviationUnits.h"
 
 
 /*! \brief This extremely simple class holds the wind speed and direction */
@@ -28,10 +29,10 @@
 class Wind : public QObject
 {
   Q_OBJECT
-  
+
 public:
   /*! \brief Default constructor
-    
+
     This constructor reads the values of the properties listed below via
     QSettings. The values are set to NaN if no valid numbers can be found in the
     settings object.
@@ -39,50 +40,74 @@ public:
     @param parent The standard QObject parent pointer
   */
   explicit Wind(QObject *parent = nullptr);
-    
+
   // Standard destructor
   ~Wind() override = default;
-  
-  /*! \brief Wind Speed
-   
+
+  /*! \brief Wind Speed in knots
+
     This property holds the wind speed. This is a number that lies in the
     interval [minWindSpeed, maxWindSpeed] or NaN if the wind speed has not been
     set.
   */
   Q_PROPERTY(double windSpeedInKT READ windSpeedInKT WRITE setWindSpeedInKT NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
 
     @returns Property windSpeedInKT
   */
-  double windSpeedInKT() const { return _windSpeedInKT; }
-  
+  double windSpeedInKT() const;
+
   /*! \brief Setter function for property of the same name
-    
+
     This method saves the new value in a QSetting object. If speedInKT is
-    outside of the interval [minAircraftSpeed, maxAircraftSpeed], the property
+    outside of the interval [minWindSpeed, maxWindSpeed], the property
     will be set to NaN.
 
     @param speedInKT Property windSpeedInKT
   */
   void setWindSpeedInKT(double speedInKT);
-  
+
+  /*! \brief Wind Speed in km/h
+
+    This property holds the wind speed. This is a number that lies in the
+    interval [minWindSpeed, maxWindSpeed] or NaN if the wind speed has not been
+    set.
+  */
+  Q_PROPERTY(double windSpeedInKMH READ windSpeedInKMH WRITE setWindSpeedInKMH NOTIFY valChanged)
+
+  /*! \brief Getter function for property of the same name
+
+    @returns Property windSpeedInKMH
+  */
+  double windSpeedInKMH() const;
+
+  /*! \brief Setter function for property of the same name
+
+    This method saves the new value in a QSetting object. If speedInKMH is
+    outside of the interval [minWindSpeed, maxWindSpeed], the property
+    will be set to NaN.
+
+    @param speedInKMH Property windSpeedInKMH
+  */
+  void setWindSpeedInKMH(double speedInKMH);
+
   /*! \brief Wind Direction
-    
+
     This property holds the wind direction. This is a number that lies in the
     interval [minWindDirection, maxWindDirection] or NaN if no value has been
     set.
   */
   Q_PROPERTY(double windDirectionInDEG READ windDirectionInDEG WRITE setWindDirectionInDEG NOTIFY valChanged)
-  
+
   /*! \brief Getter function for property of the same name
-   
+
     @returns Property windDirectionInDEG
   */
   double windDirectionInDEG() const { return _windDirectionInDEG; }
-  
+
   /*! \brief Setter function for property of the same name
-   
+
     This method saves the new value in a QSetting object. If windDirection is
     outside of the interval [minWindDirection, maxWindDirection], the property
     will be set to NaN.
@@ -90,33 +115,41 @@ public:
     @param windDirection Property windDirectionInDEG
   */
   void setWindDirectionInDEG(double windDirection);
-  
+
   /*! \brief Minimal speed of the aircraft that is considered valid */
-  Q_PROPERTY(double minWindSpeed MEMBER minWindSpeed CONSTANT)
-  
+  Q_PROPERTY(double minWindSpeedInKT MEMBER minWindSpeedInKT CONSTANT)
+
   /*! \brief Maximal speed of the aircraft that is considered valid */
-  Q_PROPERTY(double maxWindSpeed MEMBER maxWindSpeed CONSTANT)
-  
+  Q_PROPERTY(double maxWindSpeedInKT MEMBER maxWindSpeedInKT CONSTANT)
+
+  /*! \brief Minimal speed of the aircraft that is considered valid */
+  Q_PROPERTY(double minWindSpeedInKMH MEMBER minWindSpeedInKMH CONSTANT)
+
+  /*! \brief Maximal speed of the aircraft that is considered valid */
+  Q_PROPERTY(double maxWindSpeedInKMH MEMBER maxWindSpeedInKMH CONSTANT)
+
   /*! \brief Minimal wind direction that is considered valid */
   Q_PROPERTY(double minWindDirection MEMBER minWindDirection CONSTANT)
-  
+
   /*! \brief Maximal wind direction that is considered valid */
   Q_PROPERTY(double maxWindDirection MEMBER maxWindDirection CONSTANT)
-  
+
 signals:
   /*! \brief Notifier signal */
   void valChanged();
-  
+
 private:
   Q_DISABLE_COPY_MOVE(Wind)
 
-  static constexpr double minWindSpeed     =   0.0;
-  static constexpr double maxWindSpeed     = 100.0;
-  static constexpr double minWindDirection =   0.0;
-  static constexpr double maxWindDirection = 360.0;
-  
+  static constexpr double minWindSpeedInKT  = 0.0;
+  static constexpr double minWindSpeedInKMH = minWindSpeedInKT * AviationUnits::Speed::KMH_per_KT;
+  static constexpr double maxWindSpeedInKT  = 100.0;
+  static constexpr double maxWindSpeedInKMH = maxWindSpeedInKT * AviationUnits::Speed::KMH_per_KT;
+  static constexpr double minWindDirection  = 0.0;
+  static constexpr double maxWindDirection  = 360.0;
+
   double _windSpeedInKT {qQNaN()};
   double _windDirectionInDEG {qQNaN()};
-  
+
   QSettings settings;
 };

--- a/src/qml/dialogs/WaypointDescription.qml
+++ b/src/qml/dialogs/WaypointDescription.qml
@@ -240,7 +240,7 @@ Dialog {
         }
 
         Label {
-            text: dialogLoader.waypoint.wayFrom(satNav.lastValidCoordinate)
+            text: dialogLoader.waypoint.wayFrom(satNav.lastValidCoordinate, globalSettings.useMetricUnits)
             visible: satNav.status === SatNav.OK
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignRight

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -334,6 +334,7 @@ Item {
         anchors.rightMargin: 0.5*Qt.application.font.pixelSize
         anchors.verticalCenter: followGPSButton.verticalCenter
 
+        useMetricUnits: globalSettings.useMetricUnits
         pixelPer10km: flightMap.pixelPer10km
         height: 30
     }

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -390,19 +390,21 @@ Page {
                     id: cruiseSpeed
                     Layout.fillWidth: true
                     validator: DoubleValidator {
-                        bottom: aircraft.minAircraftSpeed
-                        top: aircraft.maxAircraftSpeed
+                        bottom: globalSettings.useMetricUnits ? aircraft.minAircraftSpeedInKMH : aircraft.minAircraftSpeedInKT
+                        top: globalSettings.useMetricUnits ? aircraft.maxAircraftSpeedInKMH : aircraft.maxAircraftSpeedInKT
                         notation: DoubleValidator.StandardNotation
                     }
                     inputMethodHints: Qt.ImhDigitsOnly
-                    onEditingFinished: aircraft.cruiseSpeedInKT = text
+                    onEditingFinished: globalSettings.useMetricUnits ? aircraft.cruiseSpeedInKMH = text : aircraft.cruiseSpeedInKT = text
                     color: (acceptableInput ? "black" : "red")
                     KeyNavigation.tab: descentSpeed
                     KeyNavigation.backtab: windSpeed
-                    text: isFinite(aircraft.cruiseSpeedInKT) ? aircraft.cruiseSpeedInKT.toString() : ""
+                    text: isFinite(aircraft.cruiseSpeedInKT) ? Math.round(globalSettings.useMetricUnits ?
+                                                                              aircraft.cruiseSpeedInKMH.toString() :
+                                                                              aircraft.cruiseSpeedInKT.toString() ) : ""
                     placeholderText: qsTr("undefined")
                 }
-                Label { text: "kt TAS" }
+                Label { text: globalSettings.useMetricUnits ? "km/h TAS" : "kt TAS" }
                 ToolButton {
                     icon.source: "/icons/material/ic_delete.svg"
                     enabled: cruiseSpeed.text !== ""
@@ -417,19 +419,21 @@ Page {
                     id: descentSpeed
                     Layout.fillWidth: true
                     validator: DoubleValidator {
-                        bottom: aircraft.minAircraftSpeed
-                        top: aircraft.maxAircraftSpeed
+                        bottom: globalSettings.useMetricUnits ? aircraft.minAircraftSpeedInKMH : aircraft.minAircraftSpeedInKT
+                        top: globalSettings.useMetricUnits ? aircraft.maxAircraftSpeedInKMH : aircraft.maxAircraftSpeedInKT
                         notation: DoubleValidator.StandardNotation
                     }
                     inputMethodHints: Qt.ImhDigitsOnly
-                    onEditingFinished: aircraft.descentSpeedInKT = text
+                    onEditingFinished: globalSettings.useMetricUnits ? aircraft.descentSpeedInKMH = text : aircraft.descentSpeedInKT = text
                     color: (acceptableInput ? "black" : "red")
                     KeyNavigation.tab: fuelConsumption
                     KeyNavigation.backtab: cruiseSpeed
-                    text: isFinite(aircraft.descentSpeedInKT) ? aircraft.descentSpeedInKT.toString() : ""
+                    text: isFinite(aircraft.descentSpeedInKT) ? Math.round(globalSettings.useMetricUnits ?
+                                                                              aircraft.descentSpeedInKMH.toString() :
+                                                                              aircraft.descentSpeedInKT.toString() ) : ""
                     placeholderText: qsTr("undefined")
                 }
-                Label { text: "kt TAS" }
+                Label { text: globalSettings.useMetricUnits ? "km/h TAS" : "kt TAS" }
                 ToolButton {
                     icon.source: "/icons/material/ic_delete.svg"
                     enabled: descentSpeed.text !== ""

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -67,7 +67,7 @@ Page {
                 icon.color: "transparent"
                 Layout.fillWidth: true
                 enabled: false
-                text: model.modelData.description
+                text: globalSettings.useMetricUnits ? model.modelData.descriptionMetric : model.modelData.description
             }
 
             ToolButton {

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -262,7 +262,7 @@ Page {
                                 shareErrorDialog.open()
                             }
 
-                        }                        
+                        }
                     }
 
                     MenuItem {
@@ -507,19 +507,19 @@ Page {
                     id: windSpeed
                     Layout.fillWidth: true
                     validator: DoubleValidator {
-                        bottom: wind.minWindSpeed
-                        top: wind.maxWindSpeed
+                        bottom: globalSettings.useMetricUnits ? wind.minWindSpeedInKMH : wind.minWindSpeedInKT
+                        top: globalSettings.useMetricUnits ? wind.maxWindSpeedInKMH : wind.maxWindSpeedInKT
                         notation: DoubleValidator.StandardNotation
                     }
                     inputMethodHints: Qt.ImhDigitsOnly
-                    onEditingFinished: wind.windSpeedInKT = text
+                    onEditingFinished: globalSettings.useMetricUnits ? wind.windSpeedInKMH = text : wind.windSpeedInKT = text
                     color: (acceptableInput ? "black" : "red")
                     KeyNavigation.tab: cruiseSpeed
                     KeyNavigation.backtab: windDirection
-                    text: isFinite(wind.windSpeedInKT) ? wind.windSpeedInKT : ""
+                    text: isFinite(wind.windSpeedInKT) ? Math.round(globalSettings.useMetricUnits ? wind.windSpeedInKMH : wind.windSpeedInKT) : ""
                     placeholderText: qsTr("undefined")
                 }
-                Label { text: "kt" }
+                Label { text: globalSettings.useMetricUnits ? "km/h" : "kt" }
                 ToolButton {
                     icon.source: "/icons/material/ic_delete.svg"
                     enabled: windSpeed.text !== ""

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -548,7 +548,7 @@ Page {
                 id: summary
 
                 Layout.fillWidth: true
-                text: flightRoute.summary
+                text: globalSettings.useMetricUnits ? flightRoute.summaryMetric : flightRoute.summary
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText

--- a/src/qml/pages/NearbyAirfields.qml
+++ b/src/qml/pages/NearbyAirfields.qml
@@ -39,7 +39,10 @@ Page {
         ItemDelegate {
             id: idel
             text: model.modelData.richTextName +
-                  ((satNav.status == SatNav.OK) ? ("<br>" + model.modelData.wayFrom(satNav.lastValidCoordinate)) : "")
+                  (satNav.status == SatNav.OK ?
+                       ("<br>" + model.modelData.wayFrom(satNav.lastValidCoordinate,
+                                                         globalSettings.useMetricUnits)) :
+                       "")
             icon.source: "/icons/waypoints/"+model.modelData.get("CAT")+".svg"
             icon.color: "transparent"
 

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -112,6 +112,25 @@ Page {
             }
 
             SwitchDelegate {
+                id: useMetricUnits
+                text: qsTr("Prefer metric units")
+                      + `<br><font color="#606060" size="2">`
+                      + ( globalSettings.useMetricUnits ?
+                            qsTr("Horizontal speed in km/h, distance in km") :
+                            qsTr("Horizontal speed in kt, distance in NM")
+                        )
+                      + "</font>"
+                icon.source: "/icons/material/ic_speed.svg"
+                icon.color: Material.primary
+                Layout.fillWidth: true
+                Component.onCompleted: useMetricUnits.checked = globalSettings.useMetricUnits
+                onCheckedChanged: {
+                    mobileAdaptor.vibrateBrief()
+                    globalSettings.useMetricUnits = useMetricUnits.checked
+                }
+            }
+
+            SwitchDelegate {
                 id: preferEnglish
                 text: qsTr("Prefer English")
                 icon.source: "/icons/material/ic_translate.svg"


### PR DESCRIPTION
Adding a switch to use metric units on the settings page. Switching to metric units will:

* change the wind input from kt to km/h
* change the aircraft cruise- and descent-speed inputs from kt to km/h
* display the distance in the flight route summary in km instead of NM
* display the scale legend on the map in km instead of NM

The aircraft and wind speed values are still stored in kt with double precision. Rounding to integers in done in the qml code of the interface, in order to prevent rounding or conversion issues.