### PR TITLE
FlightMap: show METAR flight-category color dots on map

### DIFF
--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -936,4 +936,39 @@ Map {
         delegate: waypointComponent
     }
 
+    // METAR flight-category color dots
+    ObserverList {
+        id: metarObservers
+    }
+
+    MapItemView {
+        model: metarObservers.observers
+        delegate: Component {
+            MapQuickItem {
+                id: metarDot
+
+                coordinate: modelData.waypoint.coordinate
+
+                anchorPoint.x: 6
+                anchorPoint.y: 6
+
+                Connections {
+                    target: flightMap
+                    function onHeightChanged() { metarDot.polishAndUpdate() }
+                }
+
+                sourceItem: Rectangle {
+                    width:  12
+                    height: 12
+                    radius: 6
+                    color: modelData.metar.isValid ? modelData.metar.flightCategoryColor : "transparent"
+                    border.color: "white"
+                    border.width: 1.5
+                    visible: modelData.metar.isValid
+                             && modelData.metar.flightCategoryColor !== "transparent"
+                }
+            }
+        }
+    }
+
 } // End of FlightMap


### PR DESCRIPTION
Each weather station that has a valid METAR is now marked with a colored dot directly on the moving map:

  green  → VFR   (ceiling > 3000 ft, vis > 5 SM)
  yellow → MVFR  (marginal VFR)
  red    → IFR / LIFR

Stations whose METAR has no flight-category field are not shown.

Implementation: an ObserverList (same type used by the Weather page) feeds a MapItemView; each observer becomes a MapQuickItem with a 12 × 12 px circle anchored to the station coordinate. The circle color is bound directly to metar.flightCategoryColor and the dot is hidden when the category is unknown.