### PR TITLE
#137 color adjustment

### DIFF
--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -104,8 +104,9 @@ Map {
     MapParameter {
         type: "paint"
         property var layer: "FIS"
-        property var lineColor: "green"
+        property var lineColor: "black"
         property var lineWidth: 2.0
+        property var lineDasharray: [8.0, 2.0, 1.0, 2.0]        
         //property var lineDasharray: [4.0, 4.0]
     }
 


### PR DESCRIPTION
zu https://github.com/Akaflieg-Freiburg/enroute/issues/137
damit ist wenigstens die Kollision mit den vielen Naturschutzgebieten weg und der optische Unterschied zu TMZ sollte groß genug sein. Aber vermutlich würde deine angedachte 4/4-Teilung sich auch gut abheben (und weniger Karte verdecken).
Wo man die Farbe der Flugstrecken ändern kann, habe ich nicht gefunden. Mein Vorschlag dafür wäre #FF00FF (nicht schön, aber markant).