### PR TITLE
Feature/waypoints2

### DIFF
--- a/src/geomaps/GeoMapProvider.cpp
+++ b/src/geomaps/GeoMapProvider.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <limits>
+
 #include <QImage>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -25,6 +27,7 @@
 #include <QLockFile>
 #include <QQmlEngine>
 #include <QRandomGenerator>
+#include <QRegularExpression>
 #include <QtConcurrent/QtConcurrentRun>
 
 #include "GlobalSettings.h"
@@ -33,7 +36,9 @@
 #include "fileFormats/MBTILES.h"
 #include "geomaps/GeoMapProvider.h"
 #include "geomaps/WaypointLibrary.h"
+#include "navigation/FlightRoute.h"
 #include "navigation/Navigator.h"
+#include "positioning/PositionProvider.h"
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -287,6 +292,124 @@ Units::Distance decodeImageData(const QImage* image, double intraTileX, double i
     double const y4 = (qRed(pix) * 256.0 + qGreen(pix) + qBlue(pix) / 256.0) - 32768.0;
 
     return Units::Distance::fromM((1-t)*(1-u)*y1 + t*(1-u)*y2+t*u*y3+(1-t)*u*y4);
+}
+
+GeoMaps::Waypoint GeoMaps::GeoMapProvider::findNavaid(const QString& id)
+{
+    // Get all navaids
+    QList<GeoMaps::Waypoint> matchingNavaids;
+    auto allWaypoints = waypoints();
+    for (const auto& wp : allWaypoints) {
+        if (wp.isValid() && wp.type() == u"NAV" && wp.ICAOCode() == id) {
+            matchingNavaids.append(wp);
+        }
+    }
+
+    if (matchingNavaids.isEmpty()) {
+        return Waypoint(); // No matching navaid found
+    }
+
+    if (matchingNavaids.size() == 1) {
+        return matchingNavaids.first();
+    }
+
+    // Choose the best navaid based on reference position:
+    QGeoCoordinate referenceCoord;
+
+    // Try to use route waypoints first
+    if (navigator()->flightRoute() != nullptr) {
+        const auto route = navigator()->flightRoute();
+        // Use the center of the bounding rectangle as reference
+        referenceCoord = route->boundingRectangle().center();
+    }
+
+    // If no route, use user position
+    if (!referenceCoord.isValid()) {
+        referenceCoord = positionProvider()->lastValidCoordinate();
+    }
+
+    // Still no reference coordinate, fail:
+    if (!referenceCoord.isValid()) {
+        return Waypoint();
+    }
+
+    // Find closest navaid to reference coordinate
+    GeoMaps::Waypoint bestNavaid;
+    double minDistance = std::numeric_limits<double>::max();
+    for (const auto& navaid : matchingNavaids) {
+        double distance = referenceCoord.distanceTo(navaid.coordinate());
+        if (distance < minDistance) {
+            minDistance = distance;
+            bestNavaid = navaid;
+        }
+    }
+
+    return bestNavaid;
+}
+
+GeoMaps::Waypoint GeoMaps::GeoMapProvider::parseWaypointString(const QString& rep)
+{
+    if (rep.isEmpty()) {
+        return Waypoint();
+    }
+
+    // Try to parse as coordinate notation
+    // 11 characters include minutes "DDMMXDDDMMX". Example: "4620N07805W"
+    // 7 characters only have degrees "DDXDDDX". Example: "46N078W"
+    QRegularExpression coordRegex(u"^(\\d{2})(\\d{2})?([NS])(\\d{3})(\\d{2})?([EW])$"_s);
+    auto coordMatch = coordRegex.match(rep);
+
+    if (coordMatch.hasMatch()) {
+        // Parse coordinate notation
+        int latDeg = coordMatch.captured(1).toInt();
+        int latMin = coordMatch.captured(2).toInt();
+        QString latDir = coordMatch.captured(3);
+        int lonDeg = coordMatch.captured(4).toInt();
+        int lonMin = coordMatch.captured(5).toInt();
+        QString lonDir = coordMatch.captured(6);
+
+        // Validate ranges
+        if (latDeg > 90 || latMin >= 60 || lonDeg > 180 || lonMin >= 60) {
+            return Waypoint(); // Invalid coordinate
+        }
+
+        // Convert to decimal degrees
+        double latitude = latDeg + latMin / 60.0;
+        if (latDir == u"S") {
+            latitude = -latitude;
+        }
+
+        double longitude = lonDeg + lonMin / 60.0;
+        if (lonDir == u"W") {
+            longitude = -longitude;
+        }
+
+        return Waypoint(QGeoCoordinate(latitude, longitude));
+    }
+
+    // Try to parse as radial notation (9 characters: SSSRRRDDD)
+    // Example: "LNO070012" (LNO VOR, radial 070°, distance 12 NM)
+    QRegularExpression radialRegex(u"^([A-Z]{3})(\\d{3})(\\d{3})$"_s);
+    auto radialMatch = radialRegex.match(rep);
+
+    if (radialMatch.hasMatch()) {
+        // Parse radial notation
+        QString navaidCode = radialMatch.captured(1);
+        int radialDeg = radialMatch.captured(2).toInt();
+        int distanceNM = radialMatch.captured(3).toInt();
+
+        // Validate ranges
+        if (radialDeg >= 360 || distanceNM > 999) {
+            return Waypoint(); // Invalid radial notation
+        }
+
+        // Create waypoint from navaid, bearing, and distance
+        auto magneticBearing = Units::Angle::fromDEG(radialDeg);
+        return Waypoint(findNavaid(navaidCode), magneticBearing, distanceNM);
+    }
+
+    // No matching representation:
+    return Waypoint();
 }
 
 Units::Distance GeoMaps::GeoMapProvider::terrainElevationAMSL(const QGeoCoordinate& coordinate)

--- a/src/geomaps/GeoMapProvider.cpp
+++ b/src/geomaps/GeoMapProvider.cpp
@@ -38,6 +38,7 @@
 #include "geomaps/WaypointLibrary.h"
 #include "navigation/FlightRoute.h"
 #include "navigation/Navigator.h"
+#include "notification/NotificationManager.h"
 #include "positioning/PositionProvider.h"
 
 using namespace Qt::Literals::StringLiterals;
@@ -357,7 +358,7 @@ GeoMaps::Waypoint GeoMaps::GeoMapProvider::parseWaypointString(const QString& re
     // 11 characters include minutes "DDMMXDDDMMX". Example: "4620N07805W"
     // 7 characters only have degrees "DDXDDDX". Example: "46N078W"
     QRegularExpression coordRegex(u"^(\\d{2})(\\d{2})?([NS])(\\d{3})(\\d{2})?([EW])$"_s);
-    auto coordMatch = coordRegex.match(rep);
+    auto coordMatch = coordRegex.match(rep.toUpper());
 
     if (coordMatch.hasMatch()) {
         // Parse coordinate notation
@@ -390,7 +391,7 @@ GeoMaps::Waypoint GeoMaps::GeoMapProvider::parseWaypointString(const QString& re
     // Try to parse as radial notation (9 characters: SSSRRRDDD)
     // Example: "LNO070012" (LNO VOR, radial 070°, distance 12 NM)
     QRegularExpression radialRegex(u"^([A-Z]{3})(\\d{3})(\\d{3})$"_s);
-    auto radialMatch = radialRegex.match(rep);
+    auto radialMatch = radialRegex.match(rep.toUpper());
 
     if (radialMatch.hasMatch()) {
         // Parse radial notation
@@ -404,7 +405,15 @@ GeoMaps::Waypoint GeoMaps::GeoMapProvider::parseWaypointString(const QString& re
         }
 
         // Create waypoint from navaid, bearing, and distance
-        auto magneticBearing = Units::Angle::fromDEG(radialDeg);
+        const auto magneticBearing = Units::Angle::fromDEG(radialDeg);
+        const auto ref = findNavaid(navaidCode);
+
+        // If navaid is invalid, show a message to the user:
+        if (!ref.isValid()) {
+            const QString msg = "'%1' is unknown or ambiguous";
+            emit GlobalObject::notificationManager()->toastPosted(msg.arg(navaidCode));
+        }
+
         return Waypoint(findNavaid(navaidCode), magneticBearing, distanceNM);
     }
 

--- a/src/geomaps/GeoMapProvider.h
+++ b/src/geomaps/GeoMapProvider.h
@@ -331,6 +331,38 @@ public:
         return {};
     }
 
+    /*! \brief Find navaid with the given name
+     *
+     * Finds a navaid from a three-letter identification code.
+     * Note that the navaid has to be in the currently active library to be found.
+     *
+     * Because the three-letter codes are sometimes ambiguous, we apply some heuristics
+     * to choose the correct one:
+     *
+     * 1. Choose the navaid that is closest to the currently active flight route.
+     * 2. If the route is empty, choose the navaid, that is closest to the user position.
+     * 3. If the user position is unknown, return an invalid waypoint.
+     */
+    [[nodiscard]] Q_INVOKABLE GeoMaps::Waypoint findNavaid(const QString& id);
+
+
+    /*! \brief Parse waypoint string
+     *
+     * Accepted formats are according to the VFR flight plan format:
+     * https://www.faa.gov/air_traffic/publications/atpubs/fss/AppendixA.htm.
+     *
+     *  Parses a waypoint representation string (either coordinate notation
+     *  like "4602N07805W" or radial notation like "DUB180040").
+     *
+     *  For radial notations with ambiguous navaid codes, the navaid closest
+     *  to the current route or user position is chosen.
+     *
+     *  @param representation String representation of the waypoint
+     *
+     *  @returns A waypoint, or invalid if the representation cannot be parsed
+     */
+    [[nodiscard]] Q_INVOKABLE GeoMaps::Waypoint parseWaypointString(const QString& representation);
+
     /*! \brief Elevation of terrain at a given coordinate, above sea level
      *
      *  @param coordinate Coordinate

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -23,6 +23,7 @@
 
 #include "GlobalObject.h"
 #include "Waypoint.h"
+#include "geomaps/GeoMapProvider.h"
 #include "navigation/Aircraft.h"
 #include "navigation/Navigator.h"
 #include "units/Distance.h"
@@ -113,6 +114,36 @@ GeoMaps::Waypoint::Waypoint(const QJsonObject &geoJSONObject)
             m_properties[u"NAM"_s] = "Waypoint";
         }
     }
+}
+
+
+GeoMaps::Waypoint::Waypoint(const GeoMaps::Waypoint& navaid, const Units::Angle& magneticBearing, double distanceNM) : Waypoint()
+{
+    // Check if navaid is valid
+    if (!navaid.isValid() || navaid.type() != u"NAV") {
+        // Return invalid waypoint
+        return;
+    }
+
+    // Get magnetic variation at navaid
+    auto var = navaid.variation();
+    if (std::isnan(var.toDEG())) {
+        // Return invalid waypoint
+        return;
+    }
+
+    // Convert magnetic bearing to true bearing
+    // True = Magnetic + Variation
+    auto trueBearing = magneticBearing + var;
+
+    // Calculate coordinate at given distance and bearing from navaid
+    auto navaidCoord = navaid.coordinate();
+    double distanceMeters = distanceNM * 1852.0; // Convert NM to meters
+
+    m_coordinate = navaidCoord.atDistanceAndAzimuth(distanceMeters, trueBearing.toDEG());
+
+    // Set the representation property to the original string
+    setRepresentation(radialNotation(navaid));
 }
 
 

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -333,7 +333,14 @@ auto GeoMaps::Waypoint::extendedName() const -> QString
         return QStringLiteral("%1 (%2)").arg(m_properties.value(QStringLiteral("NAM")).toString(), m_properties.value(QStringLiteral("CAT")).toString());
     }
 
-    return m_properties.value(QStringLiteral("NAM")).toString();
+    const auto name = m_properties.value(QStringLiteral("NAM")).toString();
+
+    // If name is generic "Waypoint", use a more concise representation instead:
+    if (name == u"Waypoint") {
+        return representation();
+    }
+
+    return name;
 }
 
 

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -423,6 +423,70 @@ auto GeoMaps::Waypoint::variation() const -> Units::Angle
 }
 
 
+auto GeoMaps::Waypoint::radialNotation(const GeoMaps::Waypoint& navaid) const -> QString
+{
+    // Check validity
+    if (!isValid() || !navaid.isValid()) {
+        return {};
+    }
+
+    // Check that navaid is actually a navigation aid
+    if (navaid.type() != u"NAV") {
+        return {};
+    }
+
+    // Get ICAO code of navaid
+    QString navaidCode = navaid.ICAOCode();
+    if (navaidCode.length() != 3) {
+        return {};
+    }
+
+    // Get magnetic variation at navaid
+    auto var = navaid.variation();
+    if (std::isnan(var.toDEG())) {
+        return {};
+    }
+
+    // Calculate radial (bearing from navaid TO this waypoint)
+    auto navaidCoord = navaid.coordinate();
+    auto thisCoord = m_coordinate;
+
+    auto radial = Units::Angle::fromDEG(navaidCoord.azimuthTo(thisCoord));
+    if (!radial.isFinite()) {
+        return {};
+    }
+
+    // Convert true bearing to magnetic bearing (relative to magnetic north).
+    // From https://en.wikipedia.org/wiki/Magnetic_declination#Navigation:
+    // True = Magnetic + Variation
+    // => Magnetic = True - Variation
+    // Make sure to use - instead of -=, because the latter is not implemented.
+    radial = radial - var;
+
+    // Calculate distance
+    qreal distanceMeters = navaidCoord.distanceTo(thisCoord);
+    if (!qIsFinite(distanceMeters)) {
+        return {};
+    }
+
+    int radialInt = qRound(radial.toDEG());
+    int distanceInt = qRound(distanceMeters / 1852.0);
+
+    // Format: STATIONRRRDDD (e.g., LNO070012)
+    // RRR = radial (3 digits, zero-padded)
+    // DDD = distance in NM (3 digits, zero-padded)
+
+    if (distanceInt > 999) {
+        return {};
+    }
+
+    return QString("%1%2%3")
+        .arg(navaidCode)
+        .arg(radialInt, 3, 10, QLatin1Char('0'))
+        .arg(distanceInt, 3, 10, QLatin1Char('0'));
+}
+
+
 auto GeoMaps::Waypoint::coordinateNotation() const -> QString {
     if (!isValid()) {
         return {};
@@ -448,6 +512,38 @@ auto GeoMaps::Waypoint::coordinateNotation() const -> QString {
         .arg(lonDeg, 3, 10, QLatin1Char('0'))
         .arg(lonMin, 2, 10, QLatin1Char('0'))
         .arg(lonDir);
+}
+
+
+auto GeoMaps::Waypoint::availableRepresentations() const -> QStringList
+{
+    QStringList representations;
+
+    if (!m_coordinate.isValid()) {
+        return representations;
+    }
+
+    // Add coordinate notation as the first (default) option
+    QString coordNotation = coordinateNotation();
+    if (!coordNotation.isEmpty()) {
+        representations.append(coordNotation);
+    }
+
+    // Get nearby navaids and add radial notations
+    if (GlobalObject::canConstruct()) {
+        auto geoMapProvider = GlobalObject::geoMapProvider();
+        if (geoMapProvider != nullptr) {
+            auto navaids = geoMapProvider->nearbyWaypoints(m_coordinate, u"NAV"_s);
+            for (const auto& navaid : navaids) {
+                QString notation = radialNotation(navaid);
+                if (!notation.isEmpty()) {
+                    representations.append(notation);
+                }
+            }
+        }
+    }
+
+    return representations;
 }
 
 

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -372,9 +372,15 @@ auto GeoMaps::Waypoint::tabularDescription() const -> QList<QString>
         result.append("NOTE" + m_properties.value(QStringLiteral("NOT")).toString());
     }
 
-    const auto var_deg = variation().toDEG();
+    auto var_deg = variation().toDEG();
     if (!std::isnan(var_deg)) {
-        result.append("VAR " + QString::number(std::round(var_deg)) + "°");
+        QString suffix = QStringLiteral("° E");
+        if (var_deg > 180) {
+            var_deg = 360 - var_deg;
+            suffix = QStringLiteral("° W");
+        }
+
+        result.append("VAR " + QString::number(std::round(var_deg)) + suffix);
     }
 
     return result;

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -578,6 +578,21 @@ auto GeoMaps::Waypoint::availableRepresentations() const -> QStringList
 }
 
 
+auto GeoMaps::Waypoint::representationIndex(const QString& representation) const -> int
+{
+    if (representation.isEmpty() || !m_coordinate.isValid())
+    {
+        return -1;
+    }
+
+    // Get all available representations for this waypoint's coordinate
+    auto representations = availableRepresentations();
+
+    // Find the representation in the list
+    return representations.indexOf(representation);
+}
+
+
 size_t GeoMaps::qHash(const GeoMaps::Waypoint& waypoint)
 {
     auto result = qHash(waypoint.m_coordinate);

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -423,6 +423,34 @@ auto GeoMaps::Waypoint::variation() const -> Units::Angle
 }
 
 
+auto GeoMaps::Waypoint::coordinateNotation() const -> QString {
+    if (!isValid()) {
+        return {};
+    }
+
+    const double latitude = coordinate().latitude();
+    const double longitude = coordinate().longitude();
+
+    // Extract degrees and minutes for latitude
+    const int latDeg = static_cast<int>(qAbs(latitude));
+    const int latMin = static_cast<int>((qAbs(latitude) - latDeg) * 60.0);
+    const QString latDir = (latitude >= 0) ? u"N"_s : u"S"_s;
+
+    // Extract degrees and minutes for longitude
+    const int lonDeg = static_cast<int>(qAbs(longitude));
+    const int lonMin = static_cast<int>((qAbs(longitude) - lonDeg) * 60.0);
+    const QString lonDir = (longitude >= 0) ? u"E"_s : u"W"_s;
+
+    return QString("%1%2%3%4%5%6")
+        .arg(latDeg, 2, 10, QLatin1Char('0'))
+        .arg(latMin, 2, 10, QLatin1Char('0'))
+        .arg(latDir)
+        .arg(lonDeg, 3, 10, QLatin1Char('0'))
+        .arg(lonMin, 2, 10, QLatin1Char('0'))
+        .arg(lonDir);
+}
+
+
 size_t GeoMaps::qHash(const GeoMaps::Waypoint& waypoint)
 {
     auto result = qHash(waypoint.m_coordinate);

--- a/src/geomaps/Waypoint.cpp
+++ b/src/geomaps/Waypoint.cpp
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cmath>
 #include <QJsonArray>
 
 #include "GlobalObject.h"
@@ -371,6 +372,11 @@ auto GeoMaps::Waypoint::tabularDescription() const -> QList<QString>
         result.append("NOTE" + m_properties.value(QStringLiteral("NOT")).toString());
     }
 
+    const auto var_deg = variation().toDEG();
+    if (!std::isnan(var_deg)) {
+        result.append("VAR " + QString::number(std::round(var_deg)) + "°");
+    }
+
     return result;
 }
 
@@ -390,6 +396,24 @@ auto GeoMaps::Waypoint::twoLineTitle() const -> QString
     }
 
     return extendedName();
+}
+
+
+auto GeoMaps::Waypoint::variation() const -> Units::Angle
+{
+    if (!m_properties.contains(QStringLiteral("VAR"))) {
+        return Units::Angle::nan();
+    }
+
+    bool ok;
+    const auto var = m_properties.value(QStringLiteral("VAR"));
+    double var_d = var.toDouble(&ok);
+
+    if (!ok) {
+        return Units::Angle::nan();
+    }
+
+    return Units::Angle::fromDEG(var_d);
 }
 
 

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -457,6 +457,20 @@ public:
      */
     [[nodiscard]] Q_INVOKABLE QStringList availableRepresentations() const;
 
+    /*! \brief Find index of representation in available representations
+     *
+     * As the list of representations is always sorted (by distance to reference
+     * station), we can refer to a representation by its index in that list.
+     *
+     * This method checks whether a given representation string is valid for
+     * this waypoint's coordinate and returns its index.
+     *
+     * @param representation The representation string to find
+     *
+     * @returns Index of the representation (0 or higher if found), or -1 if not found
+     */
+    [[nodiscard]] Q_INVOKABLE int representationIndex(const QString& representation) const;
+
     /*! \brief Serialization to GeoJSON object
      *
      * This method serialises the waypoint as a GeoJSON object. The object

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -288,10 +288,16 @@ public:
      */
     [[nodiscard]] auto shortName() const -> QString
     {
-        if (ICAOCode().isEmpty()) {
-            return name();
+        if (!ICAOCode().isEmpty()) {
+            return ICAOCode();
         }
-        return ICAOCode();
+
+        // If name is generic "Waypoint", use a more concise representation instead:
+        if (name() == u"Waypoint") {
+            return representation();
+        }
+
+        return name();
     }
 
     /*! \brief Getter method for property with the same name

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -26,6 +26,8 @@
 #include <QQmlEngine>
 #include <QXmlStreamWriter>
 
+#include "units/Angle.h"
+
 
 namespace GeoMaps {
 
@@ -175,6 +177,12 @@ public:
      */
     Q_PROPERTY(QString type READ type CONSTANT)
 
+    /*! \brief Magnetic variation at the waypoint
+     *
+     * This property holds the magnetic variation at the waypoint as a number.
+     */
+    Q_PROPERTY(Units::Angle variation READ variation CONSTANT)
+
 
     //
     // GETTER METHODS
@@ -275,6 +283,12 @@ public:
     {
         return m_properties.value(QStringLiteral("TYP")).toString();
     }
+
+    /*! \brief Get variation
+     *
+     * @returns The variation, or NaN if not available.
+     */
+    [[nodiscard]] auto variation() const -> Units::Angle;
 
 
     //

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -81,6 +81,26 @@ public:
      */
     explicit Waypoint(const QJsonObject& geoJSONObject);
 
+    /*! \brief Constructs a waypoint from fix, bearing and distance
+     *
+     * This constructor calculates a waypoint position based on a reference
+     * navigation aid, a magnetic bearing from that navaid, and a distance.
+     * The magnetic variation at the navaid is taken into account.
+     *
+     * - category is set to "WP"
+     * - name is set to "Waypoint"
+     * - type is set to "WP"
+     * - representation is set accordingly
+     *
+     * If the navaid is invalid or doesn't have valid magnetic variation,
+     * the resulting waypoint will be invalid.
+     *
+     * @param navaid Reference navigation aid waypoint
+     * @param magneticBearing Magnetic bearing from the navaid (in degrees)
+     * @param distanceNM Distance from the navaid in nautical miles
+     */
+    Waypoint(const GeoMaps::Waypoint& navaid, const Units::Angle& magneticBearing, double distanceNM);
+
 
     //
     // PROPERTIES

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -402,6 +402,18 @@ public:
      */
     [[nodiscard]] Q_INVOKABLE bool isNear(const GeoMaps::Waypoint& other) const;
 
+    /*! \brief Generate radial notation string from a navaid
+     *
+     * This method generates a radial position notation in the format used in
+     * flight plans (e.g., "LNO070012" = LNO VOR, radial 070°, distance 12 nm).
+     *
+     * @param navaid Navigation aid waypoint to use as reference
+     *
+     * @returns Radial notation string, or empty string if this waypoint or the
+     * navaid is invalid, or if navaid is not a NAV type
+     */
+    [[nodiscard]] Q_INVOKABLE QString radialNotation(const GeoMaps::Waypoint& navaid) const;
+
     /*! \brief Generate VFR flight plan format
      *
      * Convert coordinates to VFR flight plan format (degrees and minutes)
@@ -413,6 +425,17 @@ public:
      * @returns coordinate string in VFR flight plan format.
      */
     [[nodiscard]] Q_INVOKABLE QString coordinateNotation() const;
+
+    /*! \brief Compute available representations for this waypoint
+     *
+     * This method computes all possible representations for this waypoint's
+     * coordinate, including coordinate notation and radial notations from nearby
+     * navigation aids.
+     *
+     * @returns A list of representation strings, with coordinate notation first,
+     *          followed by radial notations from nearby navaids
+     */
+    [[nodiscard]] Q_INVOKABLE QStringList availableRepresentations() const;
 
     /*! \brief Serialization to GeoJSON object
      *

--- a/src/geomaps/Waypoint.h
+++ b/src/geomaps/Waypoint.h
@@ -183,6 +183,17 @@ public:
      */
     Q_PROPERTY(Units::Angle variation READ variation CONSTANT)
 
+    /*! \brief Custom representation of the waypoint
+     *
+     * This property holds a custom representation of the waypoint, e.g.
+     * by fix/bearing/distance.
+     * The custom representation is used when exporting a VFR flight plan.
+     *
+     * The property is reset, whenever the underlying waypoint is changed
+     * (i.e. the coordinates are changed).
+     */
+    Q_PROPERTY(QString representation READ representation WRITE setRepresentation)
+
 
     //
     // GETTER METHODS
@@ -290,6 +301,24 @@ public:
      */
     [[nodiscard]] auto variation() const -> Units::Angle;
 
+    /*! \brief Representation for writing this in a VFR flight plan.
+     *
+     * A custom representation may be set using #setRepresentation().
+     * If no custom representation is set, the default geocoordinate
+     * representation is returned.
+     *
+     * @returns the applicable representation.
+     */
+    [[nodiscard]] auto representation() const -> QString
+    {
+        if (!m_properties.contains(QStringLiteral("REP")) ||
+                m_properties.value(QStringLiteral("REP")).toString().isEmpty()) {
+            return coordinateNotation();
+        }
+
+        return m_properties.value(QStringLiteral("REP")).toString();
+    }
+
 
     //
     // SETTER METHODS
@@ -302,6 +331,7 @@ public:
     void setCoordinate(const QGeoCoordinate& newCoordinate)
     {
         m_coordinate = newCoordinate;
+        m_properties.remove("REP");
     }
 
     /*! \brief Set name
@@ -320,6 +350,15 @@ public:
     void setNotes(const QString &newNotes)
     {
         m_properties.insert(QStringLiteral("NOT"), newNotes);
+    }
+
+    /*! \brief Set custom representation for use in VFR flight plans.
+     *
+     * @param rep The new representation.
+     */
+    void setRepresentation(const QString rep)
+    {
+        m_properties.insert(QStringLiteral("REP"), QString(rep));
     }
 
 
@@ -362,6 +401,18 @@ public:
      *  them is less than 2km
      */
     [[nodiscard]] Q_INVOKABLE bool isNear(const GeoMaps::Waypoint& other) const;
+
+    /*! \brief Generate VFR flight plan format
+     *
+     * Convert coordinates to VFR flight plan format (degrees and minutes)
+     * Format: "4620N07805W" (DDMMNDDDMME) - 11 characters as per AIP.
+     *
+     * For more information, see (2) Significant point in
+     * https://www.faa.gov/air_traffic/publications/atpubs/fss/AppendixA.htm
+     *
+     * @returns coordinate string in VFR flight plan format.
+     */
+    [[nodiscard]] Q_INVOKABLE QString coordinateNotation() const;
 
     /*! \brief Serialization to GeoJSON object
      *

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -660,34 +660,9 @@ auto Navigation::FlightRoute::toVfrFlightPlan() const -> QString
         
         if (!useIcaoCode)
         {
-            // Convert coordinates to VFR flight plan format (degrees and minutes)
-            // Format: "4620N07805W" (DDMMNDDDDMME) - 11 characters as per AIP
-            const QGeoCoordinate coord = waypoint.coordinate();
-            if (coord.isValid())
-            {
-                const double latitude = coord.latitude();
-                const double longitude = coord.longitude();
-                
-                // Extract degrees and minutes for latitude
-                const int latDeg = static_cast<int>(qAbs(latitude));
-                const int latMin = static_cast<int>((qAbs(latitude) - latDeg) * 60.0);
-                const QString latDir = (latitude >= 0) ? u"N"_s : u"S"_s;
-                
-                // Extract degrees and minutes for longitude
-                const int lonDeg = static_cast<int>(qAbs(longitude));
-                const int lonMin = static_cast<int>((qAbs(longitude) - lonDeg) * 60.0);
-                const QString lonDir = (longitude >= 0) ? u"E"_s : u"W"_s;
-                
-                waypointString = QString("%1%2%3%4%5%6")
-                    .arg(latDeg, 2, 10, QLatin1Char('0'))
-                    .arg(latMin, 2, 10, QLatin1Char('0'))
-                    .arg(latDir)
-                    .arg(lonDeg, 3, 10, QLatin1Char('0'))
-                    .arg(lonMin, 2, 10, QLatin1Char('0'))
-                    .arg(lonDir);
-            }
+            waypointString = waypoint.representation();
         }
-        
+
         if (!waypointString.isEmpty())
         {
             routeElements.append(waypointString);

--- a/src/qml/dialogs/WaypointDescription.qml
+++ b/src/qml/dialogs/WaypointDescription.qml
@@ -729,6 +729,7 @@ CenteringDialog {
             newWP.name = newName
             newWP.notes = newNotes
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
+            newWP.representation = newRepresentation
             WaypointLibrary.replace(waypointDescriptionDialog.waypoint, newWP)
             waypointDescriptionDialog.close()
             Global.toast.doToast(qsTr("Modified entry %1 in library.").arg(newWP.extendedName))
@@ -746,6 +747,7 @@ CenteringDialog {
             newWP.name = newName
             newWP.notes = newNotes
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
+            newWP.representation = newRepresentation
             WaypointLibrary.add(newWP)
             waypointDescriptionDialog.close()
             Global.toast.doToast(qsTr("Added %1 to waypoint library.").arg(newWP.extendedName))

--- a/src/qml/dialogs/WaypointEditor.qml
+++ b/src/qml/dialogs/WaypointEditor.qml
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+import QtPositioning
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -28,8 +29,8 @@ import "../items"
 
 /* Waypoint dialog
  *
- * Short description: set property waypoint, then open. Re-implement onAccepted and read the new values from newName, newLatitude
- * and newLongitude.
+ * Short description: set property waypoint, then open. Re-implement onAccepted and read the new values from newName, newLatitude,
+ * newLongitude, newAltitudeMeter, and newRepresentation.
  */
 
 CenteringDialog {
@@ -43,6 +44,9 @@ CenteringDialog {
     readonly property double newLatitude: latInput.value
     readonly property double newLongitude: longInput.value
     readonly property double newAltitudeMeter: eleField.valueMeter
+    property string newRepresentation: ""
+    property var availableRepresentations: []
+    property bool coordinatesAreValid: waypoint.coordinate.isValid
 
     modal: true
     title: qsTr("Edit Waypoint")
@@ -55,7 +59,80 @@ CenteringDialog {
         eleField.valueMeter = waypoint.coordinate.altitude
         wpNameField.text = waypoint.extendedName
         wpNotesField.text = waypoint.notes
+        coordinatesAreValid = waypoint.coordinate.isValid
+        
+        if (coordinatesAreValid) {
+            // Get available representations from C++
+            availableRepresentations = waypoint.availableRepresentations()
+            
+            // Set the current index based on existing representation
+            var currentRep = waypoint.representation
+            if (currentRep !== "") {
+                var idx = availableRepresentations.indexOf(currentRep)
+                if (idx >= 0) {
+                    representationChoice.currentIndex = idx
+                    newRepresentation = currentRep
+                } else {
+                    // Default to coordinate notation (first option)
+                    representationChoice.currentIndex = 0
+                    newRepresentation = availableRepresentations[0]
+                }
+            } else {
+                // Default to coordinate notation (first option)
+                representationChoice.currentIndex = 0
+                newRepresentation = availableRepresentations[0]
+            }
+        } else {
+            // Coordinates are not valid - use text input mode
+            representationInput.text = waypoint.representation
+            newRepresentation = waypoint.representation
+        }
+        
         wpNameField.focus = true
+    }
+
+    // When the coordinates first become valid, replace the text input with a dropdown:
+    function updateRepresentationOptions() {
+        // Create a temporary waypoint with the current coordinates
+        var tempWaypoint = GeoMapProvider.createWaypoint()
+        tempWaypoint.coordinate = QtPositioning.coordinate(latInput.value, longInput.value, eleField.valueMeter)
+        
+        // Get available representations from C++
+        availableRepresentations = tempWaypoint.availableRepresentations()
+        
+        // Set to coordinate notation (first option) by default
+        representationChoice.currentIndex = 0
+        newRepresentation = availableRepresentations[0]
+    }
+
+    // After updating the coordinates of the waypoint, check if the current representation
+    // is still valid (only minor change in coordinates). If it is not, update the possible representations.
+    function checkAndUpdateRepresentations() {
+        // Only proceed if both coordinates are valid
+        if (!latInput.acceptableInput || !longInput.acceptableInput) {
+            return
+        }
+
+        // Create a temporary waypoint with the current coordinates
+        var tempWaypoint = GeoMapProvider.createWaypoint()
+        tempWaypoint.coordinate = QtPositioning.coordinate(latInput.value, longInput.value)
+        
+        // Get new available representations
+        availableRepresentations = tempWaypoint.availableRepresentations()
+        
+        // Check if current representation is still valid for the new coordinate
+        var currentRep = newRepresentation
+        var repIndex = tempWaypoint.representationIndex(currentRep)
+        
+        if (repIndex >= 0) {
+            // Keep the current representation if it's still valid
+            representationChoice.currentIndex = repIndex
+            newRepresentation = currentRep
+        } else {
+            // Otherwise, select coordinate notation (first option)
+            representationChoice.currentIndex = 0
+            newRepresentation = availableRepresentations[0]
+        }
     }
 
     DecoratedScrollView {
@@ -213,6 +290,22 @@ CenteringDialog {
                 value: waypoint.coordinate.latitude
                 minValue: -90.0
                 maxValue: 90.0
+                
+                onValueChanged: {
+                    if (!acceptableInput || !longInput.acceptableInput) {
+                        return
+                    }
+                    
+                    if (!coordinatesAreValid) {
+                        // Coordinates were invalid, now becoming valid
+                        coordinatesAreValid = true
+                        updateRepresentationOptions()
+                    } else {
+                        // Coordinates were already valid but changed
+                        // Check if current representation is still valid
+                        checkAndUpdateRepresentations()
+                    }
+                }
             }
 
             Label {
@@ -229,6 +322,22 @@ CenteringDialog {
                 value: waypoint.coordinate.longitude
                 minValue: -180.0
                 maxValue: 180.0
+                
+                onValueChanged: {
+                    if (!acceptableInput || !latInput.acceptableInput) {
+                        return
+                    }
+                    
+                    if (!coordinatesAreValid) {
+                        // Coordinates were invalid, now becoming valid
+                        coordinatesAreValid = true
+                        updateRepresentationOptions()
+                    } else {
+                        // Coordinates were already valid but changed
+                        // Check if current representation is still valid
+                        checkAndUpdateRepresentations()
+                    }
+                }
             }
 
 
@@ -356,6 +465,73 @@ CenteringDialog {
                 visible: (Qt.platform.os !== "ios")
 
                 model: [ qsTr("Feet"), qsTr("Meter") ]
+            }
+
+            Label {
+                Layout.alignment: Qt.AlignBaseline
+                Layout.columnSpan: 2
+            }
+
+            Label {
+                Layout.alignment: Qt.AlignBaseline
+                text: qsTr("Representation")
+            }
+
+            // Show ComboBox when coordinates are valid
+            ComboBox {
+                id: representationChoice
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignBaseline
+                Layout.rightMargin: 3
+                visible: coordinatesAreValid
+
+                model: availableRepresentations
+                
+                onCurrentIndexChanged: {
+                    if (currentIndex >= 0 && currentIndex < availableRepresentations.length) {
+                        newRepresentation = availableRepresentations[currentIndex]
+                    }
+                }
+            }
+
+            // Show text input when coordinates are not valid
+            MyTextField {
+                id: representationInput
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignBaseline
+                Layout.rightMargin: 3
+                visible: !coordinatesAreValid
+
+                placeholderText: qsTr("4602N07805W or DUB180040")
+                
+                onTextChanged: {
+                    // Parse the representation and update coordinates
+                    if (text.length > 0) {
+                        var parsedWaypoint = GeoMapProvider.parseWaypointString(text)
+                        if (parsedWaypoint.coordinate.isValid) {
+                            latInput.value = parsedWaypoint.coordinate.latitude
+                            longInput.value = parsedWaypoint.coordinate.longitude
+                            if (parsedWaypoint.coordinate.altitude !== 0) {
+                                eleField.valueMeter = parsedWaypoint.coordinate.altitude
+                            }
+                            newRepresentation = text
+                            
+                            // Update to show dropdown mode
+                            coordinatesAreValid = true
+                            
+                            // Get available representations from C++
+                            availableRepresentations = parsedWaypoint.availableRepresentations()
+                            
+                            // Select the current representation if it exists in the list
+                            var idx = availableRepresentations.indexOf(text)
+                            if (idx >= 0) {
+                                representationChoice.currentIndex = idx
+                            } else {
+                                representationChoice.currentIndex = 0
+                            }
+                        }
+                    }
+                }
             }
 
         }

--- a/src/qml/dialogs/WaypointEditor.qml
+++ b/src/qml/dialogs/WaypointEditor.qml
@@ -57,7 +57,7 @@ CenteringDialog {
         latInput.value = waypoint.coordinate.latitude
         longInput.value = waypoint.coordinate.longitude
         eleField.valueMeter = waypoint.coordinate.altitude
-        wpNameField.text = waypoint.extendedName
+        wpNameField.text = waypoint.name
         wpNotesField.text = waypoint.notes
         coordinatesAreValid = waypoint.coordinate.isValid
         
@@ -165,7 +165,7 @@ CenteringDialog {
                 Layout.alignment: Qt.AlignBaseline
                 Layout.minimumWidth: font.pixelSize*5
 
-                text: waypoint.extendedName
+                text: waypoint.name
 
                 focus: true
             }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -788,6 +788,9 @@ AppWindow {
     Label {
         id: toast
 
+        parent: Overlay.overlay
+        z: 10000
+
         width: Math.min(parent.width-4*view.font.pixelSize, 40*view.font.pixelSize)
         x: (parent.width-width)/2.0
         y: parent.height*(3.0/4.0)-height/2.0

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -899,6 +899,7 @@ Page {
             newWP.name = newName
             newWP.notes = newNotes
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
+            newWP.representation = newRepresentation
             Navigator.flightRoute.append(newWP)
             addbyCoordinates.close()
         }
@@ -971,6 +972,7 @@ Page {
             newWP.name = newName
             newWP.notes = newNotes
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
+            newWP.representation = newRepresentation
             Navigator.flightRoute.replaceWaypoint(index, newWP)
             wpEditor.close()
         }

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -748,6 +748,22 @@ Page {
 
         standardButtons: DialogButtonBox.Cancel
 
+        // Combine filtered waypoints with parsed waypoint (if valid)
+        function getWaypointList(text) {
+            var filteredWPs = GeoMapProvider.filteredWaypoints(text)
+            var parsedWP = GeoMapProvider.parseWaypointString(text)
+            
+            if (parsedWP.coordinate.isValid) {
+                // Add parsed waypoint to the beginning of the list
+                var combined = [parsedWP]
+                for (var i = 0; i < filteredWPs.length; i++) {
+                    combined.push(filteredWPs[i])
+                }
+                return combined
+            }
+            return filteredWPs
+        }
+
         Component {
             id: waypointDelegate
 
@@ -834,10 +850,10 @@ Page {
                 Timer {
                     id: debounceTimer
                     interval: 200 // 200ms
-                    onTriggered: wpList.model = GeoMapProvider.filteredWaypoints(textInput.displayText)
+                    onTriggered: wpList.model = flightRouteAddWPDialog.getWaypointList(textInput.displayText)
                 }
 
-                model: GeoMapProvider.filteredWaypoints(textInput.displayText)
+                model: flightRouteAddWPDialog.getWaypointList(textInput.displayText)
                 delegate: waypointDelegate
                 ScrollIndicator.vertical: ScrollIndicator {}
 

--- a/src/qml/pages/WaypointLibraryPage.qml
+++ b/src/qml/pages/WaypointLibraryPage.qml
@@ -466,6 +466,7 @@ Page {
             newWP.name = newName
             newWP.notes = newNotes
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
+            newWP.representation = newRepresentation
             WaypointLibrary.replace(waypoint, newWP)
             page.reloadWaypointList()
             toast.doToast(qsTr("Waypoint modified"))
@@ -483,6 +484,7 @@ Page {
             newWP.name = newName
             newWP.notes = newNotes
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
+            newWP.representation = newRepresentation
             WaypointLibrary.add(newWP)
             page.reloadWaypointList()
             toast.doToast(qsTr("Waypoint added"))


### PR DESCRIPTION
# Read/write waypoints by fix/bearing/distance

Waypoints may be written in the format REFBBBDDD, where
 - REF is a reference station (most likely, VOR)
 - BBB is the magnetic bearing from the station to the waypoint
 - DDD is the distance from station to waypoint (in nautical miles)

(For more information, see https://www.faa.gov/air_traffic/publications/atpubs/fss/AppendixA.htm (2) Significant Point)

When drawing up flight plans or verifying the flight plan with a paper map, I think this is much more readable than the coordinate representation.

I added functionality for reading from and writing to this radial representation (see `Waypoint.h`). These operations have two caveats:
1. The three letter reference station code is ambiguous. For example, `STG` may either be the Stuttgart DVOR-DME, [the Santiago (Spain) VOR-DME, the Santiago (Panama) VOR-DME or ...](https://ourairports.com/navaids/STG/). I think that displaying a separate input dialog for choosing the correct one would be too much. Instead, I apply heuristics to try and choose the correct one, which should be sufficient for our use case.
2. The bearing from the station is given as magnetic. Note that this has an impact on coordinate accuracy:
This point is located geographically exactly north of the Seida VOR in Norway:

<img width="628" height="1074" alt="image" src="https://github.com/user-attachments/assets/5ac8386a-fb60-4be4-839b-189e5ddead15" />

However, the magnetic bearing deviates by 15°. [Verifying the radial notation with online flight planning.](https://skyvector.com/?ll=70.2952064955459,28.067390454928493&chart=301&zoom=1&fpl=%20EFIV%20SDA%20SDA345006%20ENMH)

This caveat is also the reason why I implemented feature/magnetic initially.

_Note that "In areas of high latitude where it is determined by the appropriate authority that reference to degrees magnetic is impractical, degrees true may be used." However, this exceeds our use case (?)._

## User Interfacing
 - The user may create a waypoint from both "Add Waypoint to Route" dialogs directly by entering the (coordinate or radial) representation:
<img width="1256" height="1074" alt="image" src="https://github.com/user-attachments/assets/671ca8df-84e5-40e9-8a1f-9b22a2f4bb06" />

- For an existing waypoint, the user may choose a different representation (default: coordinate representation as-is):
<img width="628" height="1074" alt="Screenshot_20260413_103426" src="https://github.com/user-attachments/assets/0f42783a-4589-4ef9-9c44-eed2cdceda44" />

I personally think that a list of 16 items is too long, maybe we should reduce it?

- The default name of "Waypoint" is replaced by the chosen representation. This does not overwrite custom naming behavior. In my opinion, this helps with readability of routes:
<img width="1256" height="1074" alt="image" src="https://github.com/user-attachments/assets/7691960d-819b-4cdb-809e-f052396705e0" />