### PR TITLE
Move aircraft to bottom in flightmode

### DIFF
--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -60,15 +60,8 @@ Item {
         // Enable gestures. Make sure that whenever a gesture starts, the property "followGPS" is set to "false"
         gesture.enabled: true
         gesture.acceptedGestures: MapGestureArea.PanGesture|MapGestureArea.PinchGesture|MapGestureArea.RotationGesture
-        gesture.onPanStarted: {
-            console.log('check!!!')
-            centerBindingAnimation.pauseAnimationfor410ms();
-            flightMap.followGPS = false;
-        }
-        gesture.onRotationStarted: {
-            centerBindingAnimation.pauseAnimationfor410ms();
-            flightMap.followGPS = false;
-        }
+        gesture.onPanStarted: {flightMap.followGPS = false}
+        gesture.onRotationStarted: {flightMap.followGPS = false}
 
 
         // PROPERTY "bearing"
@@ -129,7 +122,7 @@ Item {
             CoordinateAnimation { duration: 1000 }
             enabled: true
 
-            function pauseAnimationfor410ms() {
+            function omitAnimationforZoom() {
                 centerBindingAnimation.enabled = false
                 omitAnimationForZoomTimer.stop()  // stop in case it was already runnnig
                 omitAnimationForZoomTimer.start()
@@ -326,7 +319,7 @@ Item {
         }
 
         onClicked: {
-            centerBindingAnimation.pauseAnimationfor410ms()
+            centerBindingAnimation.omitAnimationforZoom()
             mobileAdaptor.vibrateBrief()
             flightMap.zoomLevel += 1
         }

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -60,8 +60,15 @@ Item {
         // Enable gestures. Make sure that whenever a gesture starts, the property "followGPS" is set to "false"
         gesture.enabled: true
         gesture.acceptedGestures: MapGestureArea.PanGesture|MapGestureArea.PinchGesture|MapGestureArea.RotationGesture
-        gesture.onPanStarted: {flightMap.followGPS = false}
-        gesture.onRotationStarted: {flightMap.followGPS = false}
+        gesture.onPanStarted: {
+            console.log('check!!!')
+            centerBindingAnimation.pauseAnimationfor410ms();
+            flightMap.followGPS = false;
+        }
+        gesture.onRotationStarted: {
+            centerBindingAnimation.pauseAnimationfor410ms();
+            flightMap.followGPS = false;
+        }
 
 
         // PROPERTY "bearing"
@@ -122,7 +129,7 @@ Item {
             CoordinateAnimation { duration: 1000 }
             enabled: true
 
-            function omitAnimationforZoom() {
+            function pauseAnimationfor410ms() {
                 centerBindingAnimation.enabled = false
                 omitAnimationForZoomTimer.stop()  // stop in case it was already runnnig
                 omitAnimationForZoomTimer.start()
@@ -319,7 +326,7 @@ Item {
         }
 
         onClicked: {
-            centerBindingAnimation.omitAnimationforZoom()
+            centerBindingAnimation.pauseAnimationfor410ms()
             mobileAdaptor.vibrateBrief()
             flightMap.zoomLevel += 1
         }

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -101,8 +101,12 @@ Item {
                 flightMap.zoomLevel;  // zoomLevel mentioned to trigger center re-calculation after zoom-in / -out
                 let coordForCenter = satNav.lastValidCoordinate;
                 if (!globalSettings.autoFlightDetection || satNav.isInFlight) {
+                    const targetHeight = Math.min(
+                        height-150,  // stay above the ruler scale a couple of pixels
+                        height*4/5  // otherwise 4/5 of the view is fine
+                    );
                     const center = flightMap.toCoordinate(Qt.point(width/2, height/2), false);
-                    const target = flightMap.toCoordinate(Qt.point(width/2, height*3/4), false);
+                    const target = flightMap.toCoordinate(Qt.point(width/2, targetHeight), false);
                     const centerTargetDistance = center.distanceTo(target);
                     let bearing = satNav.track;
                     bearing = bearing < 0 ? 0 : bearing;  // set to 0 if undefined (which is -1)

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -97,7 +97,19 @@ Item {
 
             restoreMode: Binding.RestoreBinding
             when: flightMap.followGPS === true
-            value: satNav.lastValidCoordinate
+            value: {
+                flightMap.zoomLevel;  // zoomLevel mentioned to trigger center re-calculation after zoom-in/-out
+                let coordForCenter = satNav.lastValidCoordinate;
+                if (!globalSettings.autoFlightDetection || satNav.isInFlight) {
+                    const center = flightMap.toCoordinate(Qt.point(width/2, height/2), false);
+                    const target = flightMap.toCoordinate(Qt.point(width/2, height*4/5), false);
+                    const centerTargetDistance = center.distanceTo(target);
+                    let bearing = satNav.track;
+                    bearing = bearing < 0 ? 0 : bearing;  // set to 0 if undefined (which is -1)
+                    coordForCenter = coordForCenter.atDistanceAndAzimuth(centerTargetDistance, bearing);
+                }
+                return coordForCenter
+            }
         }
 
         // We expect GPS updates every second. So, we choose an animation of duration 1000ms here, to obtain a flowing movement


### PR DESCRIPTION
This MR solves #17, which struck me as well. 

<s>It should work correctly, but I could only test it on desktop, where I can't rotate the map. (Is there now an easy for testing on android?)</s> The downloadable binaries totally rock!

<s>Please note, when pushing the zoom-in/-out buttons, the zoom-animation happens first around the center-point and then a second animation moves the map into position. This may seem slightly odd at first, but after watching it a couple of times, I feel it's totally fine. </s>  
Implemented smooth zooming by disabling the center-binding animation while the zoom animation is running.

The Qml Map class offers a function named `alignCoordinateToPoint` which seems to be meant for this task. However, I didn't see a way to make it work with the animations.

EDIT: On my phone, there's a glitch when panning the map. It happens when `followGPS === true`, then after the first pan the map is reset to the center point. After this, panning works fine. The glitch was already there before this PR, I tried to fix it, but couldn't do (here's my attempt: https://github.com/Akaflieg-Freiburg/enroute/pull/65/commits/bfa16179e61846fc55cee788b4d5e86de8906b55).

Let me know any questions. Cheers!