### PR TITLE
fastlane structure for F-Droid

### DIFF
--- a/fastlane/android/metadata/de/short_description.txt
+++ b/fastlane/android/metadata/de/short_description.txt
@@ -1,0 +1,1 @@
+enroute ist eine freie Flugnavigationsapp für VFR-Piloten

--- a/fastlane/android/metadata/en-US/changelogs/202040.txt
+++ b/fastlane/android/metadata/en-US/changelogs/202040.txt
@@ -1,0 +1,1 @@
+Initial version for F-Droid.

--- a/fastlane/android/metadata/en-US/changelogs/203000.txt
+++ b/fastlane/android/metadata/en-US/changelogs/203000.txt
@@ -1,0 +1,3 @@
+v2.3.0 Feature release
+To improve readability, map contrast is increased and the app is less colorful than it used to be. There is now a dark mode, specifically designed for night flight.
+There are many small additional improvements, in particular for flight route editing and flight route import. It is now possible to assign names to the waypoints of your flight route.

--- a/fastlane/android/metadata/en-US/changelogs/203010.txt
+++ b/fastlane/android/metadata/en-US/changelogs/203010.txt
@@ -1,0 +1,1 @@
+v2.3.1 Minor bugfixing release

--- a/fastlane/android/metadata/en-US/changelogs/205000.txt
+++ b/fastlane/android/metadata/en-US/changelogs/205000.txt
@@ -1,0 +1,2 @@
+v2.5.0 Feature release
+The app can now connect to your aircraft's traffic receiver (typically a FLARM device) and show nearby traffic on the moving map. Open the menu and go to Information/Traffic Reveicer to try it out.

--- a/fastlane/android/metadata/en-US/changelogs/206040.txt
+++ b/fastlane/android/metadata/en-US/changelogs/206040.txt
@@ -1,0 +1,2 @@
+v2.6.4 Feature release
+Users of Stratux traffic receivers can now connect to their devices without changing the Stratux IP address. The app now shows FLARM traffic warnings and there are many small improvements in the user interface.

--- a/fastlane/android/metadata/en-US/changelogs/206050.txt
+++ b/fastlane/android/metadata/en-US/changelogs/206050.txt
@@ -1,0 +1,2 @@
+v2.6.5 Minor bugfixing release
+Users of Stratux traffic receivers can now connect to their devices without changing the Stratux IP address. The app now shows FLARM traffic warnings and there are many small improvements in the user interface.

--- a/fastlane/android/metadata/en-US/changelogs/206060.txt
+++ b/fastlane/android/metadata/en-US/changelogs/206060.txt
@@ -1,0 +1,2 @@
+v2.6.6 Bugfixing release
+Users of Stratux traffic receivers can now connect to their devices without changing the Stratux IP address. The app now shows FLARM traffic warnings and there are many small improvements in the user interface. Version 2.6.6 fixes a stability issue.

--- a/fastlane/android/metadata/en-US/full_description.txt
+++ b/fastlane/android/metadata/en-US/full_description.txt
@@ -1,0 +1,11 @@
+Enroute is a free flight navigation app for VFR pilots. Designed to be simple, functional and elegant, it takes the stress out of your next flight. The program has been written by flight enthusiasts, as a project of Akaflieg Freiburg, a flight club based in Freiburg, Germany.
+
+Enroute features a moving map, similar in style to the official ICAO maps. Your current position and your flight path for the next five minutes are marked, and so is your intended flight route. A simple tap on the display gives you all the information about airspaces, airfields and navaids – complete with frequencies, codes, elevations and runway information.
+
+Our free aeronautical maps can be downloaded for offline use. In addition to airspaces, airfields and navaids, selected maps also show traffic circuits as well as flight procedures for control zones. The maps receive near-weekly updates and cover large parts of the world.
+
+Enroute supports basic flight planning. It allows you to quickly and easily compute distances, courses and headings, and gives you an estimate for flight time and fuel consumption. If the weather turns bad, the app will show you the closest airfields for landing, complete with distances, directions, runway information and frequencies.
+
+The original author strongly supports the provision of the app via f-droid. However, this is an unofficial version of the app, which has not been tested by the original app author. It might differ from the official version, even if the version number agrees with that of the official app.
+
+Disclaimer: This free app is published in the hope that it might be useful as an aid to prudent navigation. It comes with no guarantees. It may not work as expected. The data does not come from official sources and might be incomplete, outdated or otherwise incorrect. This app is no substitute for proper flight preparation or good pilotage. Relying on it as a primary means of navigation is most likely illegal, most certainly stupid and potentially suicidal.

--- a/fastlane/android/metadata/en-US/images/icon.png
+++ b/fastlane/android/metadata/en-US/images/icon.png
@@ -1,0 +1,1 @@
+../../../../../generatedSources/metadata/de.akaflieg_freiburg.enroute.png

--- a/fastlane/android/metadata/en-US/images/phoneScreenshots/1.png
+++ b/fastlane/android/metadata/en-US/images/phoneScreenshots/1.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/phone-00-Flight.png

--- a/fastlane/android/metadata/en-US/images/phoneScreenshots/2.png
+++ b/fastlane/android/metadata/en-US/images/phoneScreenshots/2.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/phone-01-Map.png

--- a/fastlane/android/metadata/en-US/images/phoneScreenshots/3.png
+++ b/fastlane/android/metadata/en-US/images/phoneScreenshots/3.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/phone-02-Map.png

--- a/fastlane/android/metadata/en-US/images/phoneScreenshots/4.png
+++ b/fastlane/android/metadata/en-US/images/phoneScreenshots/4.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/phone-03-Info.png

--- a/fastlane/android/metadata/en-US/images/phoneScreenshots/5.png
+++ b/fastlane/android/metadata/en-US/images/phoneScreenshots/5.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/phone-04-Route.png

--- a/fastlane/android/metadata/en-US/images/phoneScreenshots/6.png
+++ b/fastlane/android/metadata/en-US/images/phoneScreenshots/6.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/phone-05-Nearby.png

--- a/fastlane/android/metadata/en-US/images/tenInchScreenshots/1.png
+++ b/fastlane/android/metadata/en-US/images/tenInchScreenshots/1.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/tab-10-Map.png

--- a/fastlane/android/metadata/en-US/images/tenInchScreenshots/2.png
+++ b/fastlane/android/metadata/en-US/images/tenInchScreenshots/2.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/tab-11-Map-Flight.png

--- a/fastlane/android/metadata/en-US/images/tenInchScreenshots/3.png
+++ b/fastlane/android/metadata/en-US/images/tenInchScreenshots/3.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/tab-12-CTR.png

--- a/fastlane/android/metadata/en-US/images/tenInchScreenshots/4.png
+++ b/fastlane/android/metadata/en-US/images/tenInchScreenshots/4.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/tab-13-Info.png

--- a/fastlane/android/metadata/en-US/images/tenInchScreenshots/5.png
+++ b/fastlane/android/metadata/en-US/images/tenInchScreenshots/5.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/tab-14-Route.png

--- a/fastlane/android/metadata/en-US/images/tenInchScreenshots/6.png
+++ b/fastlane/android/metadata/en-US/images/tenInchScreenshots/6.png
@@ -1,0 +1,1 @@
+../../../../../../propaganda/GooglePlay/tab-15-NearAD.png

--- a/fastlane/android/metadata/en-US/short_description.txt
+++ b/fastlane/android/metadata/en-US/short_description.txt
@@ -1,0 +1,1 @@
+enroute is a free flight navigation app for VFR pilots

--- a/fastlane/android/metadata/en-US/title.txt
+++ b/fastlane/android/metadata/en-US/title.txt
@@ -1,0 +1,1 @@
+enroute flight navigation


### PR DESCRIPTION
Merge request to add fastlane structure mainly for F-Droid as requested by maintainers of F-Droid in recent [merge request to update enroute flight navigation on F-Droid](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/8374#note_565459828).

Also requested in issue https://github.com/Akaflieg-Freiburg/enroute/issues/154.

A description of usage of fastlane structure in F-Droid can be found in F-Droid documentation: [All About Descriptions, Graphics, and Screenshots - Fastlane structure](https://f-droid.org/en/docs/All_About_Descriptions_Graphics_and_Screenshots/#fastlane-structure).