### PR TITLE
Run Github Actions Build on Pull Requests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Compile on Android
 on:
   push:
     branches: [ develop ]
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".gitignore"
       - "README.md"
       # ignore CI for other platforms
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/ios.yml"
       - ".github/workflows/linux.yml"
       - ".github/workflows/macos.yml"
+  pull_request:
+    branches: [ main, develop ]
+    paths-ignore: *paths-ignore
 
 jobs:
   build:
@@ -104,6 +107,7 @@ jobs:
           -DCMAKE_BUILD_TYPE:STRING=Debug
         cmake --build build-enroute
     - name: Upload to developerBuilds
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
       run: |
         gh release upload --clobber developerBuilds ../build-enroute/src/android-build//build/outputs/apk/debug/android-build-debug.apk
       env:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,7 +3,7 @@ name: Compile on iOS
 on:
   push:
     branches: [ develop ]
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".gitignore"
       - "README.md"
       # ignore CI for other platforms
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/api.yml"
       - ".github/workflows/linux.yml"
       - ".github/workflows/macos.yml"
+  pull_request:
+    branches: [ main, develop ]
+    paths-ignore: *paths-ignore
 
 jobs:
   build:
@@ -130,6 +133,7 @@ jobs:
         #brew install create-dmg
         #create-dmg enroute-iphonesimulator.dmg build-enroute/src/Debug-iphonesimulator
     - name: Upload to developerBuilds
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
       run: |
         echo "Skip uploading developer build because of size reasons..."
         #gh release upload --clobber developerBuilds ../enroute-iphonesimulator.dmg

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Compile on Linux
 on:
   push:
     branches: [ develop ]
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".gitignore"
       - "README.md"
       # ignore CI for other platforms
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/api.yml"
       - ".github/workflows/ios.yml"
       - ".github/workflows/macos.yml"
+  pull_request:
+    branches: [ main, develop ]
+    paths-ignore: *paths-ignore
 
 jobs:
   build:
@@ -79,6 +82,7 @@ jobs:
         linuxdeploy-x86_64.AppImage --appdir app --output appimage
         mv *-x86_64.AppImage enroute-Linux.AppImage
     - name: Upload to developerBuilds
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
       run: |
         gh release upload --clobber developerBuilds ../enroute-Linux.AppImage
       env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: Compile on MacOS
 on:
   push:
     branches: [ develop ]
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - ".gitignore"
       - "README.md"
       # ignore CI for other platforms
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/api.yml"
       - ".github/workflows/ios.yml"
       - ".github/workflows/linux.yml"
+  pull_request:
+    branches: [ main, develop ]
+    paths-ignore: *paths-ignore
 
 jobs:
   build:
@@ -96,6 +99,7 @@ jobs:
         /usr/bin/sudo $QT_ROOT_DIR/bin/macdeployqt enroute.app -dmg
         mv enroute.dmg enroute-macOS-universal.dmg
     - name: Upload to developerBuilds
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
       run: |
         gh release upload --clobber developerBuilds ../enroute-macOS-universal.dmg
       env:


### PR DESCRIPTION
I would like to enable Github Actions to run the build on Pull Requests. 
Then i would have noticed more early that the build failed on macos.
Of course we want to make sure that it does not upload apk files from the PR.
What do you think?