### PR TITLE
add delta of density altitude

### DIFF
--- a/src/weather/METAR.cpp
+++ b/src/weather/METAR.cpp
@@ -314,7 +314,11 @@ QString Weather::METAR::derivedData(const Navigation::Aircraft& aircraft) const
     QStringList items;
     if (m_densityAltitude.isFinite())
     {
-        items += tr("Density Altitude: %1").arg(aircraft.verticalDistanceToString(m_densityAltitude));
+        Units::Distance const altitude = Units::Distance::fromM(m_location.altitude());
+        items += tr("Density Altitude: %1 (Δ %2)").arg(
+            aircraft.verticalDistanceToString(m_densityAltitude), 
+            aircraft.verticalDistanceToString(m_densityAltitude - altitude, /*forceSign=*/ true)
+            );
     }
     auto relativeHumidity = Navigation::Atmosphere::relativeHumidity(m_temperature, m_dewpoint);
     if (!std::isnan(relativeHumidity))


### PR DESCRIPTION
I would like to display the difference of the density altitude to the real altitiude in the UI. 
Since smaller airfields dont offer Metar data, as a pilot you can lookup the delta of the next major airport and apply it to the small airfield as an estimation.
What do you think?