### PR TITLE
Fix linux.yml (github actions)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install Additional Software
       run: |
         sudo apt install extra-cmake-modules ninja-build spirv-tools
+    - name: Remove GCC 13 to avoid conflicts with Clang
+      run: |
+        sudo apt remove gcc-13 g++-13 libgcc-13-dev libstdc++-13-dev
     - name: Compile QtLocation
       run: |
         cmake -E make_directory build-qtlocation


### PR DESCRIPTION
Hello Stefan, 

The Linux build of Enroute in Github Actions CI system fails currently:
https://github.com/Akaflieg-Freiburg/enroute/actions/workflows/linux.yml

The error is:
```
/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
        static constexpr unsigned fractional_width = {_S_fractional_width()};
```

It fails since github has added gcc-13 to the ubuntu image in oktober 2023. 
https://github.com/actions/runner-images/commit/388d55d0d741619a8718061d401166ebdc1f01f5

There is some conflict between gcc13 and clang. clang is using libstdc++ from gcc.
You could work around it by removing gcc-13 again.

I like the yml files, because it is also a recipe how to compile the software. 
