### PR TITLE
simulator interface

### DIFF
--- a/src/AviationUnits.h
+++ b/src/AviationUnits.h
@@ -371,6 +371,14 @@ public:
          */
         bool operator==(AviationUnits::Speed rhs) const { return _speedInMPS == rhs._speedInMPS; }
 
+        /*! \brief Equality check
+         *
+         *  @param rhs Right hand side of the comparison
+         *
+         *  @returns Result of the comparison
+         */
+        bool operator!=(AviationUnits::Speed rhs) const { return _speedInMPS != rhs._speedInMPS; }
+
         /*! \brief Convert to meters per second
          *
          * @returns speed in meters per second

--- a/src/Librarian.cpp
+++ b/src/Librarian.cpp
@@ -354,18 +354,12 @@ at random if more than one device tries to access.</p>
 
     if (name == ":text/whatsnew.html") {
         return (R"MD(
-Technology preview: the app can now connect to your aircraft's
-traffic receiver (typically a FLARM device) and show nearby
-traffic on the moving map. Open the menu and go to
-**Information/Traffic Reveicer** to try it out.
+The app can now connect to your aircraft's traffic receiver
+(typically a FLARM device) and show nearby traffic on the
+moving map. Open the menu and go to **Information/Traffic
+Reveicer** to try it out.
 
-Please send me your feedback! Reach my by e-mail, GitHub or
-via any other chanel.
-
-- Does the feature work for you at all? Do you run into problems?
-- If it works, how do you like the map design?
-- What traffic receiver do you use?
-- Was the setup difficult? Did you find the help texts helpful? Did you even find the help texts?
+This feature is new. Your feedback is very welcome!
 )MD");
     }
 

--- a/src/Navigation_FLARMAdaptor.cpp
+++ b/src/Navigation_FLARMAdaptor.cpp
@@ -193,6 +193,26 @@ void Navigation::FLARMAdaptor::disconnectFromTrafficReceiver()
     updateStatus();
 }
 
+void Navigation::FLARMAdaptor::trafficUpdated(const Navigation::Traffic &traffic)
+{
+    foreach(auto target, _trafficObjects)
+        if (traffic.ID() == target->ID()) {
+            target->copyFrom(traffic);
+            return;
+        }
+
+    auto *lowestPriObject = _trafficObjects.at(0);
+    foreach(auto target, _trafficObjects)
+        if (lowestPriObject->hasHigherPriorityThan(*target)) {
+            lowestPriObject = target;
+        }
+    if (traffic.hasHigherPriorityThan(*lowestPriObject)) {
+        lowestPriObject->copyFrom(traffic);
+    }
+
+    return;
+
+}
 
 auto Navigation::FLARMAdaptor::globalInstance() -> Navigation::FLARMAdaptor *
 {

--- a/src/Navigation_FLARMAdaptor.h
+++ b/src/Navigation_FLARMAdaptor.h
@@ -268,6 +268,8 @@ public slots:
      */
     void disconnectFromTrafficReceiver();
 
+    void trafficUpdated(const Navigation::Traffic &traffic);
+
 private slots:
     // Handle socket errors.
     void receiveSocketErrorOccurred(QAbstractSocket::SocketError socketError);

--- a/src/Navigation_Geoid.cpp
+++ b/src/Navigation_Geoid.cpp
@@ -99,7 +99,7 @@ auto Navigation::Geoid::operator()(qreal latitude, qreal longitude) -> qreal
     auto geoid = [&] (int row, int col) -> qreal
     {
         int idx = row * egm96_cols + col;
-        return idx >=0 && idx < egm96_size ? egm[idx] * 0.01 : 0.0;
+        return idx >=0 && idx < egm96_size ? egm.at(idx) * 0.01 : 0.0;
     };
 
     // here we do a bilinear interpolation between the 4 neighbouring

--- a/src/Navigation_SatNav.cpp
+++ b/src/Navigation_SatNav.cpp
@@ -25,6 +25,7 @@
 #include "AviationUnits.h"
 #include "Navigation_SatNav.h"
 #include "SimGeoPositionInfoSource.h"
+#include "Navigation_FLARMAdaptor.h"
 
 
 // Static instance of this class
@@ -298,6 +299,11 @@ void Navigation::SatNav::initNavSource()
         connect(source,  SIGNAL(error(QGeoPositionInfoSource::Error)), this, SLOT(error(QGeoPositionInfoSource::Error)));
         connect(source,  SIGNAL(updateTimeout()), this, SLOT(timeout()));
         connect(source,  SIGNAL(positionUpdated(const QGeoPositionInfo &)), this, SLOT(onPositionUpdated_Sat(const QGeoPositionInfo &)));
+
+        if (dynamic_cast<SimGeoPositionInfoSource*>(source) != nullptr) {
+            Navigation::FLARMAdaptor * flarmAdapter = Navigation::FLARMAdaptor::globalInstance();
+            connect(dynamic_cast<SimGeoPositionInfoSource*>(source), &SimGeoPositionInfoSource::trafficUpdated, flarmAdapter, &Navigation::FLARMAdaptor::trafficUpdated);
+        }
     }
 
     if (source != nullptr) {

--- a/src/Navigation_SatNav.cpp
+++ b/src/Navigation_SatNav.cpp
@@ -296,7 +296,7 @@ void Navigation::SatNav::initNavSource()
     if (source != nullptr) {
         sourceStatus = source->error();
         connect(source,  SIGNAL(error(QGeoPositionInfoSource::Error)), this, SLOT(error(QGeoPositionInfoSource::Error)));
-        connect(source, &QGeoPositionInfoSource::updateTimeout, this, &Navigation::SatNav::timeout);
+        connect(source,  SIGNAL(updateTimeout()), this, SLOT(timeout()));
         connect(source,  SIGNAL(positionUpdated(const QGeoPositionInfo &)), this, SLOT(onPositionUpdated_Sat(const QGeoPositionInfo &)));
     }
 
@@ -421,6 +421,8 @@ void Navigation::SatNav::timeout()
     // Clear lastInfo, stop counter
     lastInfo = QGeoPositionInfo();
 
+    timeoutCounter.stop();
+
     emit iconChanged();
     emit statusChanged();
     emit update();
@@ -495,4 +497,16 @@ auto Navigation::SatNav::wayTo(const QGeoCoordinate& position) const -> QString
         return QStringLiteral("DIST %1 km • QUJ %2°").arg(dist.toKM(), 0, 'f', 1).arg(QUJ);
     }
     return QStringLiteral("DIST %1 NM • QUJ %2°").arg(dist.toNM(), 0, 'f', 1).arg(QUJ);
+}
+
+
+QString Navigation::SatNav::sourceName() const
+{
+    if (source) {
+        if (dynamic_cast<SimGeoPositionInfoSource*>(source) != nullptr) {
+            return dynamic_cast<SimGeoPositionInfoSource*>(source)->simName();
+        }
+    }
+
+    return source->sourceName();
 }

--- a/src/Navigation_SatNav.h
+++ b/src/Navigation_SatNav.h
@@ -441,6 +441,10 @@ public:
    */
     Q_INVOKABLE QString wayTo(const QGeoCoordinate& position) const;
 
+    QString sourceName() const;
+
+    Q_PROPERTY(QString sourceName READ sourceName NOTIFY update)
+
 signals:
     /*! \brief Emitted whenever the suggested icon changes */
     void iconChanged();

--- a/src/Navigation_Traffic.cpp
+++ b/src/Navigation_Traffic.cpp
@@ -101,7 +101,7 @@ void Navigation::Traffic::setColor()
 }
 
 
-void Navigation::Traffic::setData(int newAlarmLevel, const QString& newID, AviationUnits::Distance newHDist, AviationUnits::Distance newVDist, AircraftType newType, const QGeoPositionInfo& newPositionInfo)
+void Navigation::Traffic::setData(int newAlarmLevel, const QString& newID, AviationUnits::Distance newHDist, AviationUnits::Distance newVDist, AviationUnits::Speed newClimbRate, AircraftType newType, const QGeoPositionInfo& newPositionInfo)
 {
     // Set properties
     bool hasAlarmLevelChanged = (_alarmLevel != newAlarmLevel);
@@ -131,6 +131,9 @@ void Navigation::Traffic::setData(int newAlarmLevel, const QString& newID, Aviat
     bool hasHDistChanged = (_hDist != newHDist);
     _hDist = newHDist;
 
+    bool hasClimbRateChanged = (_climbRate != newClimbRate);
+    _climbRate = newClimbRate;
+
     // If the ID changed, do not animate property changes in the GUI.
     if (hasIDChanged) {
        setAnimate(false);
@@ -155,6 +158,9 @@ void Navigation::Traffic::setData(int newAlarmLevel, const QString& newID, Aviat
     }
     if (hasTTChanged) {
         emit ttChanged();
+    }
+    if (hasClimbRateChanged) {
+        emit climbRateChanged();
     }
     if (hasTypeChanged) {
         emit typeChanged();
@@ -217,7 +223,19 @@ void Navigation::Traffic::setDescription()
     }
 
     if (_vDist.isFinite()) {
-        results << _vDist.toString(GlobalSettings::useMetricUnitsStatic(), true, true);
+        auto result = _vDist.toString(GlobalSettings::useMetricUnitsStatic(), true, true);
+        if ( qIsFinite(_climbRate.toMPS())) {
+            if (_climbRate.toMPS() < -1.0) {
+                result += " ↘";
+            }
+            if ((_climbRate.toMPS() >= -1.0) && (_climbRate.toMPS() <= +1.0)) {
+                result += " →";
+            }
+            if (_climbRate.toMPS() > 1.0) {
+                result += " ↗";
+            }
+        }
+        results << result;
     }
 
     auto newDescription = results.join(u"<br>");

--- a/src/Navigation_Traffic.cpp
+++ b/src/Navigation_Traffic.cpp
@@ -46,7 +46,7 @@ Navigation::Traffic::Traffic(QObject *parent) : QObject(parent)
 }
 
 
-auto Navigation::Traffic::hasHigherPriorityThan(const Traffic &rhs) -> bool
+auto Navigation::Traffic::hasHigherPriorityThan(const Traffic &rhs) const -> bool
 {
     // Criterion 1: Valid instances have higher priority than invalid ones
     if (!rhs.valid()) {

--- a/src/Navigation_Traffic.h
+++ b/src/Navigation_Traffic.h
@@ -88,7 +88,7 @@ public:
      *
      * @returns Boolean with the result
      */
-    bool hasHigherPriorityThan(const Traffic &rhs);
+    bool hasHigherPriorityThan(const Traffic &rhs) const;
 
     //
     // PROPERTIES
@@ -424,6 +424,7 @@ private:
         setData(other._alarmLevel, other._ID, other._hDist, other._vDist, other._climbRate, other._type, other._positionInfo);
     }
 
+public:
     // Set data
     void setData(int newAlarmLevel, const QString & newID, AviationUnits::Distance newHDist, AviationUnits::Distance newVDist, AviationUnits::Speed newClimbRate, AircraftType newType, const QGeoPositionInfo & newPositionInfo);
 

--- a/src/Navigation_Traffic.h
+++ b/src/Navigation_Traffic.h
@@ -136,6 +136,39 @@ public:
         return _animate;
     }
 
+    /*! \brief Climb rate at the time of report
+     *
+     *  If known, this property holds the horizontal climb rate of the traffic
+     *  at the time of report.  Otherwise, it contains NaN.
+     */
+    Q_PROPERTY(AviationUnits::Speed climbRate READ climbRate NOTIFY climbRateChanged)
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property climbRate
+     */
+    AviationUnits::Speed climbRate() const
+    {
+        return _climbRate;
+    }
+
+    /*! \brief Climb rate at the time of report, in m/s
+     *
+     *  If known, this property holds the horizontal climb rate of the traffic
+     *  at the time of report, in m/s.  Otherwise, it contains NaN.
+     */
+
+    Q_PROPERTY(double climbRateInMPS READ climbRateInMPS NOTIFY hDistChanged)
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property climbRateInMPS
+     */
+    double climbRateInMPS() const
+    {
+        return _climbRate.toMPS();
+    }
+
     /*! \brief Suggested color for GUI representation of the traffic
      *
      *  This propery suggests a color, depending on the alarmLevel.
@@ -188,7 +221,7 @@ public:
         return _description;
     }
 
-    /*! \brief Horizontal distance from own position to the traffic in meters,
+    /*! \brief Horizontal distance from own position to the traffic,
      *  at the time of report
      *
      *  If known, this property holds the horizontal distance from the own
@@ -330,6 +363,9 @@ signals:
     void animateChanged();
 
     /*! \brief Notifier signal */
+    void climbRateChanged();
+
+    /*! \brief Notifier signal */
     void colorChanged();
 
     /*! \brief Notifier signal */
@@ -385,11 +421,11 @@ private:
     // Copy data from other object
     void copyFrom(const Traffic & other)
     {
-        setData(other._alarmLevel, other._ID, other._hDist, other._vDist, other._type, other._positionInfo);
+        setData(other._alarmLevel, other._ID, other._hDist, other._vDist, other._climbRate, other._type, other._positionInfo);
     }
 
     // Set data
-    void setData(int newAlarmLevel, const QString & newID, AviationUnits::Distance newHDist, AviationUnits::Distance newVDist, AircraftType newType, const QGeoPositionInfo & newPositionInfo);
+    void setData(int newAlarmLevel, const QString & newID, AviationUnits::Distance newHDist, AviationUnits::Distance newVDist, AviationUnits::Speed newClimbRate, AircraftType newType, const QGeoPositionInfo & newPositionInfo);
 
 private:
     // Setter function for property animate
@@ -409,11 +445,12 @@ private:
     bool _valid {false};
     AviationUnits::Distance _vDist;
     AviationUnits::Distance _hDist;
+    AviationUnits::Speed _climbRate;
 
     // Timer for timeout. Traffic objects become invalid if their data has not been
     // refreshed for timeoutMS milliseconds
     QTimer timeoutCounter;
-    static constexpr qint64 timeoutMS = 6*1000;
+    static constexpr qint64 timeoutMS = 10*1000;
 };
 
 }

--- a/src/SimGeoPositionInfoSource.cpp
+++ b/src/SimGeoPositionInfoSource.cpp
@@ -44,6 +44,8 @@ void SimGeoPositionInfoSource::startUpdates()
     connect(_simInterface, &SimInterface::positionUpdated, this, &SimGeoPositionInfoSource::positionUpdated);
     connect(_simInterface, &SimInterface::timeout, this, &SimGeoPositionInfoSource::updateTimeout);
 
+    connect(_simInterface, &SimInterface::trafficUpdated, this, &SimGeoPositionInfoSource::trafficUpdated);
+
     _simInterface->start();
 }
 

--- a/src/SimGeoPositionInfoSource.cpp
+++ b/src/SimGeoPositionInfoSource.cpp
@@ -25,9 +25,9 @@ int SimGeoPositionInfoSource::minimumUpdateInterval() const
     return 1000;
 }
 
-QString SimGeoPositionInfoSource::sourceName() const
+QString SimGeoPositionInfoSource::simName() const
 {
-    return _sourceName;
+    return _simInterface->simName();
 }
 
 QGeoPositionInfoSource::Error SimGeoPositionInfoSource::error() const
@@ -41,7 +41,6 @@ void SimGeoPositionInfoSource::startUpdates()
         _simInterface = new SimInterface(this);
     }
 
-    connect(_simInterface, &SimInterface::simNameChanged, this, &SimGeoPositionInfoSource::setSourceName);
     connect(_simInterface, &SimInterface::positionUpdated, this, &SimGeoPositionInfoSource::positionUpdated);
     connect(_simInterface, &SimInterface::timeout, this, &SimGeoPositionInfoSource::updateTimeout);
 
@@ -55,9 +54,4 @@ void SimGeoPositionInfoSource::stopUpdates()
 
 void SimGeoPositionInfoSource::requestUpdate(int)
 {
-}
-
-void SimGeoPositionInfoSource::setSourceName(const QString &sourceName)
-{
-    _sourceName = sourceName;
 }

--- a/src/SimGeoPositionInfoSource.h
+++ b/src/SimGeoPositionInfoSource.h
@@ -43,6 +43,8 @@ Q_SIGNALS:
 
     void supportedPositioningMethodsChanged();
 
+    void trafficUpdated(const Navigation::Traffic &traffic);
+
 private:
     QString _simName = "n/a";
     SimInterface *_simInterface = nullptr;

--- a/src/SimGeoPositionInfoSource.h
+++ b/src/SimGeoPositionInfoSource.h
@@ -21,7 +21,7 @@ public:
 
     int minimumUpdateInterval() const;
 
-    QString sourceName() const;
+    QString simName() const;
 
     QGeoPositionInfoSource::Error error() const;
 
@@ -33,7 +33,6 @@ public slots:
     void requestUpdate(int timeout = 0);
 
 private slots:
-    void setSourceName(const QString &sourceName);
 
 Q_SIGNALS:
     void positionUpdated(const QGeoPositionInfo &update);
@@ -45,7 +44,7 @@ Q_SIGNALS:
     void supportedPositioningMethodsChanged();
 
 private:
-    QString _sourceName = "n/a";
+    QString _simName = "n/a";
     SimInterface *_simInterface = nullptr;
     QGeoPositionInfoSource::Error _error = QGeoPositionInfoSource::Error::NoError;
 };

--- a/src/SimInterface.cpp
+++ b/src/SimInterface.cpp
@@ -69,5 +69,28 @@ void SimInterface::readPendingDatagrams()
             _timeoutPosUpdate.start(_timeoutThreshold);
             emit positionUpdated(_geoPos);
         }
+        else if (list[0].contains("XTRA")) {
+            QString targetID = list[1];
+            QGeoPositionInfo geoPositionInfo(QGeoCoordinate(list[2].toDouble(),
+                                                            list[3].toDouble(),
+                                                            list[4].toDouble()*0.3048),
+                                             QDateTime::currentDateTimeUtc());
+
+            geoPositionInfo.setAttribute(QGeoPositionInfo::VerticalSpeed, list[5].toDouble()/0.3048/60.0);
+            geoPositionInfo.setAttribute(QGeoPositionInfo::Direction, list[7].toDouble());
+            geoPositionInfo.setAttribute(QGeoPositionInfo::GroundSpeed, list[8].toDouble()*1.852/3.6);
+
+            auto traffic = Navigation::Traffic();
+
+            traffic.setData(0,
+                            targetID,
+                            AviationUnits::Distance::fromM(_geoPos.coordinate().distanceTo(geoPositionInfo.coordinate())),
+                            AviationUnits::Distance::fromM(geoPositionInfo.coordinate().altitude() - _geoPos.coordinate().altitude()),
+                            AviationUnits::Speed::fromMPS(_geoPos.attribute(QGeoPositionInfo::VerticalSpeed)),
+                            Navigation::Traffic::unknown,
+                            geoPositionInfo );
+
+            emit trafficUpdated(traffic);
+        }
     }
 }

--- a/src/SimInterface.cpp
+++ b/src/SimInterface.cpp
@@ -48,12 +48,13 @@ void SimInterface::readPendingDatagrams()
 
         if (list[0].contains("XGPS")) {
             if (_simName != list[0].remove(0,4)) {
-                _simName = list[0];
-                if (_simName == "1") {
-                    emit simNameChanged("X-Plane");
+                if ("1" == list[0]) {
+                    if (_simName != "X-Plane") {
+                        _simName = "X-Plane";
+                    }
                 }
                 else {
-                    emit simNameChanged(_simName);
+                    _simName = list[0];
                 }
             }
 

--- a/src/SimInterface.h
+++ b/src/SimInterface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Navigation_Traffic.h"
 
 #include <QUdpSocket>
 #include <QTimer>
@@ -28,6 +29,8 @@ signals:
     void positionUpdated(const QGeoPositionInfo &update);
 
     void timeout();
+
+    void trafficUpdated(const Navigation::Traffic &traffic);
 
 private:
     QUdpSocket *_udpSocket = nullptr;

--- a/src/SimInterface.h
+++ b/src/SimInterface.h
@@ -19,6 +19,8 @@ public:
 
     QGeoPositionInfo lastKnownPosition() const;
 
+    QString simName() const { return _simName; };
+
 public slots:
     void readPendingDatagrams();
 
@@ -26,8 +28,6 @@ signals:
     void positionUpdated(const QGeoPositionInfo &update);
 
     void timeout();
-
-    void simNameChanged(const QString &simName);
 
 private:
     QUdpSocket *_udpSocket = nullptr;

--- a/src/icons.qrc.in
+++ b/src/icons.qrc.in
@@ -40,6 +40,7 @@
         <file alias="icons/material/ic_refresh.svg">${material-design-icons_SOURCE_DIR}/navigation/svg/production/ic_refresh_24px.svg</file>
         <file alias="icons/material/ic_remove_circle.svg">${material-design-icons_SOURCE_DIR}/content/svg/production/ic_remove_circle_24px.svg</file>
         <file alias="icons/material/ic_satellite.svg">${material-design-icons_SOURCE_DIR}/maps/svg/production/ic_satellite_24px.svg</file>
+        <file alias="icons/material/ic_computer.svg">${material-design-icons_SOURCE_DIR}/hardware/svg/production/ic_computer_24px.svg</file>
         <file alias="icons/material/ic_send.svg">${material-design-icons_SOURCE_DIR}/content/svg/design/ic_send_24px.svg</file>
 	<file alias="icons/material/ic_settings.svg">${material-design-icons_SOURCE_DIR}/action/svg/production/ic_settings_24px.svg</file>
 	<file alias="icons/material/ic_swap_horiz.svg">${material-design-icons_SOURCE_DIR}/action/svg/production/ic_swap_horiz_24px.svg</file>

--- a/src/qml.qrc.in
+++ b/src/qml.qrc.in
@@ -11,6 +11,7 @@
         <file alias="dialogs/LongTextDialogMD.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/LongTextDialogMD.qml</file>
         <file alias="dialogs/MissingPermissionsDialog.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/MissingPermissionsDialog.qml</file>
         <file alias="dialogs/SatNavStatusDialog.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/SatNavStatusDialog.qml</file>
+        <file alias="dialogs/SimInterfaceStatusDialog.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/SimInterfaceStatusDialog.qml</file>
         <file alias="dialogs/TooManyDownloadsDialog.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/TooManyDownloadsDialog.qml</file>
         <file alias="dialogs/UpdateMapDialog.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/UpdateMapDialog.qml</file>
         <file alias="dialogs/WaypointDescription.qml">${CMAKE_CURRENT_SOURCE_DIR}/qml/dialogs/WaypointDescription.qml</file>

--- a/src/qml/dialogs/LongTextDialog.qml
+++ b/src/qml/dialogs/LongTextDialog.qml
@@ -35,8 +35,8 @@ Dialog {
     // Center in Overlay.overlay. This is a funny workaround against a bug, I believe,
     // in Qt 15.1 where setting the parent (as recommended in the Qt documentation) does not seem to work right if the Dialog is opend more than once.
     parent: Overlay.overlay
-    x: (parent.width-width)/2.0
-    y: (parent.height-height)/2.0
+    x: (view.width-width)/2.0
+    y: (view.height-height)/2.0
 
     modal: true
     

--- a/src/qml/dialogs/LongTextDialogMD.qml
+++ b/src/qml/dialogs/LongTextDialogMD.qml
@@ -34,8 +34,8 @@ Dialog {
     // Center in Overlay.overlay. This is a funny workaround against a bug, I believe,
     // in Qt 15.1 where setting the parent (as recommended in the Qt documentation) does not seem to work right if the Dialog is opend more than once.
     parent: Overlay.overlay
-    x: (parent.width-width)/2.0
-    y: (parent.height-height)/2.0
+    x: (view.width-width)/2.0
+    y: (view.height-height)/2.0
 
     modal: true
     

--- a/src/qml/dialogs/SatNavStatusDialog.qml
+++ b/src/qml/dialogs/SatNavStatusDialog.qml
@@ -31,7 +31,6 @@ Dialog {
     title: qsTr("Satellite Status")
 
     // Size is chosen so that the dialog does not cover the parent in full
-    // Size is chosen so that the dialog does not cover the parent in full
     width: Math.min(parent.width-Qt.application.font.pixelSize, 40*Qt.application.font.pixelSize)
     height: Math.min(parent.height-Qt.application.font.pixelSize, implicitHeight)
 

--- a/src/qml/dialogs/SimInterfaceStatusDialog.qml
+++ b/src/qml/dialogs/SimInterfaceStatusDialog.qml
@@ -1,0 +1,100 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Controls.Material 2.15
+import QtQuick.Layouts 1.15
+
+import enroute 1.0
+
+Dialog {
+    id: simStatusDialog
+
+    title: qsTr("Simulation Interface Status")
+
+    // Size is chosen so that the dialog does not cover the parent in full
+    // Size is chosen so that the dialog does not cover the parent in full
+    width: Math.min(parent.width-Qt.application.font.pixelSize, 40*Qt.application.font.pixelSize)
+    height: Math.min(parent.height-Qt.application.font.pixelSize, implicitHeight)
+
+    standardButtons: Dialog.Ok
+
+    ScrollView {
+        id: view
+        clip: true
+        anchors.fill: parent
+
+        // The visibility behavior of the vertical scroll bar is a little complex.
+        // The following code guarantees that the scroll bar is shown initially. If it is not used, it is faded out after half a second or so.
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        ScrollBar.vertical.policy: (height < contentHeight) ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
+
+        GridLayout {
+            id: gl
+            columnSpacing: 30
+            columns: 2
+
+            Label { text: qsTr("Simulaion Interface Status") }
+            Label {
+                font.weight: Font.Bold
+                text: satNav.statusAsString
+                color: (satNav.status === SatNav.OK) ? "green" : "red"
+                wrapMode: Text.Wrap
+            }
+
+            Label { text: qsTr("Simulator") }
+            Label { text: satNav.sourceName }
+
+            Label { text: qsTr("Last Fix") }
+            Label { text: satNav.timestampAsString }
+
+            Label { text: qsTr("Mode") }
+            Label { text: satNav.isInFlight ? qsTr("Flight") : qsTr("Ground") }
+
+            Label {
+                font.pixelSize: Qt.application.font.pixelSize*0.5
+                Layout.columnSpan: 2
+            }
+
+            Label {
+                text: qsTr("Horizontal")
+                font.weight: Font.Bold
+                Layout.columnSpan: 2
+            }
+
+            Label { text: qsTr("Latitude") }
+            Label { text: satNav.latitudeAsString }
+
+            Label { text: qsTr("Longitude") }
+            Label { text: satNav.longitudeAsString }
+
+            Label { text: qsTr("Error") }
+            Label { text: satNav.horizontalPrecisionInMetersAsString }
+
+            Label { text: qsTr("GS") }
+            Label { text: globalSettings.useMetricUnits ? satNav.groundSpeedInKMHAsString : satNav.groundSpeedInKnotsAsString }
+
+            Label { text: qsTr("TT") }
+            Label { text: satNav.trackAsString }
+
+            Label {
+                font.pixelSize: Qt.application.font.pixelSize*0.5
+                Layout.columnSpan: 2
+            }
+
+            Label {
+                text: qsTr("Vertical")
+                font.weight: Font.Bold
+                Layout.columnSpan: 2
+            }
+
+            Label { text: qsTr("ALT") }
+            Label { text: satNav.altitudeInFeetAsString }
+        } // GridLayout
+
+    } // Scrollview
+
+    onAccepted: {
+        // Give feedback
+        mobileAdaptor.vibrateBrief()
+        close()
+    }
+} // Dialog

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -150,16 +150,20 @@ ApplicationWindow {
                         id: aboutMenu
 
                         ItemDelegate { // Sat Status
-                            text: qsTr("Satellite Navigation")
-                                  +`<br><font color="#606060" size="2">`
-                                  + qsTr("Status")
-                                  + `: ${satNav.statusAsString}</font>`
-                            icon.source: "/icons/material/ic_satellite.svg"
+                            text: globalSettings.connectToSim ? qsTr("Connected to Sim: ") + satNav.sourceName
+                                                                +`<br><font color="#606060" size="2">`
+                                                                + qsTr("Status")
+                                                                + `: ${satNav.statusAsString}</font>`
+                                                              : qsTr("Satellite Navigation")
+                                                                +`<br><font color="#606060" size="2">`
+                                                                + qsTr("Status")
+                                                                + `: ${satNav.statusAsString}</font>`
+                            icon.source: globalSettings.connectToSim ? "/icons/material/ic_computer.svg" : "/icons/material/ic_satellite.svg"
                             Layout.fillWidth: true
                             onClicked: {
                                 mobileAdaptor.vibrateBrief()
                                 dialogLoader.active = false
-                                dialogLoader.source = "dialogs/SatNavStatusDialog.qml"
+                                dialogLoader.source = globalSettings.connectToSim ? "dialogs/SimInterfaceStatusDialog.qml" : "dialogs/SatNavStatusDialog.qml"
                                 dialogLoader.active = true
                                 aboutMenu.close()
                                 drawer.close()

--- a/src/qml/pages/TrafficReceiver.qml
+++ b/src/qml/pages/TrafficReceiver.qml
@@ -50,7 +50,7 @@ Page {
                     drawer.open()
                 }
             }
-        } // ToolButton
+        }
 
         Label {
             anchors.left: backButton.right
@@ -79,7 +79,8 @@ Page {
 
         }
 
-    } // ToolBar
+    }
+
 
     ScrollView {
         id: view
@@ -189,6 +190,7 @@ Page {
 
 <ul style=\"margin-left:-25px;\">
 <li>Make sure that your device has entered the WLAN network deployed by your traffic receiver.  If not, then use the button at the bottem of the screen to abort the connection attempt.</li>
+<li>Click on the question mark in the page title to open a more detailed help dialog.</li>
 </ul>
 ")
                     if (flarmAdaptor.status == FLARMAdaptor.Connected)
@@ -210,45 +212,45 @@ Page {
             }
         }
 
-    } // Scrollview
+    }
+
 
     footer: Pane {
         width: parent.width
         Material.elevation: 3
 
-        ColumnLayout {
-            width: parent.width
+        ToolButton {
+            anchors.centerIn: parent
+            width: Math.min(implicitWidth, parent.width-Qt.application.font.pixelSize)
 
-            ToolButton {
-                text: {
-                    if (flarmAdaptor.status === FLARMAdaptor.Disconnected)
-                        return qsTr("Connect to Traffic Receiver")
-                    if (flarmAdaptor.status === FLARMAdaptor.Connecting)
-                        return qsTr("Abort Connection")
-                    qsTr("Disconnect from Traffic Receiver")
-                }
+            text: {
+                if (flarmAdaptor.status === FLARMAdaptor.Disconnected)
+                    return qsTr("Connect to Traffic Receiver")
+                if (flarmAdaptor.status === FLARMAdaptor.Connecting)
+                    return qsTr("Abort Connection")
+                qsTr("Disconnect from Traffic Receiver")
+            }
 
-                icon.source: (flarmAdaptor.status === FLARMAdaptor.Disconnected) ? "/icons/material/ic_tap_and_play.svg" : "/icons/material/ic_cancel.svg"
+            icon.source: (flarmAdaptor.status === FLARMAdaptor.Disconnected) ? "/icons/material/ic_tap_and_play.svg" : "/icons/material/ic_cancel.svg"
 
-                Layout.alignment: Qt.AlignHCenter
-                Material.foreground: Material.accent
+            Layout.alignment: Qt.AlignHCenter
+            Material.foreground: Material.accent
 
-                enabled: !timer.running
-                onClicked: {
-                    if (flarmAdaptor.status == FLARMAdaptor.Disconnected)
-                        flarmAdaptor.connectToTrafficReceiver()
-                    else
-                        flarmAdaptor.disconnectFromTrafficReceiver()
-                    timer.running = true;
-                }
-                Timer {
-                    id: timer
-                    interval: 1000
-                }
-
+            enabled: !timer.running
+            onClicked: {
+                if (flarmAdaptor.status == FLARMAdaptor.Disconnected)
+                    flarmAdaptor.connectToTrafficReceiver()
+                else
+                    flarmAdaptor.disconnectFromTrafficReceiver()
+                timer.running = true;
+            }
+            Timer {
+                id: timer
+                interval: 1000
             }
 
         }
+
     }
 
 
@@ -261,5 +263,4 @@ Page {
         text: librarian.getStringFromRessource(":text/flarmSetup.md")
     }
 
-
-} // Page
+}


### PR DESCRIPTION
Draft/IWIP pull request adding an interface to receive position, altitude, track, and groundspeed from simulators like X-Plane, FS2020, FlightGear, or DCS. A description of the interface can be found here: https://www.foreflight.com/support/network-gps/.

How the interface is enabled in the simulators is described here:
* [X-Plane](https://support.foreflight.com/hc/en-us/articles/204115525-How-do-I-connect-to-the-X-Plane-flight-simulator-)
* [FS2020](https://support.foreflight.com/hc/en-us/articles/204115275-How-do-I-connect-Microsoft-Flight-Simulator-FS-X-or-FS-2004-to-ForeFlight-)
* [DCS-to-GPS](https://support.foreflight.com/hc/en-us/articles/204115275-How-do-I-connect-Microsoft-Flight-Simulator-FS-X-or-FS-2004-to-ForeFlight-)

Receiving traffic data can also be added using this interface.