### PR TITLE
Library Export/Import using existing backwards-compatible serialization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SOURCES
     GlobalObject.h
     GlobalSettings.h
     Librarian.h
+    LibrarianExportImport.h
     Sensors.h
     navigation/Aircraft.h
     navigation/Atmosphere.h
@@ -165,6 +166,7 @@ set(SOURCES
     GlobalObject.cpp
     GlobalSettings.cpp
     Librarian.cpp
+    LibrarianExportImport.cpp
     Sensors.cpp
     main.cpp
     navigation/Aircraft.cpp

--- a/src/Librarian.cpp
+++ b/src/Librarian.cpp
@@ -21,10 +21,10 @@
 #include <QNetworkAccessManager>
 #include <QStandardPaths>
 #include <QSysInfo>
-#include <QtGlobal>
 
 #include "config.h"
 #include "Librarian.h"
+#include "LibrarianExportImport.h"
 #include "navigation/FlightRoute.h"
 
 using namespace Qt::Literals::StringLiterals;
@@ -513,6 +513,18 @@ void Librarian::remove(Librarian::Library library, const QString& baseName)
 void Librarian::rename(Librarian::Library library, const QString &oldName, const QString &newName) 
 {
     QFile::rename(fullPath(library, oldName), fullPath(library, newName));
+}
+
+
+auto Librarian::exportAndShareBackup() -> QString
+{
+    return LibrarianExportImport::exportAndShareBackup();
+}
+
+
+auto Librarian::importFullBackupFromFile(const QString& fileName) -> QString
+{
+    return LibrarianExportImport::importFullBackupFromFile(fileName);
 }
 
 

--- a/src/Librarian.h
+++ b/src/Librarian.h
@@ -217,6 +217,23 @@ public:
      */
     Q_INVOKABLE static void rename(Librarian::Library library, const QString& oldName, const QString& newName);
 
+    /*! \brief Export library backup and share/save it via FileExchange
+     *
+     * @returns Empty string on success, the string "abort" if the user
+     * cancelled, or a translated error/warning message otherwise
+     */
+    Q_INVOKABLE static QString exportAndShareBackup();
+
+    /*! \brief Import complete library backup from file
+     *
+     * This method imports a JSON backup file and restores aircraft, routes, and waypoints
+     *
+     * @param fileName Path to the backup file
+     *
+     * @returns Empty string on success, translated error message on failure
+     */
+    Q_INVOKABLE static QString importFullBackupFromFile(const QString& fileName);
+
     /*! \brief Filters a QStringList in a fuzzy way
      *
      * This helper method filters a QStringList. It returns a sublist of those

--- a/src/LibrarianExportImport.cpp
+++ b/src/LibrarianExportImport.cpp
@@ -1,0 +1,512 @@
+/***************************************************************************
+ *   Copyright (C) 2020-2026 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+
+#include "GlobalObject.h"
+#include "Librarian.h"
+#include "LibrarianExportImport.h"
+#include "dataManagement/DataManager.h"
+#include "fileFormats/DataFileAbstract.h"
+#include "geomaps/Waypoint.h"
+#include "geomaps/WaypointLibrary.h"
+#include "navigation/Aircraft.h"
+#include "navigation/FlightRoute.h"
+#include "platform/FileExchange.h"
+
+using namespace Qt::Literals::StringLiterals;
+
+
+// ————————————————————————————————————————————————
+//  Export helpers
+// ————————————————————————————————————————————————
+
+auto LibrarianExportImport::createAircraftJsonArray(QStringList& errors) -> QJsonArray
+{
+    QJsonArray aircraftArray;
+
+    QDir const dir(Librarian::directory(Librarian::Aircraft));
+    auto fileList = dir.entryInfoList(QDir::Files);
+    int failed = 0;
+
+    for (const QFileInfo& fileInfo : fileList)
+    {
+        Navigation::Aircraft aircraft;
+        auto errorMsg = aircraft.loadFromJSON(fileInfo.absoluteFilePath());
+        if (!errorMsg.isEmpty())
+        {
+            failed++;
+            continue;
+        }
+
+        // Use the internal serialization format directly
+        auto jsonData = aircraft.toJSON();
+        auto doc = QJsonDocument::fromJson(jsonData);
+        if (doc.isNull())
+        {
+            failed++;
+            continue;
+        }
+
+        aircraftArray.append(doc.object());
+    }
+
+    if (failed > 0)
+    {
+        errors += tr("%1 of %2 aircraft could not be exported.").arg(failed).arg(fileList.count());
+    }
+
+    return aircraftArray;
+}
+
+
+auto LibrarianExportImport::createRoutesJsonArray(QStringList& errors) -> QJsonArray
+{
+    QJsonArray routeArray;
+
+    QDir const dir(Librarian::directory(Librarian::Routes));
+    auto fileList = dir.entryInfoList(QDir::Files);
+    int failed = 0;
+
+    for (const QFileInfo& fileInfo : fileList)
+    {
+        Navigation::FlightRoute route;
+        auto errorMsg = route.load(fileInfo.absoluteFilePath());
+        if (!errorMsg.isEmpty())
+        {
+            failed++;
+            continue;
+        }
+
+        // Embed the internal GeoJSON serialization
+        auto geoJsonData = route.toGeoJSON();
+        auto geoJsonDoc = QJsonDocument::fromJson(geoJsonData);
+        if (geoJsonDoc.isNull())
+        {
+            failed++;
+            continue;
+        }
+
+        QJsonObject routeObj;
+        routeObj.insert(QStringLiteral("name"), fileInfo.baseName());
+        routeObj.insert(QStringLiteral("route"), geoJsonDoc.object());
+
+        routeArray.append(routeObj);
+    }
+
+    if (failed > 0)
+    {
+        errors += tr("%1 of %2 routes could not be exported.").arg(failed).arg(fileList.count());
+    }
+
+    return routeArray;
+}
+
+
+auto LibrarianExportImport::createWaypointsJsonArray(QStringList& errors) -> QJsonArray
+{
+    Q_UNUSED(errors)
+
+    auto* waypointLibrary = GlobalObject::waypointLibrary();
+    if (waypointLibrary == nullptr)
+    {
+        return {};
+    }
+
+    // Use the internal GeoJSON serialization directly.
+    // WaypointLibrary::GeoJSON() returns a FeatureCollection; we extract the
+    // features array so the backup format stays an array of waypoint objects.
+    auto geoJsonData = waypointLibrary->GeoJSON();
+    auto doc = QJsonDocument::fromJson(geoJsonData);
+    if (doc.isNull())
+    {
+        return {};
+    }
+
+    return doc.object().value(QStringLiteral("features")).toArray();
+}
+
+
+auto LibrarianExportImport::createMapsJsonArray() -> QJsonArray
+{
+    QJsonArray mapArray;
+
+    auto* dataManager = GlobalObject::dataManager();
+    if (dataManager == nullptr)
+    {
+        return mapArray;
+    }
+
+    auto* allItems = dataManager->items();
+    if (allItems == nullptr)
+    {
+        return mapArray;
+    }
+
+    // Collect installed types per map name, preserving insertion order
+    QStringList orderedNames;
+    QHash<QString, QStringList> typesByName;
+
+    for (auto* item : allItems->downloadables())
+    {
+        if (item == nullptr || !item->hasFile())
+        {
+            continue;
+        }
+
+        auto name = item->objectName();
+        QString typeStr;
+
+        switch (item->contentType())
+        {
+        case DataManagement::Downloadable_Abstract::AviationMap:
+            typeStr = u"aviation"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::BaseMapVector:
+            typeStr = u"base-vector"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::BaseMapRaster:
+            typeStr = u"base-raster"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::TerrainMap:
+            typeStr = u"terrain"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::Data:
+            typeStr = u"data"_s;
+            break;
+        case DataManagement::Downloadable_Abstract::MapSet:
+            typeStr = u"mapset"_s;
+            break;
+        default:
+            continue;
+        }
+
+        if (!typesByName.contains(name))
+        {
+            orderedNames.append(name);
+        }
+        typesByName[name].append(typeStr);
+    }
+
+    for (const auto& name : orderedNames)
+    {
+        QJsonObject mapObj;
+        mapObj.insert(QStringLiteral("name"), name);
+
+        QJsonArray typesArray;
+        for (const auto& t : typesByName[name])
+        {
+            typesArray.append(t);
+        }
+        mapObj.insert(QStringLiteral("types"), typesArray);
+
+        mapArray.append(mapObj);
+    }
+
+    return mapArray;
+}
+
+
+// ————————————————————————————————————————————————
+//  Export
+// ————————————————————————————————————————————————
+
+auto LibrarianExportImport::exportAndShareBackup() -> QString
+{
+    QStringList errors;
+
+    // Create the combined backup object
+    QJsonObject rootObj;
+    rootObj.insert(QStringLiteral("content"), QStringLiteral("enroute-backup"));
+    rootObj.insert(QStringLiteral("version"), backupFormatVersion);
+    rootObj.insert(QStringLiteral("timestamp"), QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+    rootObj.insert(QStringLiteral("aircraft"), createAircraftJsonArray(errors));
+    rootObj.insert(QStringLiteral("routes"), createRoutesJsonArray(errors));
+    rootObj.insert(QStringLiteral("waypoints"), createWaypointsJsonArray(errors));
+    rootObj.insert(QStringLiteral("maps"), createMapsJsonArray());
+
+    QJsonDocument doc;
+    doc.setObject(rootObj);
+    const QByteArray backupData = doc.toJson();
+
+    // Build a date-stamped file name
+    const QString fileName = u"EnrouteBackup-"_s
+        + QDateTime::currentDateTimeUtc().date().toString(Qt::ISODate);
+
+    // Share / save via FileExchange
+    auto* fileExchange = GlobalObject::fileExchange();
+    if (fileExchange == nullptr)
+    {
+        return tr("Cannot export backup. File exchange not available.");
+    }
+    const QString shareError = fileExchange->shareContent(
+        backupData, u"application/json"_s, u"json"_s, fileName);
+
+    // Return abort immediately so the QML can distinguish it
+    if (shareError == u"abort"_s)
+    {
+        return shareError;
+    }
+
+    // Combine export warnings and share errors into one result
+    if (!shareError.isEmpty())
+    {
+        errors += shareError;
+    }
+    return errors.join(u"<br>"_s);
+}
+
+
+// ————————————————————————————————————————————————
+//  Import
+// ————————————————————————————————————————————————
+
+auto LibrarianExportImport::importFullBackup(const QByteArray& content) -> QString
+{
+    // Parse the backup file
+    QJsonParseError parseError{};
+    auto document = QJsonDocument::fromJson(content, &parseError);
+
+    if (parseError.error != QJsonParseError::NoError)
+    {
+        return tr("Cannot read backup file. Error: %1").arg(parseError.errorString());
+    }
+
+    if (!document.isObject())
+    {
+        return tr("Cannot read backup file. Error: Document is not a JSON object.");
+    }
+
+    auto rootObj = document.object();
+
+    // Verify it's a backup file
+    if (rootObj.value(QStringLiteral("content")).toString() != u"enroute-backup")
+    {
+        return tr("Cannot read backup file. Error: File is not an Enroute backup.");
+    }
+
+    // Check backup format version
+    auto fileVersion = rootObj.value(QStringLiteral("version")).toInt(0);
+    if (fileVersion < 1)
+    {
+        return tr("Cannot read backup file. Error: No valid version number found.");
+    }
+    if (fileVersion > backupFormatVersion)
+    {
+        return tr("Cannot read backup file. The file was created by a newer version of Enroute Flight Navigation. Please update the app.");
+    }
+
+    QStringList errors;
+
+    // Import aircraft — each element is an internal Aircraft JSON object
+    int aircraftFailed = 0;
+    auto aircraftArray = rootObj.value(QStringLiteral("aircraft")).toArray();
+    for (const auto& aircraftValue : aircraftArray)
+    {
+        if (!aircraftValue.isObject())
+        {
+            aircraftFailed++;
+            continue;
+        }
+
+        // Serialize the JSON object back to bytes and use the internal loader
+        QJsonDocument aircraftDoc;
+        aircraftDoc.setObject(aircraftValue.toObject());
+
+        Navigation::Aircraft aircraft;
+        auto errorMsg = aircraft.loadFromJSON(aircraftDoc.toJson());
+        if (!errorMsg.isEmpty())
+        {
+            aircraftFailed++;
+            continue;
+        }
+
+        // Skip exact duplicates
+        if (Librarian::contains(aircraft))
+        {
+            continue;
+        }
+
+        // Get aircraft name for filename
+        QString aircraftName = aircraft.name();
+        if (aircraftName.isEmpty())
+        {
+            aircraftName = u"Imported Aircraft"_s;
+        }
+
+        // Save with unique name
+        auto savePath = Librarian::fullPath(Librarian::Aircraft, aircraftName);
+        if (QFile::exists(savePath))
+        {
+            for (int i = 1; ; i++)
+            {
+                auto newName = u"%1 (%2)"_s.arg(aircraftName).arg(i);
+                savePath = Librarian::fullPath(Librarian::Aircraft, newName);
+                if (!QFile::exists(savePath))
+                {
+                    break;
+                }
+            }
+        }
+
+        auto saveError = aircraft.save(savePath);
+        if (!saveError.isEmpty())
+        {
+            aircraftFailed++;
+            continue;
+        }
+    }
+    if (aircraftFailed > 0)
+    {
+        errors += tr("%1 of %2 aircraft could not be imported.").arg(aircraftFailed).arg(aircraftArray.count());
+    }
+
+    // Import routes — each element has a "name" and a "route" GeoJSON object
+    int routesFailed = 0;
+    auto routesArray = rootObj.value(QStringLiteral("routes")).toArray();
+    for (const auto& routeValue : routesArray)
+    {
+        if (!routeValue.isObject())
+        {
+            routesFailed++;
+            continue;
+        }
+
+        auto routeObj = routeValue.toObject();
+
+        // Extract route name
+        QString routeName = routeObj.value(QStringLiteral("name")).toString();
+        if (routeName.isEmpty())
+        {
+            routeName = u"Imported Route"_s;
+        }
+
+        // The "route" field contains the internal GeoJSON FeatureCollection
+        auto geoJsonObj = routeObj.value(QStringLiteral("route")).toObject();
+        if (geoJsonObj.isEmpty())
+        {
+            routesFailed++;
+            continue;
+        }
+
+        QJsonDocument geoJsonDoc;
+        geoJsonDoc.setObject(geoJsonObj);
+
+        Navigation::FlightRoute route;
+        auto errorMsg = route.loadFromGeoJSON(geoJsonDoc.toJson());
+        if (!errorMsg.isEmpty())
+        {
+            routesFailed++;
+            continue;
+        }
+
+        // Skip exact duplicates
+        if (Librarian::contains(&route))
+        {
+            continue;
+        }
+
+        // Save with unique name
+        auto savePath = Librarian::fullPath(Librarian::Routes, routeName);
+        if (QFile::exists(savePath))
+        {
+            for (int i = 1; ; i++)
+            {
+                auto newName = u"%1 (%2)"_s.arg(routeName).arg(i);
+                savePath = Librarian::fullPath(Librarian::Routes, newName);
+                if (!QFile::exists(savePath))
+                {
+                    break;
+                }
+            }
+        }
+
+        auto saveError = route.save(savePath);
+        if (!saveError.isEmpty())
+        {
+            routesFailed++;
+            continue;
+        }
+    }
+    if (routesFailed > 0)
+    {
+        errors += tr("%1 of %2 routes could not be imported.").arg(routesFailed).arg(routesArray.count());
+    }
+
+    // Import waypoints — each element is an internal GeoJSON Feature object
+    int waypointsFailed = 0;
+    auto waypointsArray = rootObj.value(QStringLiteral("waypoints")).toArray();
+    if (!waypointsArray.isEmpty())
+    {
+        auto* waypointLibrary = GlobalObject::waypointLibrary();
+        for (const auto& waypointValue : waypointsArray)
+        {
+            if (!waypointValue.isObject())
+            {
+                waypointsFailed++;
+                continue;
+            }
+
+            // Use the internal Waypoint(QJsonObject) constructor
+            const GeoMaps::Waypoint waypoint(waypointValue.toObject());
+            if (!waypoint.isValid())
+            {
+                waypointsFailed++;
+                continue;
+            }
+
+            if (!waypointLibrary->contains(waypoint))
+            {
+                waypointLibrary->add(waypoint);
+            }
+        }
+    }
+    if (waypointsFailed > 0)
+    {
+        errors += tr("%1 of %2 waypoints could not be imported.").arg(waypointsFailed).arg(waypointsArray.count());
+    }
+
+    if (!errors.isEmpty())
+    {
+        return errors.join(u"<br>"_s);
+    }
+    return {}; // Success
+}
+
+
+auto LibrarianExportImport::importFullBackupFromFile(const QString& fileName) -> QString
+{
+    auto file = FileFormats::DataFileAbstract::openFileURL(fileName);
+    if (!file->open(QIODevice::ReadOnly))
+    {
+        return tr("Cannot open backup file.");
+    }
+
+    auto content = file->readAll();
+    file->close();
+
+    return importFullBackup(content);
+}

--- a/src/LibrarianExportImport.h
+++ b/src/LibrarianExportImport.h
@@ -1,0 +1,84 @@
+/***************************************************************************
+ *   Copyright (C) 2020-2026 by Stefan Kebekus                             *
+ *   stefan.kebekus@gmail.com                                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QJsonArray>
+#include <QObject>
+
+
+/*! \brief Backup export and import for the library
+ *
+ *  This class handles serialization and deserialization of library data
+ *  (aircraft, routes, waypoints, maps) for the backup feature.
+ *
+ *  The backup format reuses the internal serialization of each domain class
+ *  (Aircraft::toJSON(), FlightRoute::toGeoJSON(), WaypointLibrary::GeoJSON())
+ *  so that format changes only need to be maintained in one place.
+ */
+
+class LibrarianExportImport : public QObject {
+    Q_OBJECT
+
+public:
+    /*! \brief Export library backup and share/save it via FileExchange
+     *
+     *  Creates a JSON backup of all aircraft, routes, waypoints, and a list
+     *  of installed maps, then hands it to FileExchange for sharing or
+     *  saving.
+     *
+     *  @returns Empty string on success, the string "abort" if the user
+     *  cancelled, or a translated error message otherwise
+     */
+    static QString exportAndShareBackup();
+
+    /*! \brief Import complete library backup from raw data
+     *
+     *  Parses a JSON backup and restores aircraft, routes, and waypoints.
+     *  The maps section is informational and is not imported.
+     *
+     *  @param content QByteArray containing the backup JSON data
+     *
+     *  @returns Empty string on success, translated error message on failure
+     */
+    static QString importFullBackup(const QByteArray& content);
+
+    /*! \brief Import complete library backup from a file
+     *
+     *  Convenience wrapper that opens a file and calls importFullBackup().
+     *
+     *  @param fileName Path or URL to the backup file
+     *
+     *  @returns Empty string on success, translated error message on failure
+     */
+    static QString importFullBackupFromFile(const QString& fileName);
+
+private:
+    Q_DISABLE_COPY_MOVE(LibrarianExportImport)
+
+    // Helpers that build the individual JSON arrays for the backup
+    static QJsonArray createAircraftJsonArray(QStringList& errors);
+    static QJsonArray createRoutesJsonArray(QStringList& errors);
+    static QJsonArray createWaypointsJsonArray(QStringList& errors);
+    static QJsonArray createMapsJsonArray();
+
+    //! Backup format version.  Increment only for breaking changes.
+    static constexpr int backupFormatVersion = 1;
+};

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -403,13 +403,46 @@ auto Navigation::FlightRoute::load(const QString& fileName) -> QString
     {
         return tr("Error reading file '%1'").arg(myFileName);
     }
-    if (result.length() > 100)
+    return snapAndSetWaypoints(result);
+}
+
+auto Navigation::FlightRoute::loadFromGeoJSON(const QByteArray& geoJSON) -> QString
+{
+    QJsonParseError parseError{};
+    auto document = QJsonDocument::fromJson(geoJSON, &parseError);
+    if (parseError.error != QJsonParseError::NoError)
     {
-        return tr("The file '%1' contains too many waypoints. Flight routes with more than 100 waypoints are not supported.").arg(myFileName);
+        return tr("Error reading GeoJSON data.");
+    }
+
+    QVector<GeoMaps::Waypoint> result;
+    const auto features = document.object()[QStringLiteral("features")].toArray();
+    for (const auto& value : features)
+    {
+        auto wp = GeoMaps::Waypoint(value.toObject());
+        if (!wp.isValid())
+        {
+            return tr("Error reading GeoJSON data.");
+        }
+        result.append(wp);
+    }
+
+    if (result.isEmpty())
+    {
+        return tr("Error reading GeoJSON data.");
+    }
+    return snapAndSetWaypoints(result);
+}
+
+auto Navigation::FlightRoute::snapAndSetWaypoints(const QVector<GeoMaps::Waypoint>& waypoints) -> QString
+{
+    if (waypoints.length() > 100)
+    {
+        return tr("Flight routes with more than 100 waypoints are not supported.");
     }
 
     QVector<GeoMaps::Waypoint> newWaypoints;
-    foreach(auto waypoint, result)
+    foreach(auto waypoint, waypoints)
     {
         if (!waypoint.isValid())
         {

--- a/src/navigation/FlightRoute.h
+++ b/src/navigation/FlightRoute.h
@@ -293,6 +293,15 @@ namespace Navigation
          */
         Q_INVOKABLE QString load(const QString& fileName);
 
+        /*! \brief Load flight route from GeoJSON data in memory
+         *
+         * @param geoJSON QByteArray containing GeoJSON data
+         *
+         * @returns Empty string in case of success, human-readable, translated
+         * error message otherwise.
+         */
+        QString loadFromGeoJSON(const QByteArray& geoJSON);
+
         /*! \brief Move waypoint one position down in the list of waypoints
          *
          * @param idx Index of the waypoint
@@ -415,6 +424,9 @@ namespace Navigation
 
         // Helper function for method toGPX
         [[nodiscard]] auto gpxElements(const QString& indent, const QString& tag) const -> QString;
+
+        // Validate, snap to nearest known waypoints, and assign
+        QString snapAndSetWaypoints(const QVector<GeoMaps::Waypoint>& waypoints);
 
         QProperty<QList<QGeoCoordinate>> m_geoPath;
         QList<QGeoCoordinate> computeGeoPath();

--- a/src/platform/FileExchange_Abstract.cpp
+++ b/src/platform/FileExchange_Abstract.cpp
@@ -100,6 +100,31 @@ void Platform::FileExchange_Abstract::processFileOpenRequest(const QString& path
      * Check for various possible file formats/contents
      */
 
+    // Check for Enroute backup file first (try parsing as JSON)
+    // This needs to be early because backup files might not have proper MIME type on Android
+    if (!file->open(QIODevice::ReadOnly))
+    {
+        // Cannot open file, will try other methods below
+    }
+    else
+    {
+        QJsonParseError parseError{};
+        auto fileData = file->readAll();
+        auto document = QJsonDocument::fromJson(fileData, &parseError);
+        file->close();
+
+        if (parseError.error == QJsonParseError::NoError && document.isObject())
+        {
+            auto rootObj = document.object();
+            if (rootObj.value(QStringLiteral("content")).toString() == u"enroute-backup")
+            {
+                // It's a backup file - emit signal to handle import
+                emit openFileRequest(path, {}, Backup);
+                return;
+            }
+        }
+    }
+
     // Flight Route in GPX format
     if ((mimeType.inherits(QStringLiteral("application/xml"))) || (mimeType.name() == u"application/x-gpx+xml"))
     {

--- a/src/platform/FileExchange_Abstract.h
+++ b/src/platform/FileExchange_Abstract.h
@@ -56,7 +56,8 @@ public:
         OpenAir, /*< Airspace data in openAir format */
         Image, /*< Image without georeferencing information */
         TripKit, /*< Trip Kit */
-        ZipFile /*< Zip File */
+        ZipFile, /*< Zip File */
+        Backup /*< Enroute full backup file */
       };
     Q_ENUM(FileFunction)
 
@@ -164,7 +165,7 @@ public slots:
      *
      * Overloaded function for convenience
      *
-     * @param path QByteArray containing an UTF8-Encoded strong
+     * @param path File path or URL as a string
      */
     void processFileOpenRequest(const QString& path);
 

--- a/src/platform/FileExchange_Linux.cpp
+++ b/src/platform/FileExchange_Linux.cpp
@@ -49,14 +49,20 @@ void Platform::FileExchange::importContent()
 }
 
 
-QString Platform::FileExchange::shareContent(const QByteArray& content, const QString& /*mimeType*/, const QString& /*fileNameSuffix*/, const QString& fileNameTemplate)
+QString Platform::FileExchange::shareContent(const QByteArray& content, const QString& mimeType, const QString& fileNameSuffix, const QString& fileNameTemplate)
 {
     QMimeDatabase const mimeDataBase;
-    QMimeType const mime = mimeDataBase.mimeTypeForData(content);
+    QMimeType mime = mimeDataBase.mimeTypeForName(mimeType);
+    if (!mime.isValid())
+    {
+        mime = mimeDataBase.mimeTypeForData(content);
+    }
+
+    const QString suffix = fileNameSuffix.isEmpty() ? mime.preferredSuffix() : fileNameSuffix;
     auto fileNameX = QFileDialog::getSaveFileName(nullptr,
                                                   tr("Export Data"),
-                                                  QDir::homePath() + u"/"_s + fileNameTemplate + u"."_s + mime.preferredSuffix(),
-                                                  tr("%1 (*.%2);;All files (*)").arg(mime.comment(), mime.preferredSuffix()));
+                                                  QDir::homePath() + u"/"_s + fileNameTemplate + u"."_s + suffix,
+                                                  tr("%1 (*.%2);;All files (*)").arg(mime.comment(), suffix));
     if (fileNameX.isEmpty())
     {
         return QStringLiteral("abort");

--- a/src/qml/items/ImportManager.qml
+++ b/src/qml/items/ImportManager.qml
@@ -100,6 +100,16 @@ Item {
                 errorDialog.open()
                 return
             }
+            if (fileFunction === FileExchange.Backup) {
+                var errorString = Librarian.importFullBackupFromFile(importManager.filePath)
+                if (errorString !== "") {
+                    errLbl.text = errorString
+                    errorDialog.open()
+                    return
+                }
+                toast.doToast(qsTr("Backup imported successfully"))
+                return
+            }
 
             errLbl.text = qsTr("The file type of the file <strong>%1</strong> cannot be recognized.").arg(fileName)
             errorDialog.open()
@@ -559,4 +569,5 @@ Item {
 
         }
     }
+
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -21,6 +21,7 @@
 import QtCore
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import akaflieg_freiburg.enroute
@@ -283,6 +284,93 @@ AppWindow {
                                 stackView.push("pages/WaypointLibraryPage.qml")
                                 libraryMenu.close()
                                 drawer.close()
+                            }
+                        }
+
+                        MenuSeparator { }
+
+                        ItemDelegate {
+                            text: qsTr("Backup & Restore")
+                            icon.source: "/icons/material/ic_cached.svg"
+                            Layout.fillWidth: true
+
+                            onClicked: {
+                                PlatformAdaptor.vibrateBrief()
+                                backupMenu.open()
+                            }
+
+                            AutoSizingMenu {
+                                id: backupMenu
+
+                                MenuItem {
+                                    text: Qt.platform.os === "android" ? qsTr("Share Full Backup…") : qsTr("Export Full Backup…")
+
+                                    onTriggered: {
+                                        PlatformAdaptor.vibrateBrief()
+                                        highlighted = false
+                                        var errorString = Librarian.exportAndShareBackup()
+                                        if (errorString === "abort") {
+                                            toast.doToast(qsTr("Aborted"))
+                                            return
+                                        }
+                                        if (errorString !== "") {
+                                            backupErrorDialog.text = errorString
+                                            backupErrorDialog.open()
+                                            return
+                                        }
+                                        if (Qt.platform.os === "android" || Qt.platform.os === "ios")
+                                            toast.doToast(qsTr("Backup shared"))
+                                        else
+                                            toast.doToast(qsTr("Backup exported"))
+                                        backupMenu.close()
+                                        libraryMenu.close()
+                                        drawer.close()
+                                    }
+                                }
+
+                                MenuItem {
+                                    text: qsTr("Import Full Backup…")
+
+                                    onTriggered: {
+                                        PlatformAdaptor.vibrateBrief()
+                                        highlighted = false
+                                        if (Qt.platform.os === "ios") {
+                                            Global.dialogLoader.active = false
+                                            Global.dialogLoader.setSource("dialogs/LongTextDialog.qml", {
+                                                                              title: qsTr("Import backup"),
+                                                                              text: qsTr("Locate your backup file in the browser, then select 'Open with' from the share menu, and choose Enroute"),
+                                                                              standardButtons: Dialog.Ok})
+                                            Global.dialogLoader.active = true
+                                        } else if (Qt.platform.os === "android") {
+                                            FileExchange.openFilePicker("")
+                                        } else {
+                                            backupImportDialog.open()
+                                        }
+                                        backupMenu.close()
+                                        libraryMenu.close()
+                                        drawer.close()
+                                    }
+
+                                    FileDialog {
+                                        id: backupImportDialog
+
+                                        acceptLabel: qsTr("Import")
+                                        rejectLabel: qsTr("Cancel")
+
+                                        fileMode: FileDialog.OpenFile
+
+                                        nameFilters: Qt.platform.os === "android" ? undefined : [qsTr("Backup Files (*.json)")]
+
+                                        onAccepted: {
+                                            PlatformAdaptor.vibrateBrief()
+                                            var selectedFile = backupImportDialog.selectedFile.toString()
+                                            Qt.callLater(FileExchange.processFileOpenRequest, selectedFile)
+                                        }
+                                        onRejected: {
+                                            PlatformAdaptor.vibrateBrief()
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -878,6 +966,13 @@ AppWindow {
         stackView: stackView
         toast: toast
         view: view
+    }
+
+    LongTextDialog {
+        id: backupErrorDialog
+
+        title: qsTr("Error with Backup")
+        standardButtons: Dialog.Ok
     }
 
     LongTextDialog {


### PR DESCRIPTION
Hallo Stefan, 
Das ist eine alternative Implementierung zu #630, nutzt die existierende interne Serialisierung für Aircraft, Waypoint, FlightRoute.
Kannst du bestätigen dass die interne Serialisierung wegen den Software Updates immer rückwärtskompatibel bleibt?

Sie schreibt mehr Werte in das Backup File, die man meiner Meinung nicht braucht.
Aber es wäre langfristig weniger Aufwand nur eine Serialisierung zu pflegen. 
Welche Implementierung würdest du bevorzugen?

[EnrouteBackup-2026-04-12.json](https://github.com/user-attachments/files/26658202/EnrouteBackup-2026-04-12.json)
