### PR TITLE
Library Export/Import

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SOURCES
     GlobalObject.h
     GlobalSettings.h
     Librarian.h
+    LibrarianExportImport.h
     Sensors.h
     navigation/Aircraft.h
     navigation/Atmosphere.h
@@ -165,6 +166,7 @@ set(SOURCES
     GlobalObject.cpp
     GlobalSettings.cpp
     Librarian.cpp
+    LibrarianExportImport.cpp
     Sensors.cpp
     main.cpp
     navigation/Aircraft.cpp

--- a/src/Librarian.cpp
+++ b/src/Librarian.cpp
@@ -21,10 +21,10 @@
 #include <QNetworkAccessManager>
 #include <QStandardPaths>
 #include <QSysInfo>
-#include <QtGlobal>
 
 #include "config.h"
 #include "Librarian.h"
+#include "LibrarianExportImport.h"
 #include "navigation/FlightRoute.h"
 
 using namespace Qt::Literals::StringLiterals;
@@ -513,6 +513,18 @@ void Librarian::remove(Librarian::Library library, const QString& baseName)
 void Librarian::rename(Librarian::Library library, const QString &oldName, const QString &newName) 
 {
     QFile::rename(fullPath(library, oldName), fullPath(library, newName));
+}
+
+
+auto Librarian::exportAndShareBackup() -> QString
+{
+    return LibrarianExportImport::exportAndShareBackup();
+}
+
+
+auto Librarian::importFullBackupFromFile(const QString& fileName) -> QString
+{
+    return LibrarianExportImport::importFullBackupFromFile(fileName);
 }
 
 

--- a/src/Librarian.h
+++ b/src/Librarian.h
@@ -217,6 +217,23 @@ public:
      */
     Q_INVOKABLE static void rename(Librarian::Library library, const QString& oldName, const QString& newName);
 
+    /*! \brief Export library backup and share/save it via FileExchange
+     *
+     * @returns Empty string on success, the string "abort" if the user
+     * cancelled, or a translated error/warning message otherwise
+     */
+    Q_INVOKABLE static QString exportAndShareBackup();
+
+    /*! \brief Import complete library backup from file
+     *
+     * This method imports a JSON backup file and restores aircraft, routes, and waypoints
+     *
+     * @param fileName Path to the backup file
+     *
+     * @returns Empty string on success, translated error message on failure
+     */
+    Q_INVOKABLE static QString importFullBackupFromFile(const QString& fileName);
+
     /*! \brief Filters a QStringList in a fuzzy way
      *
      * This helper method filters a QStringList. It returns a sublist of those

--- a/src/LibrarianExportImport.cpp
+++ b/src/LibrarianExportImport.cpp
@@ -1,0 +1,697 @@
+/***************************************************************************
+ *   Copyright (C) 2020-2026 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QDateTime>
+#include <QDir>
+
+#include "GlobalObject.h"
+#include "Librarian.h"
+#include "LibrarianExportImport.h"
+#include "dataManagement/DataManager.h"
+#include "fileFormats/DataFileAbstract.h"
+#include "geomaps/Waypoint.h"
+#include "geomaps/WaypointLibrary.h"
+#include "navigation/Aircraft.h"
+#include "navigation/FlightRoute.h"
+#include "platform/FileExchange.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+
+// ————————————————————————————————————————————————
+//  Unit string conversion helpers
+// ————————————————————————————————————————————————
+
+static QString fuelConsumptionUnitToString(int unit)
+{
+    switch (unit) {
+    case 0:  return QStringLiteral("l/h");
+    case 1:  return QStringLiteral("gal/h");
+    default: return QStringLiteral("l/h");
+    }
+}
+
+static int fuelConsumptionUnitFromString(const QJsonValue& value)
+{
+    if (value.toString() == u"gal/h") { return 1; }
+    return 0; // default: l/h
+}
+
+static QString horizontalDistanceUnitToString(int unit)
+{
+    switch (unit) {
+    case 0:  return QStringLiteral("NM");
+    case 1:  return QStringLiteral("km");
+    case 2:  return QStringLiteral("mi");
+    default: return QStringLiteral("NM");
+    }
+}
+
+static int horizontalDistanceUnitFromString(const QJsonValue& value)
+{
+    auto str = value.toString();
+    if (str == u"km") { return 1; }
+    if (str == u"mi") { return 2; }
+    return 0; // default: NM
+}
+
+static QString verticalDistanceUnitToString(int unit)
+{
+    switch (unit) {
+    case 0:  return QStringLiteral("ft");
+    case 1:  return QStringLiteral("m");
+    default: return QStringLiteral("ft");
+    }
+}
+
+static int verticalDistanceUnitFromString(const QJsonValue& value)
+{
+    if (value.toString() == u"m") { return 1; }
+    return 0; // default: ft
+}
+
+
+// ————————————————————————————————————————————————
+//  Waypoint construction helper
+// ————————————————————————————————————————————————
+
+// Build a Waypoint from backup-format fields using only the Waypoint
+// public API.  No knowledge of the internal GeoJSON property keys is
+// needed here.
+static GeoMaps::Waypoint waypointFromBackup(double lon, double lat,
+                                            double elevation,
+                                            const QString& code,
+                                            const QString& name,
+                                            const QString& notes)
+{
+    QGeoCoordinate coord(lat, lon);
+    if (!std::isnan(elevation))
+    {
+        coord.setAltitude(elevation);
+    }
+
+    // Use the public (coordinate, name) constructor.
+    // When an ICAO code is present, it doubles as the display name.
+    GeoMaps::Waypoint wp(coord, code.isEmpty() ? (name.isEmpty() ? QStringLiteral("Waypoint") : name) : code);
+
+    if (!code.isEmpty())
+    {
+        wp.setICAOCode(code);
+    }
+    if (!notes.isEmpty())
+    {
+        wp.setNotes(notes);
+    }
+
+    return wp;
+}
+
+
+// ————————————————————————————————————————————————
+//  Export helpers
+// ————————————————————————————————————————————————
+
+auto LibrarianExportImport::createAircraftJsonArray(QStringList& errors) -> QJsonArray
+{
+    QJsonArray aircraftArray;
+
+    QDir const dir(Librarian::directory(Librarian::Aircraft));
+    auto fileList = dir.entryInfoList(QDir::Files);
+    int failed = 0;
+
+    for (const QFileInfo& fileInfo : fileList)
+    {
+        Navigation::Aircraft aircraft;
+        auto errorMsg = aircraft.loadFromJSON(fileInfo.absoluteFilePath());
+        if (!errorMsg.isEmpty())
+        {
+            failed++;
+            continue;
+        }
+
+        QJsonObject obj;
+        obj.insert(QStringLiteral("name"), aircraft.name());
+        obj.insert(QStringLiteral("cabinPressureEqualsStaticPressure"), aircraft.cabinPressureEqualsStaticPressure());
+        obj.insert(QStringLiteral("cruiseSpeed_mps"), aircraft.cruiseSpeed().toMPS());
+        obj.insert(QStringLiteral("descentSpeed_mps"), aircraft.descentSpeed().toMPS());
+        obj.insert(QStringLiteral("fuelConsumption_lph"), aircraft.fuelConsumption().toLPH());
+        obj.insert(QStringLiteral("fuelConsumptionUnit"), fuelConsumptionUnitToString(aircraft.fuelConsumptionUnit()));
+        obj.insert(QStringLiteral("horizontalDistanceUnit"), horizontalDistanceUnitToString(aircraft.horizontalDistanceUnit()));
+        obj.insert(QStringLiteral("minimumSpeed_mps"), aircraft.minimumSpeed().toMPS());
+        obj.insert(QStringLiteral("transponderCode"), aircraft.transponderCode());
+        obj.insert(QStringLiteral("verticalDistanceUnit"), verticalDistanceUnitToString(aircraft.verticalDistanceUnit()));
+
+        aircraftArray.append(obj);
+    }
+
+    if (failed > 0)
+    {
+        errors += tr("%1 of %2 aircraft could not be exported.").arg(failed).arg(fileList.count());
+    }
+
+    return aircraftArray;
+}
+
+
+auto LibrarianExportImport::createRoutesJsonArray(QStringList& errors) -> QJsonArray
+{
+    QJsonArray routeArray;
+
+    QDir const dir(Librarian::directory(Librarian::Routes));
+    auto fileList = dir.entryInfoList(QDir::Files);
+    int failed = 0;
+
+    for (const QFileInfo& fileInfo : fileList)
+    {
+        // Load the route via FlightRoute to get the parsed waypoints
+        Navigation::FlightRoute route;
+        auto errorMsg = route.load(fileInfo.absoluteFilePath());
+        if (!errorMsg.isEmpty())
+        {
+            failed++;
+            continue;
+        }
+
+        QJsonObject routeObj;
+        routeObj.insert(QStringLiteral("name"), fileInfo.baseName());
+
+        QJsonArray waypointsArray;
+        for (const auto& waypoint : route.waypoints())
+        {
+            QJsonObject wpObj;
+
+            auto code = waypoint.ICAOCode();
+            if (!code.isEmpty())
+            {
+                wpObj.insert(QStringLiteral("code"), code);
+            }
+            else
+            {
+                auto name = waypoint.name();
+                if (!name.isEmpty())
+                {
+                    wpObj.insert(QStringLiteral("name"), name);
+                }
+            }
+
+            auto coord = waypoint.coordinate();
+            if (coord.isValid())
+            {
+                wpObj.insert(QStringLiteral("longitude"), coord.longitude());
+                wpObj.insert(QStringLiteral("latitude"), coord.latitude());
+            }
+
+            if (!std::isnan(coord.altitude()))
+            {
+                wpObj.insert(QStringLiteral("elevation"), coord.altitude());
+            }
+
+            waypointsArray.append(wpObj);
+        }
+
+        routeObj.insert(QStringLiteral("waypoints"), waypointsArray);
+        routeArray.append(routeObj);
+    }
+
+    if (failed > 0)
+    {
+        errors += tr("%1 of %2 routes could not be exported.").arg(failed).arg(fileList.count());
+    }
+
+    return routeArray;
+}
+
+
+auto LibrarianExportImport::createWaypointsJsonArray(QStringList& errors) -> QJsonArray
+{
+    QJsonArray waypointArray;
+
+    auto waypointLibrary = GlobalObject::waypointLibrary();
+    auto waypoints = waypointLibrary->waypoints();
+    int failed = 0;
+
+    for (const auto& waypoint : waypoints)
+    {
+        if (!waypoint.isValid())
+        {
+            failed++;
+            continue;
+        }
+
+        QJsonObject wpObj;
+
+        auto name = waypoint.name();
+        if (!name.isEmpty())
+        {
+            wpObj.insert(QStringLiteral("name"), name);
+        }
+
+        auto notes = waypoint.notes();
+        if (!notes.isEmpty())
+        {
+            wpObj.insert(QStringLiteral("notes"), notes);
+        }
+
+        auto coord = waypoint.coordinate();
+        if (coord.isValid())
+        {
+            wpObj.insert(QStringLiteral("longitude"), coord.longitude());
+            wpObj.insert(QStringLiteral("latitude"), coord.latitude());
+        }
+
+        if (!std::isnan(coord.altitude()))
+        {
+            wpObj.insert(QStringLiteral("elevation"), coord.altitude());
+        }
+
+        waypointArray.append(wpObj);
+    }
+
+    if (failed > 0)
+    {
+        errors += tr("%1 of %2 waypoints could not be exported.").arg(failed).arg(waypoints.count());
+    }
+
+    return waypointArray;
+}
+
+
+auto LibrarianExportImport::createMapsJsonArray() -> QJsonArray
+{
+    QJsonArray mapArray;
+
+    auto* dataManager = GlobalObject::dataManager();
+    if (dataManager == nullptr)
+    {
+        return mapArray;
+    }
+
+    auto* allItems = dataManager->items();
+    if (allItems == nullptr)
+    {
+        return mapArray;
+    }
+
+    // Collect installed types per map name, preserving insertion order
+    QStringList orderedNames;
+    QHash<QString, QStringList> typesByName;
+
+    for (auto* item : allItems->downloadables())
+    {
+        if (item == nullptr || !item->hasFile())
+        {
+            continue;
+        }
+
+        auto name = item->objectName();
+        QString typeStr;
+
+        switch (item->contentType())
+        {
+        case DataManagement::Downloadable_Abstract::AviationMap:
+            typeStr = u"aviation"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::BaseMapVector:
+            typeStr = u"base-vector"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::BaseMapRaster:
+            typeStr = u"base-raster"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::TerrainMap:
+            typeStr = u"terrain"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::Data:
+            typeStr = u"data"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::MapSet:
+            typeStr = u"mapset"_s;
+            break;
+        default:
+            continue;
+        }
+
+        if (!typesByName.contains(name))
+        {
+            orderedNames.append(name);
+        }
+        typesByName[name].append(typeStr);
+    }
+
+    for (const auto& name : orderedNames)
+    {
+        QJsonObject mapObj;
+        mapObj.insert(QStringLiteral("name"), name);
+
+        QJsonArray typesArray;
+        for (const auto& t : typesByName[name])
+        {
+            typesArray.append(t);
+        }
+        mapObj.insert(QStringLiteral("types"), typesArray);
+
+        mapArray.append(mapObj);
+    }
+
+    return mapArray;
+}
+
+
+// ————————————————————————————————————————————————
+//  Export
+// ————————————————————————————————————————————————
+
+auto LibrarianExportImport::exportAndShareBackup() -> QString
+{
+    QStringList errors;
+
+    // Create the combined backup object
+    QJsonObject rootObj;
+    rootObj.insert(QStringLiteral("content"), QStringLiteral("enroute-backup"));
+    rootObj.insert(QStringLiteral("version"), backupFormatVersion);
+    rootObj.insert(QStringLiteral("timestamp"), QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+    rootObj.insert(QStringLiteral("aircraft"), createAircraftJsonArray(errors));
+    rootObj.insert(QStringLiteral("routes"), createRoutesJsonArray(errors));
+    rootObj.insert(QStringLiteral("waypoints"), createWaypointsJsonArray(errors));
+    rootObj.insert(QStringLiteral("maps"), createMapsJsonArray());
+
+    QJsonDocument doc;
+    doc.setObject(rootObj);
+    const QByteArray backupData = doc.toJson();
+
+    // Build a date-stamped file name
+    const QString fileName = u"EnrouteBackup-"_s
+        + QDateTime::currentDateTimeUtc().date().toString(Qt::ISODate);
+
+    // Share / save via FileExchange
+    auto* fileExchange = GlobalObject::fileExchange();
+    if (fileExchange == nullptr)
+    {
+        return tr("Cannot export backup. File exchange not available.");
+    }
+    const QString shareError = fileExchange->shareContent(
+        backupData, u"application/json"_s, u"json"_s, fileName);
+
+    // Return abort immediately so the QML can distinguish it
+    if (shareError == u"abort"_s)
+    {
+        return shareError;
+    }
+
+    // Combine export warnings and share errors into one result
+    if (!shareError.isEmpty())
+    {
+        errors += shareError;
+    }
+    return errors.join(u"<br>"_s);
+}
+
+
+// ————————————————————————————————————————————————
+//  Import
+// ————————————————————————————————————————————————
+
+auto LibrarianExportImport::importFullBackup(const QByteArray& content) -> QString
+{
+    // Parse the backup file
+    QJsonParseError parseError{};
+    auto document = QJsonDocument::fromJson(content, &parseError);
+
+    if (parseError.error != QJsonParseError::NoError)
+    {
+        return tr("Cannot read backup file. Error: %1").arg(parseError.errorString());
+    }
+
+    if (!document.isObject())
+    {
+        return tr("Cannot read backup file. Error: Document is not a JSON object.");
+    }
+
+    auto rootObj = document.object();
+
+    // Verify it's a backup file
+    if (rootObj.value(QStringLiteral("content")).toString() != u"enroute-backup")
+    {
+        return tr("Cannot read backup file. Error: File is not an Enroute backup.");
+    }
+
+    // Check backup format version
+    auto fileVersion = rootObj.value(QStringLiteral("version")).toInt(0);
+    if (fileVersion < 1)
+    {
+        return tr("Cannot read backup file. Error: No valid version number found.");
+    }
+    if (fileVersion > backupFormatVersion)
+    {
+        return tr("Cannot read backup file. The file was created by a newer version of Enroute Flight Navigation. Please update the app.");
+    }
+
+    QStringList errors;
+
+    // Import aircraft (skip section gracefully if missing)
+    int aircraftFailed = 0;
+    auto aircraftArray = rootObj.value(QStringLiteral("aircraft")).toArray();
+    for (const auto& aircraftValue : aircraftArray)
+    {
+        if (!aircraftValue.isObject())
+        {
+            aircraftFailed++;
+            continue;
+        }
+
+        auto aircraftObj = aircraftValue.toObject();
+
+        // Build aircraft from backup fields using only the public API
+        Navigation::Aircraft aircraft;
+        aircraft.setName(aircraftObj.value(QStringLiteral("name")).toString());
+        aircraft.setCabinPressureEqualsStaticPressure(aircraftObj.value(QStringLiteral("cabinPressureEqualsStaticPressure")).toBool(false));
+        aircraft.setCruiseSpeed(Units::Speed::fromMPS(aircraftObj.value(QStringLiteral("cruiseSpeed_mps")).toDouble(NAN)));
+        aircraft.setDescentSpeed(Units::Speed::fromMPS(aircraftObj.value(QStringLiteral("descentSpeed_mps")).toDouble(NAN)));
+        aircraft.setFuelConsumption(Units::VolumeFlow::fromLPH(aircraftObj.value(QStringLiteral("fuelConsumption_lph")).toDouble(NAN)));
+        aircraft.setFuelConsumptionUnit(static_cast<Navigation::Aircraft::FuelConsumptionUnit>(fuelConsumptionUnitFromString(aircraftObj.value(QStringLiteral("fuelConsumptionUnit")))));
+        aircraft.setHorizontalDistanceUnit(static_cast<Navigation::Aircraft::HorizontalDistanceUnit>(horizontalDistanceUnitFromString(aircraftObj.value(QStringLiteral("horizontalDistanceUnit")))));
+        aircraft.setMinimumSpeed(Units::Speed::fromMPS(aircraftObj.value(QStringLiteral("minimumSpeed_mps")).toDouble(NAN)));
+        aircraft.setTransponderCode(aircraftObj.value(QStringLiteral("transponderCode")).toString());
+        aircraft.setVerticalDistanceUnit(static_cast<Navigation::Aircraft::VerticalDistanceUnit>(verticalDistanceUnitFromString(aircraftObj.value(QStringLiteral("verticalDistanceUnit")))));
+
+        // Skip exact duplicates
+        if (Librarian::contains(aircraft))
+        {
+            continue;
+        }
+
+        // Get aircraft name for filename
+        QString aircraftName = aircraft.name();
+        if (aircraftName.isEmpty())
+        {
+            aircraftName = u"Imported Aircraft"_s;
+        }
+
+        // Save with unique name
+        auto savePath = Librarian::fullPath(Librarian::Aircraft, aircraftName);
+        if (QFile::exists(savePath))
+        {
+            for(int i=1; ; i++)
+            {
+                auto newName = u"%1 (%2)"_s.arg(aircraftName).arg(i);
+                savePath = Librarian::fullPath(Librarian::Aircraft, newName);
+                if (!QFile::exists(savePath))
+                {
+                    break;
+                }
+            }
+        }
+
+        auto errorMsg = aircraft.save(savePath);
+        if (!errorMsg.isEmpty())
+        {
+            aircraftFailed++;
+            continue;
+        }
+    }
+    if (aircraftFailed > 0)
+    {
+        errors += tr("%1 of %2 aircraft could not be imported.").arg(aircraftFailed).arg(aircraftArray.count());
+    }
+
+    // Import routes (skip section gracefully if missing)
+    int routesFailed = 0;
+    auto routesArray = rootObj.value(QStringLiteral("routes")).toArray();
+    for (const auto& routeValue : routesArray)
+    {
+        if (!routeValue.isObject())
+        {
+            routesFailed++;
+            continue;
+        }
+
+        auto routeObj = routeValue.toObject();
+
+        // Extract route name
+        QString routeName = routeObj.value(QStringLiteral("name")).toString();
+        if (routeName.isEmpty())
+        {
+            routeName = u"Imported Route"_s;
+        }
+
+        Navigation::FlightRoute route;
+
+        // Parse waypoints array
+        auto waypointsArray = routeObj.value(QStringLiteral("waypoints")).toArray();
+        if (waypointsArray.isEmpty())
+        {
+            routesFailed++;
+            continue;
+        }
+
+        for (const auto& wpValue : waypointsArray)
+        {
+            if (!wpValue.isObject())
+            {
+                continue;
+            }
+            auto wpObj = wpValue.toObject();
+
+            const double lon = wpObj.value(QStringLiteral("longitude")).toDouble(qQNaN());
+            const double lat = wpObj.value(QStringLiteral("latitude")).toDouble(qQNaN());
+            if (std::isnan(lon) || std::isnan(lat))
+            {
+                continue;
+            }
+
+            auto waypoint = waypointFromBackup(
+                lon, lat,
+                wpObj.value(QStringLiteral("elevation")).toDouble(qQNaN()),
+                wpObj.value(QStringLiteral("code")).toString(),
+                wpObj.value(QStringLiteral("name")).toString(),
+                {});
+
+            if (waypoint.isValid())
+            {
+                route.append(waypoint);
+            }
+        }
+
+        // Skip exact duplicates
+        if (Librarian::contains(&route))
+        {
+            continue;
+        }
+
+        // Save with unique name
+        auto savePath = Librarian::fullPath(Librarian::Routes, routeName);
+        if (QFile::exists(savePath))
+        {
+            for(int i=1; ; i++)
+            {
+                auto newName = u"%1 (%2)"_s.arg(routeName).arg(i);
+                savePath = Librarian::fullPath(Librarian::Routes, newName);
+                if (!QFile::exists(savePath))
+                {
+                    break;
+                }
+            }
+        }
+
+        auto saveError = route.save(savePath);
+        if (!saveError.isEmpty())
+        {
+            routesFailed++;
+            continue;
+        }
+    }
+    if (routesFailed > 0)
+    {
+        errors += tr("%1 of %2 routes could not be imported.").arg(routesFailed).arg(routesArray.count());
+    }
+
+    // Import waypoints (skip section gracefully if missing)
+    int waypointsFailed = 0;
+    auto waypointsArray = rootObj.value(QStringLiteral("waypoints")).toArray();
+    if (!waypointsArray.isEmpty())
+    {
+        auto waypointLibrary = GlobalObject::waypointLibrary();
+        for (const auto& waypointValue : waypointsArray)
+        {
+            if (!waypointValue.isObject())
+            {
+                waypointsFailed++;
+                continue;
+            }
+
+            auto wpObj = waypointValue.toObject();
+
+            const double lon = wpObj.value(QStringLiteral("longitude")).toDouble(qQNaN());
+            const double lat = wpObj.value(QStringLiteral("latitude")).toDouble(qQNaN());
+            if (std::isnan(lon) || std::isnan(lat))
+            {
+                waypointsFailed++;
+                continue;
+            }
+
+            auto waypoint = waypointFromBackup(
+                lon, lat,
+                wpObj.value(QStringLiteral("elevation")).toDouble(qQNaN()),
+                {},
+                wpObj.value(QStringLiteral("name")).toString(),
+                wpObj.value(QStringLiteral("notes")).toString());
+
+            if (!waypoint.isValid())
+            {
+                waypointsFailed++;
+                continue;
+            }
+
+            if (!waypointLibrary->contains(waypoint))
+            {
+                waypointLibrary->add(waypoint);
+            }
+        }
+    }
+    if (waypointsFailed > 0)
+    {
+        errors += tr("%1 of %2 waypoints could not be imported.").arg(waypointsFailed).arg(waypointsArray.count());
+    }
+
+    if (!errors.isEmpty())
+    {
+        return errors.join(u"<br>"_s);
+    }
+    return {}; // Success
+}
+
+
+auto LibrarianExportImport::importFullBackupFromFile(const QString& fileName) -> QString
+{
+    auto file = FileFormats::DataFileAbstract::openFileURL(fileName);
+    if (!file->open(QIODevice::ReadOnly))
+    {
+        return tr("Cannot open backup file.");
+    }
+
+    auto content = file->readAll();
+    file->close();
+
+    return importFullBackup(content);
+}

--- a/src/LibrarianExportImport.h
+++ b/src/LibrarianExportImport.h
@@ -1,0 +1,85 @@
+/***************************************************************************
+ *   Copyright (C) 2020-2026 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QJsonArray>
+#include <QObject>
+
+
+/*! \brief Backup export and import for the library
+ *
+ *  This class handles serialization and deserialization of library data
+ *  (aircraft, routes, waypoints, maps) for the backup feature.
+ *
+ *  The backup format is intentionally decoupled from internal data structures.
+ *  All sections use a clean, human-readable JSON format with explicit field
+ *  names.  Domain classes are accessed exclusively through their public APIs;
+ *  no knowledge of internal file formats is required here.
+ */
+
+class LibrarianExportImport : public QObject {
+    Q_OBJECT
+
+public:
+    /*! \brief Export library backup and share/save it via FileExchange
+     *
+     *  Creates a JSON backup of all aircraft, routes, waypoints, and a list
+     *  of installed maps, then hands it to FileExchange for sharing or
+     *  saving.
+     *
+     *  @returns Empty string on success, the string "abort" if the user
+     *  cancelled, or a translated error message otherwise
+     */
+    static QString exportAndShareBackup();
+
+    /*! \brief Import complete library backup from raw data
+     *
+     *  Parses a JSON backup and restores aircraft, routes, and waypoints.
+     *  The maps section is informational and is not imported.
+     *
+     *  @param content QByteArray containing the backup JSON data
+     *
+     *  @returns Empty string on success, translated error message on failure
+     */
+    static QString importFullBackup(const QByteArray& content);
+
+    /*! \brief Import complete library backup from a file
+     *
+     *  Convenience wrapper that opens a file and calls importFullBackup().
+     *
+     *  @param fileName Path or URL to the backup file
+     *
+     *  @returns Empty string on success, translated error message on failure
+     */
+    static QString importFullBackupFromFile(const QString& fileName);
+
+private:
+    Q_DISABLE_COPY_MOVE(LibrarianExportImport)
+
+    // Helpers that build the individual JSON arrays for the backup
+    static QJsonArray createAircraftJsonArray(QStringList& errors);
+    static QJsonArray createRoutesJsonArray(QStringList& errors);
+    static QJsonArray createWaypointsJsonArray(QStringList& errors);
+    static QJsonArray createMapsJsonArray();
+
+    //! Backup format version.  Increment only for breaking changes.
+    static constexpr int backupFormatVersion = 1;
+};

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -290,6 +290,15 @@ public:
         m_coordinate = newCoordinate;
     }
 
+    /*! \brief Set ICAO code
+     *
+     *  @param newICAOCode New ICAO code of the waypoint
+     */
+    void setICAOCode(const QString &newICAOCode)
+    {
+        m_properties.insert(QStringLiteral("COD"), newICAOCode);
+    }
+
     /*! \brief Set name
      *
      *  @param newName New name of the waypoint

--- a/src/platform/FileExchange_Abstract.cpp
+++ b/src/platform/FileExchange_Abstract.cpp
@@ -100,6 +100,31 @@ void Platform::FileExchange_Abstract::processFileOpenRequest(const QString& path
      * Check for various possible file formats/contents
      */
 
+    // Check for Enroute backup file first (try parsing as JSON)
+    // This needs to be early because backup files might not have proper MIME type on Android
+    if (!file->open(QIODevice::ReadOnly))
+    {
+        // Cannot open file, will try other methods below
+    }
+    else
+    {
+        QJsonParseError parseError{};
+        auto fileData = file->readAll();
+        auto document = QJsonDocument::fromJson(fileData, &parseError);
+        file->close();
+
+        if (parseError.error == QJsonParseError::NoError && document.isObject())
+        {
+            auto rootObj = document.object();
+            if (rootObj.value(QStringLiteral("content")).toString() == u"enroute-backup")
+            {
+                // It's a backup file - emit signal to handle import
+                emit openFileRequest(path, {}, Backup);
+                return;
+            }
+        }
+    }
+
     // Flight Route in GPX format
     if ((mimeType.inherits(QStringLiteral("application/xml"))) || (mimeType.name() == u"application/x-gpx+xml"))
     {

--- a/src/platform/FileExchange_Abstract.h
+++ b/src/platform/FileExchange_Abstract.h
@@ -56,7 +56,8 @@ public:
         OpenAir, /*< Airspace data in openAir format */
         Image, /*< Image without georeferencing information */
         TripKit, /*< Trip Kit */
-        ZipFile /*< Zip File */
+        ZipFile, /*< Zip File */
+        Backup /*< Enroute full backup file */
       };
     Q_ENUM(FileFunction)
 
@@ -164,7 +165,7 @@ public slots:
      *
      * Overloaded function for convenience
      *
-     * @param path QByteArray containing an UTF8-Encoded strong
+     * @param path File path or URL as a string
      */
     void processFileOpenRequest(const QString& path);
 

--- a/src/platform/FileExchange_Linux.cpp
+++ b/src/platform/FileExchange_Linux.cpp
@@ -49,14 +49,20 @@ void Platform::FileExchange::importContent()
 }
 
 
-QString Platform::FileExchange::shareContent(const QByteArray& content, const QString& /*mimeType*/, const QString& /*fileNameSuffix*/, const QString& fileNameTemplate)
+QString Platform::FileExchange::shareContent(const QByteArray& content, const QString& mimeType, const QString& fileNameSuffix, const QString& fileNameTemplate)
 {
     QMimeDatabase const mimeDataBase;
-    QMimeType const mime = mimeDataBase.mimeTypeForData(content);
+    QMimeType mime = mimeDataBase.mimeTypeForName(mimeType);
+    if (!mime.isValid())
+    {
+        mime = mimeDataBase.mimeTypeForData(content);
+    }
+
+    const QString suffix = fileNameSuffix.isEmpty() ? mime.preferredSuffix() : fileNameSuffix;
     auto fileNameX = QFileDialog::getSaveFileName(nullptr,
                                                   tr("Export Data"),
-                                                  QDir::homePath() + u"/"_s + fileNameTemplate + u"."_s + mime.preferredSuffix(),
-                                                  tr("%1 (*.%2);;All files (*)").arg(mime.comment(), mime.preferredSuffix()));
+                                                  QDir::homePath() + u"/"_s + fileNameTemplate + u"."_s + suffix,
+                                                  tr("%1 (*.%2);;All files (*)").arg(mime.comment(), suffix));
     if (fileNameX.isEmpty())
     {
         return QStringLiteral("abort");

--- a/src/qml/items/ImportManager.qml
+++ b/src/qml/items/ImportManager.qml
@@ -100,6 +100,16 @@ Item {
                 errorDialog.open()
                 return
             }
+            if (fileFunction === FileExchange.Backup) {
+                var errorString = Librarian.importFullBackupFromFile(importManager.filePath)
+                if (errorString !== "") {
+                    errLbl.text = errorString
+                    errorDialog.open()
+                    return
+                }
+                toast.doToast(qsTr("Backup imported successfully"))
+                return
+            }
 
             errLbl.text = qsTr("The file type of the file <strong>%1</strong> cannot be recognized.").arg(fileName)
             errorDialog.open()
@@ -559,4 +569,5 @@ Item {
 
         }
     }
+
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -21,6 +21,7 @@
 import QtCore
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import akaflieg_freiburg.enroute
@@ -283,6 +284,93 @@ AppWindow {
                                 stackView.push("pages/WaypointLibraryPage.qml")
                                 libraryMenu.close()
                                 drawer.close()
+                            }
+                        }
+
+                        MenuSeparator { }
+
+                        ItemDelegate {
+                            text: qsTr("Backup & Restore")
+                            icon.source: "/icons/material/ic_cached.svg"
+                            Layout.fillWidth: true
+
+                            onClicked: {
+                                PlatformAdaptor.vibrateBrief()
+                                backupMenu.open()
+                            }
+
+                            AutoSizingMenu {
+                                id: backupMenu
+
+                                MenuItem {
+                                    text: Qt.platform.os === "android" ? qsTr("Share Full Backup…") : qsTr("Export Full Backup…")
+
+                                    onTriggered: {
+                                        PlatformAdaptor.vibrateBrief()
+                                        highlighted = false
+                                        var errorString = Librarian.exportAndShareBackup()
+                                        if (errorString === "abort") {
+                                            toast.doToast(qsTr("Aborted"))
+                                            return
+                                        }
+                                        if (errorString !== "") {
+                                            backupErrorDialog.text = errorString
+                                            backupErrorDialog.open()
+                                            return
+                                        }
+                                        if (Qt.platform.os === "android" || Qt.platform.os === "ios")
+                                            toast.doToast(qsTr("Backup shared"))
+                                        else
+                                            toast.doToast(qsTr("Backup exported"))
+                                        backupMenu.close()
+                                        libraryMenu.close()
+                                        drawer.close()
+                                    }
+                                }
+
+                                MenuItem {
+                                    text: qsTr("Import Full Backup…")
+
+                                    onTriggered: {
+                                        PlatformAdaptor.vibrateBrief()
+                                        highlighted = false
+                                        if (Qt.platform.os === "ios") {
+                                            Global.dialogLoader.active = false
+                                            Global.dialogLoader.setSource("dialogs/LongTextDialog.qml", {
+                                                                              title: qsTr("Import backup"),
+                                                                              text: qsTr("Locate your backup file in the browser, then select 'Open with' from the share menu, and choose Enroute"),
+                                                                              standardButtons: Dialog.Ok})
+                                            Global.dialogLoader.active = true
+                                        } else if (Qt.platform.os === "android") {
+                                            FileExchange.openFilePicker("")
+                                        } else {
+                                            backupImportDialog.open()
+                                        }
+                                        backupMenu.close()
+                                        libraryMenu.close()
+                                        drawer.close()
+                                    }
+
+                                    FileDialog {
+                                        id: backupImportDialog
+
+                                        acceptLabel: qsTr("Import")
+                                        rejectLabel: qsTr("Cancel")
+
+                                        fileMode: FileDialog.OpenFile
+
+                                        nameFilters: Qt.platform.os === "android" ? undefined : [qsTr("Backup Files (*.json)")]
+
+                                        onAccepted: {
+                                            PlatformAdaptor.vibrateBrief()
+                                            var selectedFile = backupImportDialog.selectedFile.toString()
+                                            Qt.callLater(FileExchange.processFileOpenRequest, selectedFile)
+                                        }
+                                        onRejected: {
+                                            PlatformAdaptor.vibrateBrief()
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -878,6 +966,13 @@ AppWindow {
         stackView: stackView
         toast: toast
         view: view
+    }
+
+    LongTextDialog {
+        id: backupErrorDialog
+
+        title: qsTr("Error with Backup")
+        standardButtons: Dialog.Ok
     }
 
     LongTextDialog {


### PR DESCRIPTION
Ich hab einen Library Export / Import implementiert, siehe #519. 

<img width="148" height="281" alt="LibraryExport" src="https://github.com/user-attachments/assets/2d479a1a-ac46-481b-bedf-11db8439ab5d" />

Es wird in eine JSON Datei exportiert, hier eine Beispiel Datei: 
[EnrouteBackup-2026-04-11.json](https://github.com/user-attachments/files/26648227/EnrouteBackup-2026-04-11.json)
Das Dateiformat ist komplett entkoppelt von den internen Datenformaten. 

Beim Import werden genaue Duplikate vermieden, wenn man also einfach seine Library exportiert und dann wieder importiert schaut es so aus als ob nichts passiert, ändert man aber zwischendurch einen Wert, wird es als weiteres Item in die Library importiert. 

Die Liste der installierten Landkarten wird auch in die JSON Datei geschrieben, aktuell aber nicht wieder importiert, sondern nur:
* Aircraft
* Routes
* Waypoints

Getestet auf Linux und Android. 
