### PR TITLE
Reporting Point shows Name (NAM) instead of Radio Code (SCO)

### DIFF
--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -271,7 +271,7 @@ Map {
 
             layout: {
                 "icon-image": ["get", "CAT"],
-                "text-field": ["get", "NAM"],
+                "text-field": ["get", "SCO"],
                 "text-size": 0.85*GlobalSettings.fontSize,
                 "text-anchor": "top",
                 "text-offset": [0, 1],


### PR DESCRIPTION
When you fly to Italy, e.g. Lido/Venezia, there are all these Airspaces in the north of Italy, it is not easy. 
ATC uses Codes like "PSZ4" for the reporting points, while Enroute shows the Name like "CHIOGGIA" on the map, only in the details could you find this radio code. It makes it really difficult to navigate and communicate with ATC. 

Looking at the [documentation in the wiki](https://github.com/Akaflieg-Freiburg/enrouteServer/wiki/GeoJSON-files-used-in-enroute-flight-navigation#property-sco---required-for-cat--mrp-and-cat--rp) it specifies that SCO field should be shown, not NAM field. 

In any case i would like to see the Code of the reporting point like "PSZ4" in the Map. 