### PR TITLE
Add another path hint for the Qt6 translations folder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -665,6 +665,7 @@ find_path(Qt6_TRANSLATION_DIR qtbase_de.qm
     HINTS
     ${Qt6Core_DIR}/../../../translations
     /usr/translations
+    /usr/share/qt6/translations
     REQUIRED
 )
 qt_add_resources(${PROJECT_NAME} translations_qt


### PR DESCRIPTION
Hi Stefan,

I am trying to build Enroute on Arch Linux, and encountering the same issue as in #329:
```bash
[...]
Currently working with git branch main
Currently working with git Commit 2b2201200
Currently working with git commit from 2025-05-24
-- QtWebView found.
CMake Error at src/CMakeLists.txt:664 (find_path):
  Could not find Qt6_TRANSLATION_DIR using the following files: qtbase_de.qm


-- Configuring incomplete, errors occurred!
```

I don't know how Qt is packaged on other systems, but on Arch Linux the `translations` folder resides in `/usr/share/qt6` (see the [file list](https://archlinux.org/packages/extra/any/qt6-translations/files/)).

I fixed this issue for me by adding another path hint for this folder.