### PR TITLE
More exact formula for density altitude calculation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ set(SOURCES
     units/Volume.h
     units/VolumeFlow.h
     weather/Decoder.h
+    weather/DensityAltitude.h
     weather/METAR.h
     weather/Station.h
     weather/TAF.h
@@ -210,6 +211,7 @@ set(SOURCES
     units/Volume.cpp
     units/VolumeFlow.cpp
     weather/Decoder.cpp
+    weather/DensityAltitude.cpp
     weather/METAR.cpp
     weather/Station.cpp
     weather/TAF.cpp

--- a/src/qml/dialogs/WeatherReport.qml
+++ b/src/qml/dialogs/WeatherReport.qml
@@ -105,6 +105,11 @@ CenteringDialog {
                     textFormat: Text.RichText // OK
                 }
 
+                Label { // calculated density altitude
+                    visible: (weatherStation != null) && weatherStation.hasCalculatedDensityAltitude
+                    text: (weatherStation != null) && weatherStation.hasCalculatedDensityAltitude ? ( "calculated Density Altitude: " + weatherStation.calculatedDensityAltitude + " ft" ) : ""
+                }
+
                 Label { // title: "TAF"
                     visible: (weatherStation != null) && weatherStation.hasTAF
                     text: "TAF"

--- a/src/units/Temperature.cpp
+++ b/src/units/Temperature.cpp
@@ -20,3 +20,16 @@
 
 #include "units/Temperature.h"
 
+auto operator<<(QDataStream &out, Units::Temperature t) -> QDataStream &
+{
+    out << t.toDegreeKelvin();
+    return out;
+}
+
+auto operator>>(QDataStream &in, Units::Temperature &t) -> QDataStream &
+{
+    double buffer = NAN;
+    in >> buffer;
+    t = Units::Temperature::fromDegreeKelvin(buffer);
+    return in;
+}

--- a/src/units/Temperature.h
+++ b/src/units/Temperature.h
@@ -127,6 +127,8 @@ private:
 };
 } // namespace Units
 
+auto operator<<(QDataStream &out, Units::Temperature t) -> QDataStream &;
+auto operator>>(QDataStream &in, Units::Temperature &t) -> QDataStream &;
 
 // Declare meta types
 Q_DECLARE_METATYPE(Units::Temperature)

--- a/src/weather/DensityAltitude.cpp
+++ b/src/weather/DensityAltitude.cpp
@@ -1,0 +1,16 @@
+#include "weather/DensityAltitude.h"
+#include <cmath>
+
+// calculate Density Altitude.
+// Parameters:
+//   elevation: The elevation above sea level in feet.
+//   qnh: The atmospheric pressure at sea level in hPa.
+//   T: The outside air temperature in degrees Celsius.
+// For the formulas, see:
+//   https://aerotoolbox.com/density-altitude/
+double Weather::calculateDensityAltitude(double elevation, double qnh, double T) {
+    double PA = (1013.25 - qnh) * 30.0 + elevation;
+    double Tisa = 15.0 - (0.00198 * PA);
+    double DA = PA + 120.0 * (T - Tisa);
+    return DA;
+}

--- a/src/weather/DensityAltitude.cpp
+++ b/src/weather/DensityAltitude.cpp
@@ -1,16 +1,126 @@
-#include "weather/DensityAltitude.h"
-#include <cmath>
+/***************************************************************************
+ *   Copyright (C) 2019-2022 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
 
-// calculate Density Altitude.
-// Parameters:
-//   elevation: The elevation above sea level in feet.
-//   qnh: The atmospheric pressure at sea level in hPa.
-//   T: The outside air temperature in degrees Celsius.
-// For the formulas, see:
-//   https://aerotoolbox.com/density-altitude/
-double Weather::calculateDensityAltitude(double elevation, double qnh, double T) {
-    double PA = (1013.25 - qnh) * 30.0 + elevation;
-    double Tisa = 15.0 - (0.00198 * PA);
-    double DA = PA + 120.0 * (T - Tisa);
-    return DA;
+
+#include "weather/DensityAltitude.h"
+#include "units/Distance.h"
+#include "units/Temperature.h"
+#include <math.h>
+
+double Weather::DensityAltitude::calculateDensityAltitudeDryAirApproximation(double oat, double qnh, double geometricAltitudeInFt)
+{
+    return calculateDensityAltitudeInternal(oat, qnh, geometricAltitudeInFt, 0, false);
+}
+
+double Weather::DensityAltitude::calculateDensityAltitude(double oat, double qnh, double geometricAltitudeInFt, double dewPoint)
+{
+    return calculateDensityAltitudeInternal(oat, qnh, geometricAltitudeInFt, dewPoint, true);
+}
+
+
+double Weather::DensityAltitude::calculateDensityAltitudeInternal(double oat, double qnh, double geometricAltitudeInFt, double dewPoint, bool bWithDewPoint)
+{
+    const double geometricAltitudeInKm = Units::Distance::fromFT(geometricAltitudeInFt).toKM();
+    const double geopotentialAltitude = geometricAltitudeToGeopotentialAltitude(geometricAltitudeInKm);
+    const double pAir = calculateAirDensity(oat, qnh, geopotentialAltitude, dewPoint, bWithDewPoint); // Air density
+
+    const double g = 9.80665; // Acceleration due to gravity
+    const double M = 0.028964; // Molar mass of dry air
+    const double R = 8.31432; // Universal Gas Constant
+    const double Gamma = 0.0065; // Environmental Lapse Rate (valid below 11 000 m)
+    const double T0 = 288.15; // Sea level Standard Temperature
+    const double P0 = 101325; // Sea level Standard Pressure
+    
+    // density equation formula
+    const double h1 = T0 / Gamma;
+    const double h2 = R * T0 * pAir;
+    const double h3 = M * P0;
+    const double h4 = h2 / h3;
+    const double h5 = 1 - (pow(h4, ((Gamma * R) / (g * M - Gamma * R))));
+    const double h = h1 * h5;
+    
+    return Units::Distance::fromM(h).toFeet();
+}
+
+double Weather::DensityAltitude::calculateVapourPressure(double dewPoint)
+{
+    const double eso = 6.1078; // polynomial constant
+
+    // remark: errors in odd coefficients in https://aerotoolbox.com/density-altitude/
+    // refer to https://wahiduddin.net/calc/density_altitude.htm instead
+    const double c[10] = {
+         0.99999683,         
+        -0.90826951e-2, 
+         0.78736169e-4,    
+        -0.61117958e-6,
+         0.43884187e-8,     
+        -0.29883885e-10,
+         0.21874425e-12,    
+        -0.17892321e-14,
+         0.11112018e-16,    
+        -0.30994571e-19
+    };
+    
+    const double p = (c[0] + dewPoint * (c[1] + dewPoint * (c[2] + dewPoint * (c[3] + dewPoint * (c[4] + dewPoint * (c[5] + dewPoint * (c[6] + dewPoint * (c[7] + dewPoint * (c[8] + dewPoint * (c[9]))))))))));
+    const double Es = eso / (pow(p, 8)); // Saturation pressure of water vapour, Herman Wobus approximation
+    const double Pv = Es; // partial pressure of water vapour
+    
+    return Pv;
+}
+
+double Weather::DensityAltitude::calculateAbsolutePressure(double qnh, double height)
+{
+  const double heightInM = Units::Distance::fromKM(height).toM();
+  const double k1 = 0.190263; // Constant
+  const double k2 = 8.417286e-5; // Constant
+
+  // Absolute pressure formula
+  const double Pa1 = pow(qnh, k1);
+  const double Pa2 = k2 * heightInM;
+  const double Pa3 = (Pa1 - Pa2);
+  const double Pa = pow(Pa3, (1 / (k1))); // Absolute pressure
+  
+  return Pa;
+}
+
+double Weather::DensityAltitude::calculateAirDensity(double temperature, double qnh, double height, double dewPoint, bool bWithDewPoint)
+{
+    const double Rd = 287.058; // Gas constant dry air
+    const double Rv = 461.495; // Gas constant water vapour
+    const double Pv = bWithDewPoint ? calculateVapourPressure(dewPoint) : 0; // partial pressure of water vapour
+    const double Pa = calculateAbsolutePressure(qnh, height); // Absolute or Station Pressure
+    const double Pd = Pa - Pv; // Partial pressure of dry air
+    const double temperatureInK = Units::Temperature::fromDegreeCelsius(temperature).toDegreeKelvin();
+
+    // air density formula
+    const double pAir1 = ((Pd * 100) / (Rd * temperatureInK));
+    const double pAir2 = ((Pv * 100) / (Rv * temperatureInK));
+    const double pAir = pAir1 + pAir2; // Calculated Density of Air
+    return pAir;
+}
+
+double Weather::DensityAltitude::geometricAltitudeToGeopotentialAltitude(double geometricAltitudeInKm)
+{
+    const double E = 6356.766; // ISA radius of the Earth
+
+    // Geopotential Altitude formula
+    const double H = (geometricAltitudeInKm * E) / (E + geometricAltitudeInKm); // Geopotential Altitude
+    return H;
 }

--- a/src/weather/DensityAltitude.h
+++ b/src/weather/DensityAltitude.h
@@ -1,4 +1,68 @@
+/***************************************************************************
+ *   Copyright (C) 2019-2022 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
 #pragma once
+
 namespace Weather {
-    double calculateDensityAltitude(double elevation, double qnh, double T);
-}
+
+/*! \brief This class calculates the density altiude according to temperature, QNH,  Altitude (and dewpoint) */
+class DensityAltitude {
+public:
+    //
+    // Methods
+    //
+
+    /*! \brief calculates the density altiude without dewpoint information
+     * 
+     * @param oat outside air temperature in degrees Celsius.
+     * @param qnh The atmospheric pressure at sea level in hPa.
+     * @param geometricAltitudeInFt The elevation above sea level in feet.
+     * @returns dry air approximation of density altiude according to https://aerotoolbox.com/density-altitude/
+     */
+    static double calculateDensityAltitudeDryAirApproximation(double oat, double qnh, double geometricAltitudeInFt);
+
+    
+    /*! \brief 
+    * 
+    * @param oat outside air temperature in celsius
+    * @param qnh The atmospheric pressure at sea level in hPa.
+    * @param geometricAltitudeInFt The elevation above sea level in feet.
+    * @param dewPoint dew point in degrees Celsius.
+    * @returns density altiude according to https://aerotoolbox.com/density-altitude/
+    */
+    static double calculateDensityAltitude(double oat, double qnh, double geometricAltitudeInFt, double dewPoint);
+private:
+    // calculates the actual density altitude either with or without a given dewpoint
+    static double calculateDensityAltitudeInternal(double oat, double qnh, double geometricAltitudeInFt, double dewPoint, bool bWithDewPoint);
+
+    // converts the geometricAltitude into geopotential altitude
+    static double geometricAltitudeToGeopotentialAltitude(double geometricAltitudeInKm);
+
+    // calculates the air density either with or without a given dewpoint
+    static double calculateAirDensity(double temperature, double qnh, double height, double dewPoint, bool bWithDewPoint);
+
+    // calculates the air density
+    static double calculateAbsolutePressure(double qnh, double height);
+
+    // calculates the vapour pressure using the Herman Wobus approximation polynominal curve
+    static double calculateVapourPressure(double dewPoint);
+};
+
+} // namespace Weather

--- a/src/weather/DensityAltitude.h
+++ b/src/weather/DensityAltitude.h
@@ -20,6 +20,11 @@
 
 #pragma once
 
+#include "units/Distance.h"
+#include "units/Density.h"
+#include "units/Pressure.h"
+#include "units/Temperature.h"
+
 namespace Weather {
 
 /*! \brief This class calculates the density altiude according to temperature, QNH,  Altitude (and dewpoint) */
@@ -31,38 +36,39 @@ public:
 
     /*! \brief calculates the density altiude without dewpoint information
      * 
-     * @param oat outside air temperature in degrees Celsius.
-     * @param qnh The atmospheric pressure at sea level in hPa.
-     * @param geometricAltitudeInFt The elevation above sea level in feet.
+     * @param oat outside air temperature
+     * @param qnh The atmospheric pressure at sea level
+     * @param geometricAltitude The elevation above sea level
      * @returns dry air approximation of density altiude according to https://aerotoolbox.com/density-altitude/
      */
-    static double calculateDensityAltitudeDryAirApproximation(double oat, double qnh, double geometricAltitudeInFt);
+    static Units::Distance calculateDensityAltitudeDryAirApproximation(Units::Temperature oat, Units::Pressure qnh, Units::Distance geometricAltitude);
 
     
-    /*! \brief 
+    /*! \brief  calculates the density altiude with dewpoint information
     * 
-    * @param oat outside air temperature in celsius
-    * @param qnh The atmospheric pressure at sea level in hPa.
-    * @param geometricAltitudeInFt The elevation above sea level in feet.
-    * @param dewPoint dew point in degrees Celsius.
+    * @param oat outside air temperature
+    * @param qnh The atmospheric pressure at sea level
+    * @param geometricAltitude The elevation above sea level
+    * @param dewPoint dew point
     * @returns density altiude according to https://aerotoolbox.com/density-altitude/
     */
-    static double calculateDensityAltitude(double oat, double qnh, double geometricAltitudeInFt, double dewPoint);
+    static Units::Distance calculateDensityAltitude(Units::Temperature oat, Units::Pressure qnh, Units::Distance geometricAltitude, Units::Temperature dewPoint);
 private:
     // calculates the actual density altitude either with or without a given dewpoint
-    static double calculateDensityAltitudeInternal(double oat, double qnh, double geometricAltitudeInFt, double dewPoint, bool bWithDewPoint);
-
-    // converts the geometricAltitude into geopotential altitude
-    static double geometricAltitudeToGeopotentialAltitude(double geometricAltitudeInKm);
-
-    // calculates the air density either with or without a given dewpoint
-    static double calculateAirDensity(double temperature, double qnh, double height, double dewPoint, bool bWithDewPoint);
-
-    // calculates the air density
-    static double calculateAbsolutePressure(double qnh, double height);
+    static Units::Distance calculateDensityAltitudeInternal(Units::Temperature oat, Units::Pressure qnh, Units::Distance geometricAltitude, Units::Temperature dewPoint, bool bWithDewPoint);
 
     // calculates the vapour pressure using the Herman Wobus approximation polynominal curve
-    static double calculateVapourPressure(double dewPoint);
+    static Units::Pressure calculateVapourPressure(Units::Temperature dewPoint);
+
+    // calculates the air density
+    static Units::Pressure calculateAbsolutePressure(Units::Pressure qnh, Units::Distance height);
+
+    // calculates the air density either with or without a given dewpoint
+    static Units::Density calculateAirDensity(Units::Temperature temperature, Units::Pressure qnh, Units::Distance height, Units::Temperature dewPoint, bool bWithDewPoint);
+
+
+    // converts the geometricAltitude into geopotential altitude
+    static Units::Distance geometricAltitudeToGeopotentialAltitude(Units::Distance geometricAltitude);
 };
 
 } // namespace Weather

--- a/src/weather/DensityAltitude.h
+++ b/src/weather/DensityAltitude.h
@@ -1,0 +1,4 @@
+#pragma once
+namespace Weather {
+    double calculateDensityAltitude(double elevation, double qnh, double T);
+}

--- a/src/weather/METAR.cpp
+++ b/src/weather/METAR.cpp
@@ -66,6 +66,12 @@ Weather::METAR::METAR(QXmlStreamReader &xml, QObject *parent)
             continue;
         }
 
+        // Read temperature
+        if (xml.isStartElement() && name == u"temp_c"_qs) {
+            _temperature = Units::Temperature::fromDegreeCelsius(xml.readElementText().toDouble());
+            continue;
+        }
+
         // QNH
         if (xml.isStartElement() && name == u"altim_in_hg"_qs) {
             auto content = xml.readElementText();
@@ -140,6 +146,7 @@ Weather::METAR::METAR(QDataStream &inputStream, QObject *parent)
     inputStream >> _raw_text;
     inputStream >> _wind;
     inputStream >> _gust;
+    inputStream >> _temperature;
 
     // Interpret the METAR message
     setRawText(_raw_text, _observationTime.date());
@@ -296,4 +303,5 @@ void Weather::METAR::write(QDataStream &out)
     out << _raw_text;
     out << _wind;
     out << _gust;
+    out << _temperature;
 }

--- a/src/weather/METAR.cpp
+++ b/src/weather/METAR.cpp
@@ -72,6 +72,12 @@ Weather::METAR::METAR(QXmlStreamReader &xml, QObject *parent)
             continue;
         }
 
+        // Read dewpoint
+        if (xml.isStartElement() && name == u"dewpoint_c"_qs) {
+            _dewpoint = Units::Temperature::fromDegreeCelsius(xml.readElementText().toDouble());
+            continue;
+        }
+
         // QNH
         if (xml.isStartElement() && name == u"altim_in_hg"_qs) {
             auto content = xml.readElementText();
@@ -147,6 +153,7 @@ Weather::METAR::METAR(QDataStream &inputStream, QObject *parent)
     inputStream >> _wind;
     inputStream >> _gust;
     inputStream >> _temperature;
+    inputStream >> _dewpoint;
 
     // Interpret the METAR message
     setRawText(_raw_text, _observationTime.date());
@@ -304,4 +311,5 @@ void Weather::METAR::write(QDataStream &out)
     out << _wind;
     out << _gust;
     out << _temperature;
+    out << _dewpoint;
 }

--- a/src/weather/METAR.h
+++ b/src/weather/METAR.h
@@ -26,6 +26,7 @@
 
 #include "units/Pressure.h"
 #include "units/Speed.h"
+#include "units/Temperature.h"
 #include "weather/Decoder.h"
 
 namespace Weather {
@@ -234,6 +235,10 @@ public:
      */
     [[nodiscard]] auto summary() const -> QString;
 
+    [[nodiscard]] auto temperature() const -> Units::Temperature
+    {
+        return _temperature;
+    }
 
 signals:
     /*! \brief Notifier signal */
@@ -285,5 +290,8 @@ private:
 
     // Wind speed, as returned by the Aviation Weather Center
     Units::Speed _wind;
+
+    // Temperature
+    Units::Temperature _temperature;
 };
 } // namespace Weather

--- a/src/weather/METAR.h
+++ b/src/weather/METAR.h
@@ -235,9 +235,22 @@ public:
      */
     [[nodiscard]] auto summary() const -> QString;
 
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property summary
+     */
     [[nodiscard]] auto temperature() const -> Units::Temperature
     {
         return _temperature;
+    }
+
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property summary
+     */
+    [[nodiscard]] auto dewPoint() const -> Units::Temperature
+    {
+        return _dewpoint;
     }
 
 signals:
@@ -293,5 +306,8 @@ private:
 
     // Temperature
     Units::Temperature _temperature;
+
+    // Dewpoint
+    Units::Temperature _dewpoint;
 };
 } // namespace Weather

--- a/src/weather/Station.cpp
+++ b/src/weather/Station.cpp
@@ -197,11 +197,16 @@ void Weather::Station::calculateDensityAltitude()
                    && _metar->coordinate().isValid() 
                    && _metar->QNH().isFinite() 
                    && _metar->temperature().isFinite() ) {
-        using Weather::calculateDensityAltitude;
         double altFeet = Units::Distance::fromM(_coordinate.altitude()).toFeet();
         double qnh = _metar->QNH().toHPa();
         double temp_c = _metar->temperature().toDegreeCelsius();
-        _calculatedDensityAltitude = calculateDensityAltitude(altFeet, qnh, temp_c);
+        if (_metar->dewPoint().isFinite() ) {
+            double dewpoint_c = _metar->dewPoint().toDegreeCelsius();
+            _calculatedDensityAltitude = Weather::DensityAltitude::calculateDensityAltitude(temp_c, qnh, altFeet, dewpoint_c);
+        } 
+        else {
+            _calculatedDensityAltitude = Weather::DensityAltitude::calculateDensityAltitudeDryAirApproximation(temp_c, qnh, altFeet);
+        }
     }
     else {
         _calculatedDensityAltitude.reset();

--- a/src/weather/Station.cpp
+++ b/src/weather/Station.cpp
@@ -197,15 +197,17 @@ void Weather::Station::calculateDensityAltitude()
                    && _metar->coordinate().isValid() 
                    && _metar->QNH().isFinite() 
                    && _metar->temperature().isFinite() ) {
-        double altFeet = Units::Distance::fromM(_coordinate.altitude()).toFeet();
-        double qnh = _metar->QNH().toHPa();
-        double temp_c = _metar->temperature().toDegreeCelsius();
+
+        Units::Distance altitude = Units::Distance::fromM(_coordinate.altitude());
+        Units::Pressure qnh = _metar->QNH();
+        Units::Temperature temperature = _metar->temperature();
+        
         if (_metar->dewPoint().isFinite() ) {
-            double dewpoint_c = _metar->dewPoint().toDegreeCelsius();
-            _calculatedDensityAltitude = Weather::DensityAltitude::calculateDensityAltitude(temp_c, qnh, altFeet, dewpoint_c);
+            Units::Temperature dewpoint = _metar->dewPoint();
+            _calculatedDensityAltitude = Weather::DensityAltitude::calculateDensityAltitude(temperature, qnh, altitude, dewpoint).toFeet();
         } 
         else {
-            _calculatedDensityAltitude = Weather::DensityAltitude::calculateDensityAltitudeDryAirApproximation(temp_c, qnh, altFeet);
+            _calculatedDensityAltitude = Weather::DensityAltitude::calculateDensityAltitudeDryAirApproximation(temperature, qnh, altitude).toFeet();
         }
     }
     else {

--- a/src/weather/Station.h
+++ b/src/weather/Station.h
@@ -311,6 +311,7 @@ private:
     // the TAF. The signal tafChanged() will be emitted if appropriate.
     void setTAF(Weather::TAF *taf);
 
+    // calculates the density altitude
     void calculateDensityAltitude();
 
     // Coordinate of this weather station

--- a/src/weather/Station.h
+++ b/src/weather/Station.h
@@ -225,6 +225,38 @@ public:
         return _taf;
     }
 
+    /*! \brief Check if a Calculated Density Altitude is known for this weather station
+     *
+     * This convenience property can be used to check if a Calculated Density Altitude is available
+     * for the weather station.  The actual Calculated Density Altitude can be accessed via the
+     * property calculatedDensityAltitude.
+     */
+    Q_PROPERTY(bool hasCalculatedDensityAltitude READ hasCalculatedDensityAltitude NOTIFY calculatedDensityAltitudeChanged)
+
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property hasCalculatedDensityAltitude
+     */
+    [[nodiscard]] auto hasCalculatedDensityAltitude() const -> bool
+    {
+        return _calculatedDensityAltitude.has_value();
+    }
+
+    /*! \brief Calculated Density Altitude for this weather station as an integer
+     *
+     * This property holds the calculated density altitude for the weather station as an integer.
+     */
+    Q_PROPERTY(int calculatedDensityAltitude READ calculatedDensityAltitude NOTIFY calculatedDensityAltitudeChanged)
+
+    /*! \brief Getter method for property of the same name
+     *
+     * @returns Property calculatedDensityAltitudeInt
+     */
+    [[nodiscard]] auto calculatedDensityAltitude() const -> int
+    {
+        return _calculatedDensityAltitude.value_or(0);
+    }
+
 signals:
     /* \brief Notifier signal */
     void coordinateChanged();
@@ -249,6 +281,9 @@ signals:
 
     /* \brief Notifier signal */
     void twoLineTitleChanged();
+
+    /* \brief Notifier signal */
+    void calculatedDensityAltitudeChanged();
 
 private slots:
     // This method attempts to find a waypoint matchting this weather station,
@@ -276,6 +311,8 @@ private:
     // the TAF. The signal tafChanged() will be emitted if appropriate.
     void setTAF(Weather::TAF *taf);
 
+    void calculateDensityAltitude();
+
     // Coordinate of this weather station
     QGeoCoordinate _coordinate;
 
@@ -296,6 +333,9 @@ private:
 
     // Two-Line-Title
     QString _twoLineTitle;
+
+    // calculated Density Altitude
+    std::optional<int> _calculatedDensityAltitude;
 
     // Pointer to GeoMapProvider, used in order to find matching waypoints
     QPointer<GeoMaps::GeoMapProvider> _geoMapProvider;


### PR DESCRIPTION
I read about the discussion of adding a density altitude calculation and, based on https://github.com/charlylima/enroute/tree/feature/densityAltitude I implemented the more exact formula, according to issue comment https://github.com/Akaflieg-Freiburg/enroute/issues/408#issuecomment-2067600299
I also added a dry air approximation, in case for whatever reason, the dew point is not present in the METAR.

The formulas described in https://aerotoolbox.com/density-altitude/ have been used. Note that on that website, there are errors in the formula for Herman Wobus approximation (odd polynomial coefficients lack minus signs).