### PR TITLE
Sideview: add Route mode, Y/X scales, horizontal scrolling

### DIFF
--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ *   59 Temple Place - Suite 330, Boston, MA  02211-1307, USA.             *
  ***************************************************************************/
 
 import QtQuick
@@ -25,223 +25,459 @@ import QtQuick.Shapes
 import akaflieg_freiburg.enroute
 
 SideviewQuickItem {
-    id: rawSideView
+    id: sideViewRoot
 
     clip: true
     pixelPer10km: flightMap.pixelPer10km
 
+    // Feed the C++ backend the actual content width so it computes
+    // coordinates in the Flickable's content space.
+    renderWidth: flickable.contentWidth
+
+    // Full-area sky background (scale panels sit on top of it)
     Rectangle {
-        id: sky
         anchors.fill: parent
         color: "lightblue"
+        z: -1
     }
 
-    Shape {
-        id: shp
+    // -------------------------------------------------------------------------
+    // Unit helpers
+    // -------------------------------------------------------------------------
+    readonly property bool useFeet: Navigator.aircraft.verticalDistanceUnit === Aircraft.Feet
+    readonly property bool useNM:   Navigator.aircraft.horizontalDistanceUnit === Aircraft.NauticalMile
+    readonly property bool useSM:   Navigator.aircraft.horizontalDistanceUnit === Aircraft.StatuteMile
+    // km → display unit conversions
+    readonly property double kmToHDist: useNM ? 0.539957 : (useSM ? 0.621371 : 1.0)
+    readonly property string hDistUnit: useNM ? qsTr("NM") : (useSM ? qsTr("mi") : qsTr("km"))
+    // ft → display unit for altitude
+    readonly property double ftToVDist: useFeet ? 1.0 : 0.3048
+    readonly property string vDistUnit: useFeet ? qsTr("ft") : qsTr("m")
 
-        preferredRendererType: Shape.CurveRenderer
-        asynchronous: true
+    // -------------------------------------------------------------------------
+    // Y-axis scale (altitude) — fixed strip on the left, not scrolled
+    // -------------------------------------------------------------------------
+    readonly property int yScaleWidth: 54
+    readonly property int xScaleHeight: 20
 
-        ShapePath {
-            id: terrain
-            strokeWidth: -1
-            strokeColor: "saddlebrown"
-            fillColor: "brown"
+    Item {
+        id: yScalePanel
 
-            PathPolyline { path: rawSideView.terrain }
+        x: 0
+        y: 0
+        width: sideViewRoot.yScaleWidth
+        height: sideViewRoot.height - sideViewRoot.xScaleHeight
+        z: 20
+        clip: true
+
+        // Semi-transparent background
+        Rectangle {
+            anchors.fill: parent
+            color: "#99F0F0F0"
         }
 
-        ShapePath {
-            id: airspacesABorder
-            strokeWidth: 10
-            strokeColor: "#330000FF"
-            fillColor: "transparent"
+        // Tick marks and labels
+        Repeater {
+            id: yTicks
 
-            PathMultiline { paths: rawSideView.airspaces["A"] }
-        }
+            // Work in display units (ft or m)
+            readonly property double minDisp: sideViewRoot.scaleMinAltFt * sideViewRoot.ftToVDist
+            readonly property double maxDisp: sideViewRoot.scaleMaxAltFt * sideViewRoot.ftToVDist
+            readonly property double rangeH:  maxDisp - minDisp
 
-        ShapePath {
-            id: airspacesA
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["A"] }
-        }
-
-        ShapePath {
-            id: airspacesRBorder
-            strokeWidth: 10
-            strokeColor: "#33FF0000"
-            fillColor: "transparent"
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["R"] }
-        }
-
-        ShapePath {
-            id: airspacesR
-            strokeWidth: 2
-            strokeColor: "red"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["R"] }
-        }
-
-        ShapePath {
-            id: airspacesPJE
-            strokeWidth: 2
-            strokeColor: "red"
-            fillColor: "transparent"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-
-            PathMultiline { paths: rawSideView.airspaces["PJE"] }
-        }
-
-        ShapePath {
-            id: airspacesTMZ
-            strokeWidth: 2
-            strokeColor: "black"
-            fillColor: "transparent"
-            dashPattern: [4.0, 3.0, 0.5, 3.0]
-            strokeStyle: ShapePath.DashLine
-
-            PathMultiline { paths: rawSideView.airspaces["TMZ"] }
-        }
-
-        ShapePath {
-            id: airspacesNRABorder
-            strokeWidth: 10
-            strokeColor: "#3300FF00"
-            fillColor: "transparent"
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["NRA"] }
-        }
-
-        ShapePath {
-            id: airspacesNRA
-            strokeWidth: 2
-            strokeColor: "green"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["NRA"] }
-        }
-
-        ShapePath {
-            id: airspacesRMZ
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "#330000FF"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["RMZ"] }
-        }
-
-        ShapePath {
-            id: airspacesCTR
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "#33FF0000"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["CTR"] }
-        }
-
-        property double animatedFiveMinuteBarX: rawSideView.fiveMinuteBar.x
-        Behavior on animatedFiveMinuteBarX { NumberAnimation {duration: 1000} }
-        property double animatedFiveMinuteBarY: rawSideView.fiveMinuteBar.y
-        Behavior on animatedFiveMinuteBarY { NumberAnimation {duration: 1000} }
-
-        ShapePath {
-            id: fiveMinuteBar
-            strokeWidth: 3
-            strokeColor: "black"
-
-            startX: rawSideView.ownshipPosition.x
-            startY: rawSideView.ownshipPosition.y
-            PathLine {
-                relativeX: shp.animatedFiveMinuteBarX
-                relativeY: shp.animatedFiveMinuteBarY
+            // Pick a tick interval (in display units) giving roughly 4-8 ticks
+            readonly property double tickStep: {
+                var range = rangeH > 0 ? rangeH : 1000
+                var candidates = sideViewRoot.useFeet
+                    ? [100, 200, 500, 1000, 2000, 5000]
+                    : [50, 100, 200, 500, 1000, 2000]
+                for (var i = 0; i < candidates.length; i++) {
+                    if (range / candidates[i] <= 8) { return candidates[i] }
+                }
+                return candidates[candidates.length - 1]
             }
-        }
+            readonly property double firstTick: Math.ceil(minDisp / tickStep) * tickStep
+            readonly property int tickCount: rangeH > 0
+                ? Math.floor((maxDisp - firstTick) / tickStep) + 1
+                : 0
 
-        ShapePath {
-            id: fiveMinuteBar_1_2
-            strokeWidth: 2
-            strokeColor: "white"
+            model: (rangeH > 0 && tickCount > 0) ? tickCount : 0
 
-            startX: rawSideView.ownshipPosition.x + 0.2*shp.animatedFiveMinuteBarX
-            startY: rawSideView.ownshipPosition.y + 0.2*shp.animatedFiveMinuteBarY
-            PathLine {
-                relativeX: 0.2*shp.animatedFiveMinuteBarX
-                relativeY: 0.2*shp.animatedFiveMinuteBarY
-            }
-        }
+            delegate: Item {
+                required property int index
+                readonly property double altDisp: yTicks.firstTick + index * yTicks.tickStep
+                readonly property double frac: (altDisp - yTicks.minDisp) / yTicks.rangeH
+                readonly property double yPos: (1.0 - frac) * yScalePanel.height
 
-        ShapePath {
-            id: fiveMinuteBar_3_4
-            strokeWidth: 2
-            strokeColor: "white"
+                y: yPos - 7
+                x: 0
+                width: yScalePanel.width
+                height: 14
+                visible: yPos >= 0 && yPos <= yScalePanel.height
 
-            startX: rawSideView.ownshipPosition.x + 0.6*shp.animatedFiveMinuteBarX
-            startY: rawSideView.ownshipPosition.y + 0.6*shp.animatedFiveMinuteBarY
-            PathLine {
-                relativeX: 0.2*shp.animatedFiveMinuteBarX
-                relativeY: 0.2*shp.animatedFiveMinuteBarY
+                Rectangle {
+                    x: yScalePanel.width - 4
+                    y: 6
+                    width: 4
+                    height: 1
+                    color: "#80000000"
+                }
+
+                Label {
+                    x: 2; y: 0
+                    width: yScalePanel.width - 6
+                    height: 14
+                    text: qsTr("%1 %2").arg(Math.round(altDisp)).arg(sideViewRoot.vDistUnit)
+                    font.pixelSize: 9
+                    color: "#CC000000"
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideNone
+                }
             }
         }
     }
 
-    Image {
-        id: ownShip
+    // -------------------------------------------------------------------------
+    // X-axis scale (distance) — fixed strip at the bottom
+    // -------------------------------------------------------------------------
+    Item {
+        id: xScalePanel
 
-        x: rawSideView.ownshipPosition.x-width/2.0
-        y: rawSideView.ownshipPosition.y-height/2.0
-        rotation: {
-            if (shp.animatedFiveMinuteBarX > 2)
-            {
-                return 90 + 360*Math.atan( shp.animatedFiveMinuteBarY/shp.animatedFiveMinuteBarX )/(2*Math.PI)
-            }
-            return 90
+        x: sideViewRoot.yScaleWidth
+        y: sideViewRoot.height - sideViewRoot.xScaleHeight
+        width: sideViewRoot.width - sideViewRoot.yScaleWidth
+        height: sideViewRoot.xScaleHeight
+        z: 20
+        clip: true
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#99F0F0F0"
         }
 
-        source: {
-            var pInfo = PositionProvider.positionInfo
-            if (!pInfo.isValid()) {
-                return "/icons/self-noPosition.svg"
-            }
-            if (!pInfo.trueTrack().isFinite()) {
-                return "/icons/self-noDirection.svg"
-            }
-            return "/icons/self-withDirection.svg"
-        }
+        // Scrolling tick marks — shift opposite to Flickable.contentX
+        Item {
+            x: -flickable.contentX
+            width: flickable.contentWidth
+            height: xScalePanel.height
 
-        sourceSize.width: 25
-        sourceSize.height: 25
+            Repeater {
+                id: xTicks
+
+                readonly property double totalKm: sideViewRoot.scaleTotalDistKm
+                readonly property double contentW: flickable.contentWidth
+                readonly property bool isRouteMode: totalKm > 0
+
+                // distance (in display units) per pixel in content space
+                readonly property double dispPerPx: isRouteMode
+                    ? (totalKm * sideViewRoot.kmToHDist / contentW)
+                    : (10.0 * sideViewRoot.kmToHDist / sideViewRoot.pixelPer10km)
+
+                // pixels per display-unit
+                readonly property double pxPerDisp: dispPerPx > 0 ? 1.0 / dispPerPx : 0
+
+                // pick a nice tick interval (display units) giving ≥ 50 px between ticks
+                readonly property double tickDist: {
+                    if (pxPerDisp <= 0) { return 100 }
+                    var candidates = sideViewRoot.useNM
+                        ? [0.5, 1, 2, 5, 10, 20, 50, 100, 200]
+                        : [1, 2, 5, 10, 20, 50, 100, 200, 500]
+                    for (var i = 0; i < candidates.length; i++) {
+                        if (pxPerDisp * candidates[i] >= 50) { return candidates[i] }
+                    }
+                    return candidates[candidates.length - 1]
+                }
+
+                readonly property double totalDispShown: dispPerPx > 0 ? contentW * dispPerPx : 0
+                readonly property int tickCount: totalDispShown > 0
+                    ? Math.ceil(totalDispShown / tickDist) + 2
+                    : 0
+
+                model: tickCount
+
+                delegate: Item {
+                    required property int index
+                    // distance value this tick represents (in display units)
+                    readonly property double dist: {
+                        if (xTicks.isRouteMode) {
+                            return index * xTicks.tickDist
+                        }
+                        // track mode: pixel x=0 is 0.2*contentW*dispPerPx behind ownship
+                        var startDisp = -0.2 * xTicks.contentW * xTicks.dispPerPx
+                        return Math.ceil(startDisp / xTicks.tickDist) * xTicks.tickDist
+                               + index * xTicks.tickDist
+                    }
+                    readonly property double xPos: xTicks.isRouteMode
+                        ? (xTicks.pxPerDisp > 0 ? dist * xTicks.pxPerDisp : 0)
+                        : (xTicks.pxPerDisp > 0
+                           ? (dist + 0.2 * xTicks.contentW * xTicks.dispPerPx) * xTicks.pxPerDisp
+                           : 0)
+
+                    x: xPos - 1
+                    y: 0
+                    width: 2
+                    height: xScalePanel.height
+                    visible: xPos >= 0 && xPos <= xTicks.contentW
+
+                    Rectangle {
+                        x: 0; y: 0; width: 1; height: 4
+                        color: "#80000000"
+                    }
+
+                    Label {
+                        x: 2; y: 2
+                        font.pixelSize: 9
+                        color: "#CC000000"
+                        text: {
+                            var v = sideViewRoot.useNM
+                                    ? dist.toFixed(1)
+                                    : Math.round(dist)
+                            return xTicks.isRouteMode
+                                ? qsTr("%1 %2").arg(v).arg(sideViewRoot.hDistUnit)
+                                : (dist >= 0
+                                   ? qsTr("+%1 %2").arg(v).arg(sideViewRoot.hDistUnit)
+                                   : qsTr("%1 %2").arg(v).arg(sideViewRoot.hDistUnit))
+                        }
+                    }
+                }
+            }
+        }
     }
 
+    // -------------------------------------------------------------------------
+    // Flickable — horizontal scrolling for the content area
+    // -------------------------------------------------------------------------
+    Flickable {
+        id: flickable
+
+        x: sideViewRoot.yScaleWidth
+        y: 0
+        width: sideViewRoot.width - sideViewRoot.yScaleWidth
+        height: sideViewRoot.height - sideViewRoot.xScaleHeight
+
+        contentWidth: width * zoomFactor
+        contentHeight: height
+
+        flickableDirection: Flickable.HorizontalFlick
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+
+        property real zoomFactor: 1.0
+
+        Shape {
+            id: shp
+
+            width: flickable.contentWidth
+            height: flickable.contentHeight
+
+            preferredRendererType: Shape.CurveRenderer
+            asynchronous: true
+
+            ShapePath {
+                id: terrain
+                strokeWidth: -1
+                strokeColor: "saddlebrown"
+                fillColor: "brown"
+
+                PathPolyline { path: sideViewRoot.terrain }
+            }
+
+            ShapePath {
+                id: airspacesABorder
+                strokeWidth: 10
+                strokeColor: "#330000FF"
+                fillColor: "transparent"
+
+                PathMultiline { paths: sideViewRoot.airspaces["A"] }
+            }
+
+            ShapePath {
+                id: airspacesA
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "transparent"
+
+                PathMultiline { paths: sideViewRoot.airspaces["A"] }
+            }
+
+            ShapePath {
+                id: airspacesRBorder
+                strokeWidth: 10
+                strokeColor: "#33FF0000"
+                fillColor: "transparent"
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: sideViewRoot.airspaces["R"] }
+            }
+
+            ShapePath {
+                id: airspacesR
+                strokeWidth: 2
+                strokeColor: "red"
+                fillColor: "transparent"
+
+                PathMultiline { paths: sideViewRoot.airspaces["R"] }
+            }
+
+            ShapePath {
+                id: airspacesPJE
+                strokeWidth: 2
+                strokeColor: "red"
+                fillColor: "transparent"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+
+                PathMultiline { paths: sideViewRoot.airspaces["PJE"] }
+            }
+
+            ShapePath {
+                id: airspacesTMZ
+                strokeWidth: 2
+                strokeColor: "black"
+                fillColor: "transparent"
+                dashPattern: [4.0, 3.0, 0.5, 3.0]
+                strokeStyle: ShapePath.DashLine
+
+                PathMultiline { paths: sideViewRoot.airspaces["TMZ"] }
+            }
+
+            ShapePath {
+                id: airspacesNRABorder
+                strokeWidth: 10
+                strokeColor: "#3300FF00"
+                fillColor: "transparent"
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: sideViewRoot.airspaces["NRA"] }
+            }
+
+            ShapePath {
+                id: airspacesNRA
+                strokeWidth: 2
+                strokeColor: "green"
+                fillColor: "transparent"
+
+                PathMultiline { paths: sideViewRoot.airspaces["NRA"] }
+            }
+
+            ShapePath {
+                id: airspacesRMZ
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "#330000FF"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: sideViewRoot.airspaces["RMZ"] }
+            }
+
+            ShapePath {
+                id: airspacesCTR
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "#33FF0000"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: sideViewRoot.airspaces["CTR"] }
+            }
+
+            property double animatedFiveMinuteBarX: sideViewRoot.fiveMinuteBar.x
+            Behavior on animatedFiveMinuteBarX { NumberAnimation {duration: 1000} }
+            property double animatedFiveMinuteBarY: sideViewRoot.fiveMinuteBar.y
+            Behavior on animatedFiveMinuteBarY { NumberAnimation {duration: 1000} }
+
+            ShapePath {
+                id: fiveMinuteBar
+                strokeWidth: 3
+                strokeColor: "black"
+
+                startX: sideViewRoot.ownshipPosition.x
+                startY: sideViewRoot.ownshipPosition.y
+                PathLine {
+                    relativeX: shp.animatedFiveMinuteBarX
+                    relativeY: shp.animatedFiveMinuteBarY
+                }
+            }
+
+            ShapePath {
+                id: fiveMinuteBar_1_2
+                strokeWidth: 2
+                strokeColor: "white"
+
+                startX: sideViewRoot.ownshipPosition.x + 0.2*shp.animatedFiveMinuteBarX
+                startY: sideViewRoot.ownshipPosition.y + 0.2*shp.animatedFiveMinuteBarY
+                PathLine {
+                    relativeX: 0.2*shp.animatedFiveMinuteBarX
+                    relativeY: 0.2*shp.animatedFiveMinuteBarY
+                }
+            }
+
+            ShapePath {
+                id: fiveMinuteBar_3_4
+                strokeWidth: 2
+                strokeColor: "white"
+
+                startX: sideViewRoot.ownshipPosition.x + 0.6*shp.animatedFiveMinuteBarX
+                startY: sideViewRoot.ownshipPosition.y + 0.6*shp.animatedFiveMinuteBarY
+                PathLine {
+                    relativeX: 0.2*shp.animatedFiveMinuteBarX
+                    relativeY: 0.2*shp.animatedFiveMinuteBarY
+                }
+            }
+        }
+
+        Image {
+            id: ownShip
+
+            x: sideViewRoot.ownshipPosition.x-width/2.0
+            y: sideViewRoot.ownshipPosition.y-height/2.0
+            rotation: {
+                if (shp.animatedFiveMinuteBarX > 2)
+                {
+                    return 90 + 360*Math.atan( shp.animatedFiveMinuteBarY/shp.animatedFiveMinuteBarX )/(2*Math.PI)
+                }
+                return 90
+            }
+
+            source: {
+                var pInfo = PositionProvider.positionInfo
+                if (!pInfo.isValid()) {
+                    return "/icons/self-noPosition.svg"
+                }
+                if (!pInfo.trueTrack().isFinite()) {
+                    return "/icons/self-noDirection.svg"
+                }
+                return "/icons/self-withDirection.svg"
+            }
+
+            sourceSize.width: 25
+            sourceSize.height: 25
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Labels (outside Flickable — anchored to the visible area)
+    // -------------------------------------------------------------------------
     Label {
         id: trackLabel
 
-        x: rawSideView.width*0.1
-        text: rawSideView.track
-        visible: rawSideView.track !== ""
+        x: sideViewRoot.yScaleWidth + flickable.width*0.1
+        text: sideViewRoot.track
+        visible: sideViewRoot.track !== ""
     }
 
     Label {
         id: errorLabel
 
         anchors.centerIn: parent
+        anchors.horizontalCenterOffset: sideViewRoot.yScaleWidth / 2.0
 
-        text: rawSideView.error
-        visible: rawSideView.error !== ""
-        width: 0.66*rawSideView.width
+        text: sideViewRoot.error
+        visible: sideViewRoot.error !== ""
+        width: 0.66*sideViewRoot.width
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
 
@@ -262,6 +498,77 @@ SideviewQuickItem {
                                    }
                                    )
             dialogLoader.active = true
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Zoom buttons — Route mode only
+    // -------------------------------------------------------------------------
+    Column {
+        id: zoomButtons
+
+        anchors.right: modeToggle.left
+        anchors.top:   parent.top
+        anchors.margins: 4
+        spacing: 2
+        z: 10
+
+        visible: sideViewRoot.mode === SideviewQuickItem.Route
+
+        RoundButton {
+            width:  28; height: 28; padding: 0
+            text: "+"
+            font.pixelSize: 16
+            opacity: 0.85
+            enabled: flickable.zoomFactor < 8.0
+            onClicked: flickable.zoomFactor = Math.min(8.0, flickable.zoomFactor * 2.0)
+        }
+
+        RoundButton {
+            width:  28; height: 28; padding: 0
+            text: "−"
+            font.pixelSize: 16
+            opacity: 0.85
+            enabled: flickable.zoomFactor > 1.0
+            onClicked: {
+                flickable.zoomFactor = Math.max(1.0, flickable.zoomFactor / 2.0)
+                if (flickable.contentWidth <= flickable.width) {
+                    flickable.contentX = 0
+                }
+            }
+        }
+    }
+
+    // Mode toggle button — rendered last so it sits above all other children
+    RoundButton {
+        id: modeToggle
+
+        anchors.right:   parent.right
+        anchors.top:     parent.top
+        anchors.margins: 4
+        z: 10
+
+        width:  32
+        height: 32
+        padding: 0
+
+        text: sideViewRoot.mode === SideviewQuickItem.Route ? "✈" : "⇢"
+        font.pixelSize: 16
+        opacity: 0.85
+
+        ToolTip.text: sideViewRoot.mode === SideviewQuickItem.Route
+                      ? qsTr("Showing planned route – tap for current track")
+                      : qsTr("Showing current track – tap for planned route")
+        ToolTip.visible: hovered
+
+        onClicked: {
+            if (sideViewRoot.mode === SideviewQuickItem.Route) {
+                sideViewRoot.mode = SideviewQuickItem.Track
+                flickable.zoomFactor = 1.0
+                flickable.contentX = 0
+            } else {
+                sideViewRoot.mode = SideviewQuickItem.Route
+            }
         }
     }
 }

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -21,35 +21,54 @@
 #include "GeoMapProvider.h"
 #include "PositionProvider.h"
 #include "SideviewQuickItem.h"
+#include "navigation/Navigator.h"
 #include "weather/WeatherDataProvider.h"
 
 using namespace Qt::Literals::StringLiterals;
 
-QStringList airspaceCategories = {"ATZ", "TMZ", "RMZ", "TIA", "TIZ", "NRA", "DNG", "D", "C", "B", "A", "CTR", "R", "P", "PJE", "SUA"};
+QStringList airspaceCategories = {u"ATZ"_s, u"TMZ"_s, u"RMZ"_s, u"TIA"_s, u"TIZ"_s,
+                                   u"NRA"_s, u"DNG"_s, u"D"_s, u"C"_s, u"B"_s, u"A"_s,
+                                   u"CTR"_s, u"R"_s, u"P"_s, u"PJE"_s, u"SUA"_s};
 
 
 Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
     : QQuickItem(parent), m_baroCache(new Navigation::BaroCache(this))
 {
     m_timer.setSingleShot(true);
-    connect(&m_timer, &QTimer::timeout, this, &Ui::SideviewQuickItem::updateProperties);
-    connect(GlobalObject::weatherDataProvider(), &Weather::WeatherDataProvider::QNHInfoChanged, this, &Ui::SideviewQuickItem::updateProperties);
+    connect(&m_timer, &QTimer::timeout, this, &SideviewQuickItem::updateProperties);
+    connect(GlobalObject::weatherDataProvider(), &Weather::WeatherDataProvider::QNHInfoChanged,
+            this, &SideviewQuickItem::updateProperties);
 
     notifiers.push_back(bindableHeight().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(bindableWidth().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(GlobalObject::positionProvider()->bindablePositionInfo().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(GlobalObject::positionProvider()->bindablePressureAltitude().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(m_pixelPer10km.addNotifier([this]() {updateProperties();}));
-    updateProperties();   
+    notifiers.push_back(m_renderWidth.addNotifier([this]() { emit renderWidthChanged(); updateProperties(); }));
+    notifiers.push_back(m_scaleMaxAltFt.addNotifier([this]() { emit scaleRangeChanged(); }));
+    notifiers.push_back(m_scaleMinAltFt.addNotifier([this]() { emit scaleRangeChanged(); }));
+    notifiers.push_back(m_scaleTotalDistKm.addNotifier([this]() { emit scaleRangeChanged(); }));
+
+    // React to route changes when in Route mode
+    notifiers.push_back(GlobalObject::navigator()->flightRoute()->bindableGeoPath().addNotifier([this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    }));
+
+    updateProperties();
+}
+
+void Ui::SideviewQuickItem::setMode(Mode newMode)
+{
+    if (m_mode == newMode) { return; }
+    m_mode = newMode;
+    emit modeChanged();
+    updateProperties();
 }
 
 void Ui::SideviewQuickItem::updateProperties()
 {
-    // Rate-limiting code. Ensure that this expensive method runs at most every minimumUpdateInterval_ms and not more often.
-    if (m_timer.isActive())
-    {
-        return;
-    }
+    // Rate-limiting: at most once every minimumUpdateInterval_ms
+    if (m_timer.isActive()) { return; }
     if (m_elapsedTimer.isValid())
     {
         auto elapsed = (int)m_elapsedTimer.elapsed();
@@ -61,43 +80,132 @@ void Ui::SideviewQuickItem::updateProperties()
     }
     m_elapsedTimer.start();
 
-    //
-    // Set all properties to default values. We update those depending on the data we have available.
-    //
-    const QScopedPropertyUpdateGroup updateLock;
-    m_fiveMinuteBar = {0, 0};
-    m_ownshipPosition = {-100, -100};
-    m_track = QString();
-    m_error = QString();
-    m_terrain = QPolygonF();
+    if (m_mode == Mode::Route)
+    {
+        updatePropertiesRoute();
+    }
+    else
+    {
+        updatePropertiesTrack();
+    }
+}
 
-    QVariantMap newAirspaces;
+
+// ---------------------------------------------------------------------------
+// Shared helper: build airspace polygons along a sampled geo-path
+// ---------------------------------------------------------------------------
+QVariantMap Ui::SideviewQuickItem::buildAirspacePolygons(
+    const QList<int>& xCoordinates,
+    const QList<QGeoCoordinate>& geoCoordinates,
+    const QList<Units::Distance>& elevations,
+    Units::Distance ownshipGeometricAltitude,
+    Units::Distance ownshipPressureAltitude,
+    std::function<double(Units::Distance)> altToY)
+{
     const QVector<QPolygonF> empty;
-    newAirspaces[u"A"_s] = QVariant::fromValue(empty);
+    QVariantMap result;
+    result[u"A"_s]   = QVariant::fromValue(empty);
+    result[u"CTR"_s] = QVariant::fromValue(empty);
+    result[u"R"_s]   = QVariant::fromValue(empty);
+    result[u"RMZ"_s] = QVariant::fromValue(empty);
+    result[u"NRA"_s] = QVariant::fromValue(empty);
+    result[u"PJE"_s] = QVariant::fromValue(empty);
+    result[u"TMZ"_s] = QVariant::fromValue(empty);
+
+    auto QNH = GlobalObject::weatherDataProvider()->QNH();
+    if (!QNH.isFinite()) { return result; }
+
+    QVector<QPolygonF> polyA, polyCTR, polyR, polyRMZ, polyNRA, polyPJE, polyTMZ;
+
+    auto airspaces = GlobalObject::geoMapProvider()->airspaces();
+    QGeoRectangle const viewBBox(QList({geoCoordinates.constFirst(), geoCoordinates.constLast()}));
+
+    for (const auto& airspace : std::as_const(airspaces))
+    {
+        if (!airspaceCategories.contains(airspace.CAT())) { continue; }
+        if (!airspace.polygon().boundingGeoRectangle().intersects(viewBBox)) { continue; }
+
+        QList<QPointF> upper, lower;
+        auto airspacePolygon = airspace.polygon();
+
+        for (int i = 0; i < xCoordinates.size(); i++)
+        {
+            auto x = xCoordinates[i];
+            const auto& gc = geoCoordinates[i];
+            if ((i != xCoordinates.size()-1) && airspacePolygon.contains(gc))
+            {
+                auto u = airspace.estimatedUpperBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
+                auto l = airspace.estimatedLowerBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
+                if (l < u)
+                {
+                    upper << QPointF(x, altToY(u));
+                    lower << QPointF(x, altToY(l));
+                    continue;
+                }
+            }
+
+            if (!upper.isEmpty())
+            {
+                std::reverse(lower.begin(), lower.end());
+                QPolygonF poly(upper + lower);
+                poly << upper[0];
+
+                auto cat = airspace.CAT();
+                if (cat == u"A"_s || cat == u"B"_s || cat == u"C"_s || cat == u"D"_s) { polyA   << poly; }
+                if (cat == u"CTR"_s)                                                   { polyCTR << poly; }
+                if (cat == u"R"_s  || cat == u"P"_s  || cat == u"DNG"_s)              { polyR   << poly; }
+                if (cat == u"ATZ"_s|| cat == u"RMZ"_s|| cat == u"TIA"_s|| cat == u"TIZ"_s) { polyRMZ << poly; }
+                if (cat == u"NRA"_s)                                                   { polyNRA << poly; }
+                if (cat == u"PJE"_s|| cat == u"SUA"_s)                                { polyPJE << poly; }
+                if (cat == u"TMZ"_s)                                                   { polyTMZ << poly; }
+
+                upper.clear();
+                lower.clear();
+            }
+        }
+    }
+
+    result[u"A"_s]   = QVariant::fromValue(polyA);
+    result[u"CTR"_s] = QVariant::fromValue(polyCTR);
+    result[u"R"_s]   = QVariant::fromValue(polyR);
+    result[u"RMZ"_s] = QVariant::fromValue(polyRMZ);
+    result[u"NRA"_s] = QVariant::fromValue(polyNRA);
+    result[u"PJE"_s] = QVariant::fromValue(polyPJE);
+    result[u"TMZ"_s] = QVariant::fromValue(polyTMZ);
+    return result;
+}
+
+
+// ---------------------------------------------------------------------------
+// Mode::Track  — original logic, unchanged except extracted to own method
+// ---------------------------------------------------------------------------
+void Ui::SideviewQuickItem::updatePropertiesTrack()
+{
+    const QScopedPropertyUpdateGroup updateLock;
+    m_fiveMinuteBar    = {0, 0};
+    m_ownshipPosition  = {-100, -100};
+    m_track            = QString();
+    m_error            = QString();
+    m_terrain          = QPolygonF();
+
+    const QVector<QPolygonF> empty;
+    QVariantMap newAirspaces;
+    newAirspaces[u"A"_s]   = QVariant::fromValue(empty);
     newAirspaces[u"CTR"_s] = QVariant::fromValue(empty);
-    newAirspaces[u"R"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"R"_s]   = QVariant::fromValue(empty);
     newAirspaces[u"RMZ"_s] = QVariant::fromValue(empty);
     newAirspaces[u"NRA"_s] = QVariant::fromValue(empty);
     newAirspaces[u"PJE"_s] = QVariant::fromValue(empty);
     newAirspaces[u"TMZ"_s] = QVariant::fromValue(empty);
     m_airspaces = newAirspaces;
 
-    // If the side view is really small, safe CPU cycles by doing nothing
-    if (height() < 5.0)
-    {
-        return;
-    }
-
-    // If zoom is totally out of range, then exit
+    if (height() < 5.0) { return; }
     if (!qIsFinite(m_pixelPer10km) || (m_pixelPer10km < 5.0))
     {
         m_error = tr("Unable to show side view: Zoom value out of range.");
         return;
     }
 
-    //
-    // Get data required in the drawing
-    //
     auto ownshipCoordinate = Positioning::PositionProvider::lastValidCoordinate();
     if (!ownshipCoordinate.isValid())
     {
@@ -122,11 +230,7 @@ void Ui::SideviewQuickItem::updateProperties()
         ownshipTrack = Positioning::PositionProvider::lastValidTT();
         if (ownshipTrack.isFinite())
         {
-            m_track = u"Direction → %1°"_s.arg( qRound(ownshipTrack.toDEG()));
-        }
-        else
-        {
-            m_track = QString();
+            m_track = u"Direction → %1°"_s.arg(qRound(ownshipTrack.toDEG()));
         }
     }
     if (!ownshipTrack.isFinite())
@@ -135,6 +239,7 @@ void Ui::SideviewQuickItem::updateProperties()
         m_track = QString();
         return;
     }
+
     auto ownshipGeometricAltitude = Units::Distance::fromM(ownshipCoordinate.altitude());
     if (!ownshipGeometricAltitude.isFinite())
     {
@@ -157,86 +262,59 @@ void Ui::SideviewQuickItem::updateProperties()
         m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because the QNH is not available. Please wait while QNH information is downloaded from the internet.");
         return;
     }
-    if (ownshipTerrainElevation.isFinite())
+    if (ownshipTerrainElevation.isFinite() && ownshipGeometricAltitude < ownshipTerrainElevation)
     {
-        if (ownshipGeometricAltitude < ownshipTerrainElevation)
-        {
-            ownshipGeometricAltitude = ownshipTerrainElevation;
-        }
+        ownshipGeometricAltitude = ownshipTerrainElevation;
     }
-    Units::Speed ownshipHSpeed;
-    Units::Speed ownshipVSpeed;
+
+    Units::Speed ownshipHSpeed, ownshipVSpeed;
     if (ownshipPositionInfo.isValid())
     {
         ownshipHSpeed = ownshipPositionInfo.groundSpeed();
         ownshipVSpeed = ownshipPositionInfo.verticalSpeed();
         if (!ownshipHSpeed.isFinite() || (ownshipHSpeed < Units::Speed::fromKN(10)))
         {
-            // If horizontal speed is low, vertical speed info is typically too jittery to be
-            // useful. We just ignore it then.
             ownshipVSpeed = {};
         }
     }
 
-    //
-    // Compute array of x-coordinates in pixels.
-    //
-    const int step = 4.0;
+    const double renderW = rw();
+    const int step = 4;
     QList<int> xCoordinates;
-    xCoordinates.reserve( qRound((width()+20)/step) );
-    for(int x = -10; x <= width()+10; x += step)
-    {
-        xCoordinates << x;
-    }
+    xCoordinates.reserve(qRound((renderW+20)/step));
+    for (int x = -10; x <= renderW+10; x += step) { xCoordinates << x; }
 
-    //
-    // For each x-coordinate, compute the associated QGeoCoordinate
-    //
     QList<QGeoCoordinate> geoCoordinates;
     geoCoordinates.reserve(xCoordinates.size());
-    for(auto x : std::as_const(xCoordinates))
+    for (auto x : std::as_const(xCoordinates))
     {
-        auto dist = 10000.0*(x-0.2*width())/(m_pixelPer10km.value());
-        auto geoCoordinate = ownshipCoordinate.atDistanceAndAzimuth(dist, ownshipTrack.toDEG());
-        geoCoordinates << geoCoordinate;
+        auto dist = 10000.0*(x - 0.2*renderW) / m_pixelPer10km.value();
+        geoCoordinates << ownshipCoordinate.atDistanceAndAzimuth(dist, ownshipTrack.toDEG());
     }
 
-    // For each geoCoordinate, compute the elevation
     QList<Units::Distance> elevations;
     elevations.reserve(geoCoordinates.size());
     Units::Distance minElevation = ownshipTerrainElevation;
     Units::Distance maxElevation = ownshipTerrainElevation;
-    for(const auto& geoCoordinate : std::as_const(geoCoordinates))
+    for (const auto& gc : std::as_const(geoCoordinates))
     {
-        auto elevation = GlobalObject::geoMapProvider()->terrainElevationAMSL(geoCoordinate);
-        if (!elevation.isFinite())
+        auto elev = GlobalObject::geoMapProvider()->terrainElevationAMSL(gc);
+        if (!elev.isFinite())
         {
-            elevation = Units::Distance::fromM(0.0);
+            elev = Units::Distance::fromM(0.0);
             m_error = tr("Incomplete terrain data. Please install the relevant terrain maps.");
         }
-        elevations << elevation;
-        if (elevation < minElevation)
-        {
-            minElevation = elevation;
-        }
-        if (elevation > maxElevation)
-        {
-            maxElevation = elevation;
-        }
+        elevations << elev;
+        minElevation = qMin(minElevation, elev);
+        maxElevation = qMax(maxElevation, elev);
     }
 
-    //
-    // Compute minimum and maximum altitude shown in the QML item,
-    // generate function altToYCoordinate() that computes pixel the coordinate from the altitude.
-    //
     auto sideview_minAlt = ownshipGeometricAltitude;
     auto sideview_maxAlt = ownshipGeometricAltitude;
     if (ownshipPositionInfo.verticalSpeed().isFinite())
     {
-        sideview_maxAlt += qMax(Units::Distance::fromFT(3000.0),
-                                Units::Distance::fromFT(ownshipPositionInfo.verticalSpeed().toFPM()*7.5));
-        sideview_minAlt += qMin(Units::Distance::fromFT(-3000.0),
-                                Units::Distance::fromFT(ownshipPositionInfo.verticalSpeed().toFPM()*7.5));
+        sideview_maxAlt += qMax(Units::Distance::fromFT(3000.0), Units::Distance::fromFT(ownshipPositionInfo.verticalSpeed().toFPM()*7.5));
+        sideview_minAlt += qMin(Units::Distance::fromFT(-3000.0), Units::Distance::fromFT(ownshipPositionInfo.verticalSpeed().toFPM()*7.5));
     }
     else
     {
@@ -244,123 +322,270 @@ void Ui::SideviewQuickItem::updateProperties()
         sideview_minAlt += Units::Distance::fromFT(-3000.0);
     }
     sideview_minAlt = qMax(sideview_minAlt, minElevation - Units::Distance::fromFT(100));
-    auto altToYCoordinate = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt)
-    {
-        return ((double)height())*(sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
+
+    auto altToY = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt) {
+        return ((double)height()) * (sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
     };
 
-    //
-    // Compute graphics data
-    //
+    m_scaleMinAltFt  = sideview_minAlt.toFeet();
+    m_scaleMaxAltFt  = sideview_maxAlt.toFeet();
+    m_scaleTotalDistKm = 0.0;
 
-    // Ownship position
-    m_ownshipPosition = {width()*0.2, altToYCoordinate(ownshipGeometricAltitude)};
+    m_ownshipPosition = {renderW*0.2, altToY(ownshipGeometricAltitude)};
 
-    // 5-Minute-Bar
     if (ownshipVSpeed.isFinite() && ownshipHSpeed.isFinite())
     {
-        m_fiveMinuteBar = {m_pixelPer10km.value()*(ownshipHSpeed.toMPS()*5*60)/10000, -height()*ownshipVSpeed.toFPM()*5.0/((sideview_maxAlt - sideview_minAlt).toFeet())};
+        m_fiveMinuteBar = {m_pixelPer10km.value()*(ownshipHSpeed.toMPS()*5*60)/10000,
+                           -height()*ownshipVSpeed.toFPM()*5.0/((sideview_maxAlt - sideview_minAlt).toFeet())};
     }
 
-    // Terrain
     QPolygonF polygon;
-    polygon.reserve( elevations.size()+4 );
-    for(qsizetype i = 0; i < elevations.size(); i++)
+    polygon.reserve(elevations.size() + 4);
+    for (qsizetype i = 0; i < elevations.size(); i++)
     {
-        polygon << QPointF(xCoordinates[i], altToYCoordinate(elevations[i]));
+        polygon << QPointF(xCoordinates[i], altToY(elevations[i]));
     }
-    polygon  << QPointF(width(), height()+2000) << QPointF(-20, height()+2000);
+    polygon << QPointF(renderW, height()+2000) << QPointF(-20, height()+2000);
     m_terrain = polygon;
-    //qWarning() << "SideviewQuickItem terrain" << m_elapsedTimer.elapsed();
 
-    // Airspaces
-    auto airspaces = GlobalObject::geoMapProvider()->airspaces();
-    QVector<QPolygonF> airspacePolygonsA;
-    QVector<QPolygonF> airspacePolygonsCTR;
-    QVector<QPolygonF> airspacePolygonsR;
-    QVector<QPolygonF> airspacePolygonsRMZ;
-    QVector<QPolygonF> airspacePolygonsNRA;
-    QVector<QPolygonF> airspacePolygonsPJE;
-    QVector<QPolygonF> airspacePolygonsTMZ;
-    QList<QPointF> upper;
-    QList<QPointF> lower;
-    QGeoRectangle const viewBBox(QList({geoCoordinates.constFirst(), geoCoordinates.constLast()}));
-    for(const auto& airspace : std::as_const(airspaces))
+    m_airspaces = buildAirspacePolygons(xCoordinates, geoCoordinates, elevations,
+                                         ownshipGeometricAltitude, ownshipPressureAltitude, altToY);
+}
+
+
+// ---------------------------------------------------------------------------
+// Mode::Route  — terrain/airspaces along the planned flight route
+// ---------------------------------------------------------------------------
+void Ui::SideviewQuickItem::updatePropertiesRoute()
+{
+    const QScopedPropertyUpdateGroup updateLock;
+    m_fiveMinuteBar   = {0, 0};
+    m_ownshipPosition = {-100, -100};
+    m_track           = QString();
+    m_error           = QString();
+    m_terrain         = QPolygonF();
+
+    const QVector<QPolygonF> empty;
+    QVariantMap newAirspaces;
+    newAirspaces[u"A"_s]   = QVariant::fromValue(empty);
+    newAirspaces[u"CTR"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"R"_s]   = QVariant::fromValue(empty);
+    newAirspaces[u"RMZ"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"NRA"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"PJE"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"TMZ"_s] = QVariant::fromValue(empty);
+    m_airspaces = newAirspaces;
+
+    if (height() < 5.0) { return; }
+
+    // -----------------------------------------------------------------------
+    // 1. Get the planned route
+    // -----------------------------------------------------------------------
+    auto geoPath = GlobalObject::navigator()->flightRoute()->geoPath();
+    if (geoPath.size() < 2)
     {
-        if (!airspaceCategories.contains(airspace.CAT()))
-        {
-            continue;
-        }
-        auto bbox = airspace.polygon().boundingGeoRectangle();
-        if (!bbox.intersects(viewBBox))
-        {
-            continue;
-        }
+        m_error = tr("Unable to show side view: No flight route. Please plan a route first.");
+        return;
+    }
 
-        auto airspacePolygon = airspace.polygon();
-        for(int i=0; i < xCoordinates.size(); i++)
+    // -----------------------------------------------------------------------
+    // 2. Build cumulative distance table along the route polyline
+    //    cumulativeDist[i] = distance from geoPath[0] to geoPath[i], in metres
+    // -----------------------------------------------------------------------
+    QList<double> cumulativeDist;
+    cumulativeDist.reserve(geoPath.size());
+    cumulativeDist << 0.0;
+    for (qsizetype i = 1; i < geoPath.size(); i++)
+    {
+        cumulativeDist << cumulativeDist.last() + geoPath[i-1].distanceTo(geoPath[i]);
+    }
+    const double totalRouteLen = cumulativeDist.last();
+    if (totalRouteLen < 1.0)
+    {
+        m_error = tr("Unable to show side view: Flight route is too short.");
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Helper: given a distance along the route, return the QGeoCoordinate
+    //    by linear interpolation between the nearest waypoints.
+    // -----------------------------------------------------------------------
+    auto coordAtDist = [&](double distM) -> QGeoCoordinate
+    {
+        distM = qBound(0.0, distM, totalRouteLen);
+        // Find the leg that contains distM
+        qsizetype seg = 0;
+        for (qsizetype i = 1; i < cumulativeDist.size(); i++)
         {
-            auto x = xCoordinates[i];
-            const auto& geoCoordinate = geoCoordinates[i];
-            if ((i != xCoordinates.size()-1) && airspacePolygon.contains(geoCoordinate))
+            if (cumulativeDist[i] >= distM)
             {
-                auto u = airspace.estimatedUpperBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
-                auto l = airspace.estimatedLowerBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
-                if (l < u)
-                {
-                    upper << QPointF(x, altToYCoordinate(u));
-                    lower << QPointF(x, altToYCoordinate(l));
-                    continue;
-                }
+                seg = i - 1;
+                break;
             }
+            seg = i - 1; // last segment
+        }
+        double segLen = cumulativeDist[seg+1] - cumulativeDist[seg];
+        if (segLen < 0.01) { return geoPath[seg]; }
+        double t = (distM - cumulativeDist[seg]) / segLen;
+        double az = geoPath[seg].azimuthTo(geoPath[seg+1]);
+        return geoPath[seg].atDistanceAndAzimuth(t * segLen, az);
+    };
 
-            if (!upper.isEmpty())
+    // -----------------------------------------------------------------------
+    // 4. Sample the route at pixel resolution
+    //    Each pixel column x maps to a distance proportional along the route.
+    // -----------------------------------------------------------------------
+    const double renderW = rw();
+    const int step = 4;
+    QList<int> xCoordinates;
+    xCoordinates.reserve(qRound((renderW+20)/step));
+    for (int x = -10; x <= renderW+10; x += step) { xCoordinates << x; }
+
+    QList<QGeoCoordinate> geoCoordinates;
+    geoCoordinates.reserve(xCoordinates.size());
+    for (auto x : std::as_const(xCoordinates))
+    {
+        double fraction = (double)x / renderW;
+        geoCoordinates << coordAtDist(fraction * totalRouteLen);
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Sample terrain elevations
+    // -----------------------------------------------------------------------
+    QList<Units::Distance> elevations;
+    elevations.reserve(geoCoordinates.size());
+    Units::Distance minElevation = Units::Distance::fromM(0.0);
+    Units::Distance maxElevation = Units::Distance::fromM(0.0);
+    bool firstElev = true;
+    for (const auto& gc : std::as_const(geoCoordinates))
+    {
+        auto elev = GlobalObject::geoMapProvider()->terrainElevationAMSL(gc);
+        if (!elev.isFinite())
+        {
+            elev = Units::Distance::fromM(0.0);
+            m_error = tr("Incomplete terrain data. Please install the relevant terrain maps.");
+        }
+        elevations << elev;
+        if (firstElev) { minElevation = maxElevation = elev; firstElev = false; }
+        else { minElevation = qMin(minElevation, elev); maxElevation = qMax(maxElevation, elev); }
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Determine vertical extent of the view
+    //    Centre vertically around the terrain + a comfortable margin above.
+    // -----------------------------------------------------------------------
+    Units::Distance sideview_minAlt = minElevation - Units::Distance::fromFT(200);
+    Units::Distance sideview_maxAlt = maxElevation + Units::Distance::fromFT(4000);
+
+    auto altToY = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt) {
+        return ((double)height()) * (sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
+    };
+
+    m_scaleMinAltFt    = sideview_minAlt.toFeet();
+    m_scaleMaxAltFt    = sideview_maxAlt.toFeet();
+    m_scaleTotalDistKm = totalRouteLen / 1000.0;
+
+    // -----------------------------------------------------------------------
+    // 7. Terrain polygon
+    // -----------------------------------------------------------------------
+    QPolygonF polygon;
+    polygon.reserve(elevations.size() + 4);
+    for (qsizetype i = 0; i < elevations.size(); i++)
+    {
+        polygon << QPointF(xCoordinates[i], altToY(elevations[i]));
+    }
+    polygon << QPointF(renderW, height()+2000) << QPointF(-10, height()+2000);
+    m_terrain = polygon;
+
+    // -----------------------------------------------------------------------
+    // 8. Ownship position — project current GPS fix onto the route polyline
+    //    by finding the closest point along all legs.
+    // -----------------------------------------------------------------------
+    auto ownshipCoordinate = Positioning::PositionProvider::lastValidCoordinate();
+    auto ownshipGeometricAltitude = Units::Distance::fromM(0.0);
+    auto ownshipPressureAltitude  = Units::Distance::fromM(0.0);
+
+    if (ownshipCoordinate.isValid())
+    {
+        // Find the leg with minimum perpendicular distance to ownship
+        double bestDistM = std::numeric_limits<double>::max();
+        double bestAlongRouteM = 0.0;
+
+        for (qsizetype i = 0; i+1 < geoPath.size(); i++)
+        {
+            // Project ownship onto this leg segment
+            double legLen = geoPath[i].distanceTo(geoPath[i+1]);
+            if (legLen < 1.0) { continue; }
+
+            double az      = geoPath[i].azimuthTo(geoPath[i+1]);
+            double azOwn   = geoPath[i].azimuthTo(ownshipCoordinate);
+            double distFromStart = geoPath[i].distanceTo(ownshipCoordinate);
+            double angleDiff = (azOwn - az) * M_PI / 180.0;
+            double along = distFromStart * std::cos(angleDiff);
+            along = qBound(0.0, along, legLen);
+
+            QGeoCoordinate projected = geoPath[i].atDistanceAndAzimuth(along, az);
+            double perp = projected.distanceTo(ownshipCoordinate);
+
+            if (perp < bestDistM)
             {
-                std::reverse(lower.begin(), lower.end());
-                QPolygonF polygon(upper + lower);
-                polygon << upper[0];
-                if ((airspace.CAT() == u"A"_s) || (airspace.CAT() == u"B"_s) || (airspace.CAT() == u"C"_s) || (airspace.CAT() == u"D"_s))
-                {
-                    airspacePolygonsA << polygon;
-                }
-                if (airspace.CAT() == u"CTR"_s)
-                {
-                    airspacePolygonsCTR << polygon;
-                }
-                if ((airspace.CAT() == u"R"_s) || (airspace.CAT() == u"P"_s) || (airspace.CAT() == u"DNG"_s))
-                {
-                    airspacePolygonsR << polygon;
-                }
-                if ((airspace.CAT() == u"ATZ"_s) || (airspace.CAT() == u"RMZ"_s) || (airspace.CAT() == u"TIA"_s) || (airspace.CAT() == u"TIZ"_s))
-                {
-                    airspacePolygonsRMZ << polygon;
-                }
-                if (airspace.CAT() == u"NRA"_s)
-                {
-                    airspacePolygonsNRA << polygon;
-                }
-                if ((airspace.CAT() == u"PJE"_s) || (airspace.CAT() == u"SUA"_s))
-                {
-                    airspacePolygonsPJE << polygon;
-                }
-                if (airspace.CAT() == u"TMZ"_s)
-                {
-                    airspacePolygonsTMZ << polygon;
-                }
-                upper.clear();
-                lower.clear();
+                bestDistM = perp;
+                bestAlongRouteM = cumulativeDist[i] + along;
+            }
+        }
+
+        double ownX = (bestAlongRouteM / totalRouteLen) * renderW;
+
+        ownshipGeometricAltitude = Units::Distance::fromM(ownshipCoordinate.altitude());
+        if (!ownshipGeometricAltitude.isFinite()) { ownshipGeometricAltitude = minElevation; }
+
+        ownshipPressureAltitude = GlobalObject::positionProvider()->pressureAltitude();
+        if (!ownshipPressureAltitude.isFinite())
+        {
+            ownshipPressureAltitude = m_baroCache->estimatedPressureAltitude(ownshipGeometricAltitude);
+        }
+        if (!ownshipPressureAltitude.isFinite())
+        {
+            ownshipPressureAltitude = ownshipGeometricAltitude;
+            m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because barometric altitude information is not available. <a href='xx'>Click here</a> for more information.");
+        }
+
+        // Clamp to terrain
+        auto ownTerrainElev = GlobalObject::geoMapProvider()->terrainElevationAMSL(ownshipCoordinate);
+        if (ownTerrainElev.isFinite() && ownshipGeometricAltitude < ownTerrainElev)
+        {
+            ownshipGeometricAltitude = ownTerrainElev;
+        }
+
+        double ownY = altToY(ownshipGeometricAltitude);
+        m_ownshipPosition = {ownX, ownY};
+
+        // 5-minute bar: use current speed/vspeed projected along the route
+        auto posInfo = GlobalObject::positionProvider()->positionInfo();
+        if (posInfo.isValid())
+        {
+            auto hSpeed = posInfo.groundSpeed();
+            auto vSpeed = posInfo.verticalSpeed();
+            if (hSpeed.isFinite() && hSpeed >= Units::Speed::fromKN(10) && vSpeed.isFinite())
+            {
+                double dxPixels = (hSpeed.toMPS() * 5.0 * 60.0 / totalRouteLen) * renderW;
+                double dyPixels = -height() * vSpeed.toFPM() * 5.0 / (sideview_maxAlt - sideview_minAlt).toFeet();
+                m_fiveMinuteBar = {dxPixels, dyPixels};
             }
         }
     }
 
-    newAirspaces[u"A"_s] = QVariant::fromValue(airspacePolygonsA);
-    newAirspaces[u"CTR"_s] = QVariant::fromValue(airspacePolygonsCTR);
-    newAirspaces[u"R"_s] = QVariant::fromValue(airspacePolygonsR);
-    newAirspaces[u"RMZ"_s] = QVariant::fromValue(airspacePolygonsRMZ);
-    newAirspaces[u"NRA"_s] = QVariant::fromValue(airspacePolygonsNRA);
-    newAirspaces[u"PJE"_s] = QVariant::fromValue(airspacePolygonsPJE);
-    newAirspaces[u"TMZ"_s] = QVariant::fromValue(airspacePolygonsTMZ);
-
-    m_airspaces = newAirspaces;
-    //qWarning() << "SideviewQuickItem full" << m_elapsedTimer.elapsed();
+    // -----------------------------------------------------------------------
+    // 9. Airspace polygons
+    // -----------------------------------------------------------------------
+    if (!GlobalObject::weatherDataProvider()->QNH().isFinite())
+    {
+        m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because the QNH is not available. Please wait while QNH information is downloaded from the internet.");
+        // Still show terrain — don't return early
+    }
+    else
+    {
+        m_airspaces = buildAirspacePolygons(xCoordinates, geoCoordinates, elevations,
+                                             ownshipGeometricAltitude, ownshipPressureAltitude, altToY);
+    }
 }

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -42,6 +42,14 @@ class SideviewQuickItem : public QQuickItem
     QML_NAMED_ELEMENT(SideviewQuickItem)
 
 public:
+
+    /*! \brief Display mode for the side view */
+    enum class Mode {
+        Track, /*!< Show terrain/airspaces along current position and track (default) */
+        Route  /*!< Show terrain/airspaces along the planned flight route */
+    };
+    Q_ENUM(Mode)
+
     explicit SideviewQuickItem(QQuickItem *parent = nullptr);
 
     ~SideviewQuickItem() override = default;
@@ -83,6 +91,16 @@ public:
      */
     Q_PROPERTY(QPointF fiveMinuteBar READ fiveMinuteBar BINDABLE bindableFiveMinuteBar)
 
+    /*! \brief Display mode
+     *
+     * Controls whether the side view is computed along the current track
+     * (Mode::Track, default) or along the planned flight route (Mode::Route).
+     * In Route mode the ownship marker is placed at the aircraft's projected
+     * position along the route; the horizontal extent of the view covers the
+     * full route from first to last waypoint.
+     */
+    Q_PROPERTY(Mode mode READ mode WRITE setMode NOTIFY modeChanged)
+
     /*! \brief Position of the own aircraft
      *
      * This property holds the position of the own aircraft, in pixel
@@ -96,6 +114,22 @@ public:
      * flightmap in order to synchronize the scales.
      */
     Q_PROPERTY(double pixelPer10km READ pixelPer10km WRITE setPixelPer10km BINDABLE bindablePixelPer10km REQUIRED)
+
+    /*! \brief Width (in pixels) used for horizontal coordinate computation.
+     *
+     * Set this to the Flickable contentWidth to enable horizontal scrolling.
+     * When ≤ 0 the item's own width() is used instead.
+     */
+    Q_PROPERTY(double renderWidth READ renderWidth WRITE setRenderWidth NOTIFY renderWidthChanged)
+
+    /*! \brief Maximum altitude shown on the Y axis, in feet */
+    Q_PROPERTY(double scaleMaxAltFt READ scaleMaxAltFt NOTIFY scaleRangeChanged)
+
+    /*! \brief Minimum altitude shown on the Y axis, in feet */
+    Q_PROPERTY(double scaleMinAltFt READ scaleMinAltFt NOTIFY scaleRangeChanged)
+
+    /*! \brief Total route length shown on the X axis, in kilometres (0 in Track mode) */
+    Q_PROPERTY(double scaleTotalDistKm READ scaleTotalDistKm NOTIFY scaleRangeChanged)
 
     /*! \brief Terrain polygons
      *
@@ -117,128 +151,87 @@ public:
     // Getter and Setter Methods
     //
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property airspaces
-     */
     QVariantMap airspaces() const {return m_airspaces.value();}
-
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property airspaces
-     */
     QBindable<QVariantMap> bindableAirspaces() const {return &m_airspaces;}
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property error
-     */
     QString error() const {return m_error.value();}
-
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property error
-     */
     QBindable<QString> bindableError() const {return &m_error;}
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property fiveMinuteBar
-     */
     QPointF fiveMinuteBar() const {return m_fiveMinuteBar.value();}
-
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property fiveMinuteBar
-     */
     QBindable<QPointF> bindableFiveMinuteBar() const {return &m_fiveMinuteBar;}
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property ownshipPosition
-     */
-    QPointF ownshipPosition() const {return m_ownshipPosition.value();}
+    Mode mode() const { return m_mode; }
+    void setMode(Mode newMode);
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property ownshipPosition
-     */
+    QPointF ownshipPosition() const {return m_ownshipPosition.value();}
     QBindable<QPointF> bindableOwnshipPosition() const {return &m_ownshipPosition;}
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property pixelPer10km
-     */
     double pixelPer10km() const {return m_pixelPer10km.value();}
-
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property pixelPer10km
-     */
     QBindable<double> bindablePixelPer10km() {return &m_pixelPer10km;}
-
-    /*! \brief Getter method for property with the same name
-     *
-     *  @param newVal Property pixelPer10km
-     */
     void setPixelPer10km(double newVal) {m_pixelPer10km = newVal;}
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property track
-     */
-    QString track() const {return m_track.value();}
+    double renderWidth() const { auto v = m_renderWidth.value(); return v > 0 ? v : width(); }
+    void setRenderWidth(double v) { m_renderWidth = v; }
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property track
-     */
+    double scaleMaxAltFt() const { return m_scaleMaxAltFt.value(); }
+    double scaleMinAltFt() const { return m_scaleMinAltFt.value(); }
+    double scaleTotalDistKm() const { return m_scaleTotalDistKm.value(); }
+
+    QString track() const {return m_track.value();}
     QBindable<QString> bindableTrack() const {return &m_track;}
 
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property terrain
-     */
     QPolygonF terrain() const {return m_terrain.value();}
-
-    /*! \brief Getter method for property with the same name
-     *
-     *  @returns Property terrain
-     */
     QBindable<QPolygonF> bindableTerrain() const {return &m_terrain;}
 
+signals:
+    void modeChanged();
+    void renderWidthChanged();
+    void scaleRangeChanged();
 
 private:
     Q_DISABLE_COPY_MOVE(SideviewQuickItem)
 
-    // Timers used for rate-limiting, used to ensure that the expensive method
-    // updateProperties() runs at most every minimumUpdateInterval_ms.
+    // Timers used for rate-limiting
     QElapsedTimer m_elapsedTimer;
     QTimer m_timer;
     static constexpr int minimumUpdateInterval_ms = 700;
 
-    // Compute
     void updateProperties();
+    void updatePropertiesTrack();
+    void updatePropertiesRoute();
 
+    // Returns renderWidth if set, else actual item width.
+    double rw() const { auto v = m_renderWidth.value(); return v > 0 ? v : width(); }
+
+    // Shared helper: build airspace polygons along a sampled geo-path.
+    // xCoordinates and geoCoordinates must be the same length.
+    // elevations must be the same length.
+    // Returns a QVariantMap with the same keys as m_airspaces.
+    QVariantMap buildAirspacePolygons(
+        const QList<int>& xCoordinates,
+        const QList<QGeoCoordinate>& geoCoordinates,
+        const QList<Units::Distance>& elevations,
+        Units::Distance ownshipGeometricAltitude,
+        Units::Distance ownshipPressureAltitude,
+        std::function<double(Units::Distance)> altToY);
+
+    Mode m_mode {Mode::Track};
 
     QProperty<QString> m_error;
-
     QProperty<QString> m_track;
-
     QProperty<double> m_pixelPer10km;
-
     QProperty<QPointF> m_ownshipPosition;
-
     QProperty<QPointF> m_fiveMinuteBar;
-
     QProperty<QPolygonF> m_terrain;
-
     QProperty<QVariantMap> m_airspaces;
+    QProperty<double> m_renderWidth   {0.0};
+    QProperty<double> m_scaleMaxAltFt {0.0};
+    QProperty<double> m_scaleMinAltFt {0.0};
+    QProperty<double> m_scaleTotalDistKm {0.0};
 
     Navigation::BaroCache* m_baroCache;
 
     std::vector<QPropertyNotifier> notifiers;
-
 };
 
 } // namespace Ui


### PR DESCRIPTION
Implements planned-route side view alongside the existing track-based view, plus altitude/distance axis scales and zoomable horizontal scrolling for the route view.

Route mode (SideviewQuickItem::Mode::Route):
- Terrain and airspaces sampled along the full planned flight route rather than ahead of the current track.
- Ownship marker projected onto the nearest route leg.
- 5-minute bar scaled proportionally to route length.
- Mode toggle button (✈ / ⇢) in the top-right corner switches modes.

Axis scales:
- Y axis (left panel, 54 px): altitude ticks in the aircraft's configured vertical unit (ft or m), auto-spaced to 4-8 ticks.
- X axis (bottom panel, 20 px): distance ticks in the aircraft's configured horizontal unit (NM, km, or mi), scrolls with content.

Horizontal scrolling / zoom (Route mode only):
- Flickable wraps the content area; contentWidth = width × zoomFactor.
- + / − buttons double/halve the zoom (1× – 8×); hidden in Track mode.
- C++ renderWidth property lets the backend compute coordinates in content space so terrain and airspaces stay correctly positioned.
- Switching back to Track mode resets zoom and scroll position.

New C++ properties on SideviewQuickItem:
- renderWidth (writable): used instead of width() for X coordinate computation; defaults to actual item width when ≤ 0.
- scaleMinAltFt / scaleMaxAltFt: altitude range set each update.
- scaleTotalDistKm: total route length (Route mode) or 0 (Track mode).