### PR TITLE
Route cannot be opened for reading

### DIFF
--- a/src/FlightRoute.cpp
+++ b/src/FlightRoute.cpp
@@ -441,7 +441,7 @@ auto FlightRoute::suggestedFilename() const -> QString
     name.replace("(", "");
     name.replace(")", "");
     if (name.length() > 11) {  // Shorten name
-        name = name.left(10)+"…";
+        name = name.left(10)+"_";
     }
     if (!name.isEmpty()) {
         if (start.isEmpty()) {


### PR DESCRIPTION
There seems to be an issue with abbreviated route names. I reckon the app doesn't like more than one "." (and this one where it belongs).
The respective route had been created inside the app an then saved successfully. 
Opening routes with "normal" names works. Blanks and brackets within the file name seem to be no problem. 

I suggest to replace the three dots by an underscore.

I first could not add screenshots here, so I created #141. It can be dropped.

![1](https://user-images.githubusercontent.com/65605447/104451353-b59d1b80-55a1-11eb-87cb-ce799af2b0a0.jpg)
![2](https://user-images.githubusercontent.com/65605447/104451362-b8980c00-55a1-11eb-885e-03ee465ff012.jpg)
![3](https://user-images.githubusercontent.com/65605447/104451365-ba61cf80-55a1-11eb-9848-7935bdf9ee1f.jpg)
