### PR TITLE
Feature/282 export route as flight plan: add pointer check for clipboard

### DIFF
--- a/src/platform/PlatformAdaptor_Abstract.cpp
+++ b/src/platform/PlatformAdaptor_Abstract.cpp
@@ -49,13 +49,14 @@ QString Platform::PlatformAdaptor_Abstract::clipboardText()
 }
 
 
-void Platform::PlatformAdaptor_Abstract::setClipboardText(const QString& text)
+bool Platform::PlatformAdaptor_Abstract::setClipboardText(const QString& text)
 {
-    if (qGuiApp == nullptr)
+    if (qGuiApp && qGuiApp->clipboard())
     {
-        return;
+        qGuiApp->clipboard()->setText(text);
+        return true;
     }
-    qGuiApp->clipboard()->setText(text);
+    return false;
 }
 
 

--- a/src/platform/PlatformAdaptor_Abstract.cpp
+++ b/src/platform/PlatformAdaptor_Abstract.cpp
@@ -41,11 +41,11 @@ Platform::PlatformAdaptor_Abstract::PlatformAdaptor_Abstract(QObject *parent)
 
 QString Platform::PlatformAdaptor_Abstract::clipboardText()
 {
-    if (qGuiApp == nullptr)
+    if (qGuiApp && qGuiApp->clipboard())
     {
-        return {};
+        return qGuiApp->clipboard()->text();
     }
-    return qGuiApp->clipboard()->text();
+    return {};
 }
 
 

--- a/src/platform/PlatformAdaptor_Abstract.h
+++ b/src/platform/PlatformAdaptor_Abstract.h
@@ -85,8 +85,9 @@ public:
     /*! \brief Set text content to ClipBoard
      *
      *  @param text Text to set in the clipboard
+     *  @returns True if the text was set, false if the clipboard is not available
      */
-    Q_INVOKABLE static void setClipboardText(const QString& text);
+    Q_INVOKABLE static bool setClipboardText(const QString& text);
 
     /*! \brief SSID of current Wi-Fi network
      *

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -406,8 +406,12 @@ Page {
 
                         var flightPlanText = Navigator.flightRoute.toVfrFlightPlan()
                         if (flightPlanText !== "") {
-                            PlatformAdaptor.setClipboardText(flightPlanText)
-                            toast.doToast(qsTr("Flight plan copied to clipboard"))
+                            var success = PlatformAdaptor.setClipboardText(flightPlanText)
+                            if (success) {
+                                toast.doToast(qsTr("Flight plan copied to clipboard"))
+                            } else {
+                                toast.doToast(qsTr("Failed to copy flight plan"))
+                            }
                         } else {
                             toast.doToast(qsTr("No flight route to copy"))
                         }


### PR DESCRIPTION
Hi Stefan
For my previous PR #536 and considering issue #535, i would like to add a pointer check for the clipboard, 
and also for the previous getter function PlatformAdaptor_Abstract::clipboardText(). 

I do not own apple devices, but according to some analysis there seem to be restrictions, privacy setting or access rights on MacOS that restrict in some cases accessing the clipboard.