### PR TITLE
Display magnetic variation

### DIFF
--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -372,9 +372,15 @@ auto GeoMaps::Waypoint::tabularDescription() const -> QList<QString>
         result.append("NOTE" + m_properties.value(QStringLiteral("NOT")).toString());
     }
 
-    const auto var_deg = variation().toDEG();
+    auto var_deg = variation().toDEG();
     if (!std::isnan(var_deg)) {
-        result.append("VAR " + QString::number(std::round(var_deg)) + "°");
+        QString suffix = QStringLiteral("° E");
+        if (var_deg > 180) {
+            var_deg = 360 - var_deg;
+            suffix = QStringLiteral("° W");
+        }
+
+        result.append("VAR " + QString::number(std::round(var_deg)) + suffix);
     }
 
     return result;

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cmath>
 #include <QJsonArray>
 
 #include "GlobalObject.h"
@@ -371,6 +372,11 @@ auto GeoMaps::Waypoint::tabularDescription() const -> QList<QString>
         result.append("NOTE" + m_properties.value(QStringLiteral("NOT")).toString());
     }
 
+    const auto var_deg = variation().toDEG();
+    if (!std::isnan(var_deg)) {
+        result.append("VAR " + QString::number(std::round(var_deg)) + "°");
+    }
+
     return result;
 }
 
@@ -390,6 +396,24 @@ auto GeoMaps::Waypoint::twoLineTitle() const -> QString
     }
 
     return extendedName();
+}
+
+
+auto GeoMaps::Waypoint::variation() const -> Units::Angle
+{
+    if (!m_properties.contains(QStringLiteral("VAR"))) {
+        return Units::Angle::nan();
+    }
+
+    bool ok;
+    const auto var = m_properties.value(QStringLiteral("VAR"));
+    double var_d = var.toDouble(&ok);
+
+    if (!ok) {
+        return Units::Angle::nan();
+    }
+
+    return Units::Angle::fromDEG(var_d);
 }
 
 

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -26,6 +26,8 @@
 #include <QQmlEngine>
 #include <QXmlStreamWriter>
 
+#include "units/Angle.h"
+
 
 namespace GeoMaps {
 
@@ -175,6 +177,12 @@ public:
      */
     Q_PROPERTY(QString type READ type CONSTANT)
 
+    /*! \brief Magnetic variation at the waypoint
+     *
+     * This property holds the magnetic variation at the waypoint as a number.
+     */
+    Q_PROPERTY(Units::Angle variation READ variation CONSTANT)
+
 
     //
     // GETTER METHODS
@@ -275,6 +283,12 @@ public:
     {
         return m_properties.value(QStringLiteral("TYP")).toString();
     }
+
+    /*! \brief Get variation
+     *
+     * @returns The variation, or NaN if not available.
+     */
+    [[nodiscard]] auto variation() const -> Units::Angle;
 
 
     //


### PR DESCRIPTION
Display the magnetic variation (https://github.com/Akaflieg-Freiburg/enrouteServer/pull/60) in the waypoint information dialog:

<img width="526" height="740" alt="image" src="https://github.com/user-attachments/assets/3d6c80d9-7621-404e-9263-3774ef56ff5b" />

For reference:
<img width="1250" height="438" alt="image" src="https://github.com/user-attachments/assets/9872a475-6d3f-4bb8-9c24-44b6a509d131" />


Negative variations wrap around because of the usage of `Units::Angle`. They would display as excessive figures (e.g. 357 degrees). Instead, I show the negative variation with the suffix "W" (vs. "E"):
<img width="525" height="579" alt="Screenshot_20260412_163621" src="https://github.com/user-attachments/assets/02de2d68-8ded-4152-b652-00c156bd30b4" />
