### PR TITLE
SideviewQuickItem: add Route mode, axis scales, and horizontal scrolling

### DIFF
--- a/src/navigation/Aircraft.cpp
+++ b/src/navigation/Aircraft.cpp
@@ -233,6 +233,7 @@ QString Navigation::Aircraft::loadFromJSON(const QByteArray &JSON)
     }
 
     setCabinPressureEqualsStaticPressure( content[QStringLiteral("cabinPressureEqualsStaticPressure")].toBool(false) );
+    setCruiseAltitude( Units::Distance::fromM( content[QStringLiteral("cruiseAltitude_m")].toDouble(NAN) ));
     setCruiseSpeed( Units::Speed::fromMPS( content[QStringLiteral("cruiseSpeed_mps")].toDouble(NAN) ));
     setDescentSpeed( Units::Speed::fromMPS( content[QStringLiteral("descentSpeed_mps")].toDouble(NAN) ));
     setFuelConsumption( Units::VolumeFlow::fromLPH( content[QStringLiteral("fuelConsumption_lph")].toDouble(NAN) ));
@@ -274,6 +275,7 @@ QByteArray Navigation::Aircraft::toJSON() const
     jsonObj.insert(QStringLiteral("content"), "aircraft");
 
     jsonObj.insert(QStringLiteral("cabinPressureEqualsStaticPressure"), m_cabinPressureEqualsStaticPressure);
+    jsonObj.insert(QStringLiteral("cruiseAltitude_m"), m_cruiseAltitude.toM());
     jsonObj.insert(QStringLiteral("cruiseSpeed_mps"), m_cruiseSpeed.toMPS());
     jsonObj.insert(QStringLiteral("descentSpeed_mps"), m_descentSpeed.toMPS());
     jsonObj.insert(QStringLiteral("fuelConsumption_lph"), m_fuelConsumption.toLPH());

--- a/src/navigation/Aircraft.h
+++ b/src/navigation/Aircraft.h
@@ -78,6 +78,17 @@ public:
     /*! \brief Preferred units of measurement for vertical distances */
     Q_PROPERTY(bool cabinPressureEqualsStaticPressure READ cabinPressureEqualsStaticPressure WRITE setCabinPressureEqualsStaticPressure)
 
+    /*! \brief Default cruise altitude
+     *
+     * This property holds the default planned cruise altitude of the aircraft.
+     * It is used as the fallback when a route waypoint has no explicit planned
+     * altitude set. The value is NaN if no default has been set.
+     */
+    Q_PROPERTY(Units::Distance cruiseAltitude READ cruiseAltitude WRITE setCruiseAltitude)
+
+    /*! \brief Default cruise altitude in meters (NaN if not set), for QML use */
+    Q_PROPERTY(double cruiseAltitudeM READ cruiseAltitudeM WRITE setCruiseAltitudeM)
+
     /*! \brief Cruise Speed
      *
      * This property holds the cruise speed of the aircraft. This lies in the interval [minAircraftSpeed,
@@ -161,6 +172,18 @@ public:
 
     /*! \brief Getter function for property of the same name
      *
+     * @returns Property cruiseAltitude (NaN if not set)
+     */
+    [[nodiscard]] Units::Distance cruiseAltitude() const { return m_cruiseAltitude; }
+
+    /*! \brief Getter function for property of the same name
+     *
+     * @returns Property cruiseAltitudeM (NaN if not set)
+     */
+    [[nodiscard]] double cruiseAltitudeM() const { return m_cruiseAltitude.toM(); }
+
+    /*! \brief Getter function for property of the same name
+     *
      * @returns Property descentSpeed
      */
     [[nodiscard]] Units::Speed descentSpeed() const { return m_descentSpeed; }
@@ -227,6 +250,18 @@ public:
      * @param newSpeed Property cruise speed
      */
     void setCruiseSpeed(Units::Speed newSpeed);
+
+    /*! \brief Setter function for property of the same name
+     *
+     * @param newAltitude Default cruise altitude (NaN to clear)
+     */
+    void setCruiseAltitude(Units::Distance newAltitude) { m_cruiseAltitude = newAltitude; }
+
+    /*! \brief Setter function for property of the same name
+     *
+     * @param altitudeM Default cruise altitude in meters (NaN to clear)
+     */
+    void setCruiseAltitudeM(double altitudeM) { m_cruiseAltitude = Units::Distance::fromM(altitudeM); }
 
     /*! \brief Setter function for property of the same name
      *
@@ -415,6 +450,7 @@ private:
     static constexpr Units::VolumeFlow maxValidFuelConsumption = Units::VolumeFlow::fromLPH(300.0);
 
     bool m_cabinPressureEqualsStaticPressure {false};
+    Units::Distance m_cruiseAltitude {};
     Units::Speed m_cruiseSpeed {};
     Units::Speed m_descentSpeed {};
     Units::VolumeFlow m_fuelConsumption {};

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -429,6 +429,26 @@ auto Navigation::FlightRoute::load(const QString& fileName) -> QString
         }
     }
     m_waypoints = newWaypoints;
+
+    // Planned altitudes are stored as a top-level object in our own GeoJSON
+    // files. Read them back if present (other formats simply have none).
+    m_plannedAltitudes.clear();
+    {
+        QFile jsonFile(myFileName);
+        if (jsonFile.open(QIODevice::ReadOnly))
+        {
+            auto doc = QJsonDocument::fromJson(jsonFile.readAll());
+            if (doc.isObject())
+            {
+                auto altObj = doc.object().value(QStringLiteral("plannedAltitudes")).toObject();
+                for (auto it = altObj.constBegin(); it != altObj.constEnd(); ++it)
+                {
+                    m_plannedAltitudes.insert(it.key(), it.value().toDouble());
+                }
+            }
+        }
+    }
+    emit plannedAltitudesChanged();
     return {};
 }
 
@@ -499,6 +519,46 @@ void Navigation::FlightRoute::reverse()
     auto newWaypoints = m_waypoints.value();
     std::reverse(newWaypoints.begin(), newWaypoints.end());
     m_waypoints = newWaypoints;
+}
+
+QString Navigation::FlightRoute::waypointKey(const GeoMaps::Waypoint& waypoint)
+{
+    auto icao = waypoint.ICAOCode();
+    if (!icao.isEmpty())
+    {
+        return icao;
+    }
+    auto coord = waypoint.coordinate();
+    return u"%1,%2"_s.arg(coord.latitude(), 0, 'f', 6).arg(coord.longitude(), 0, 'f', 6);
+}
+
+double Navigation::FlightRoute::plannedAltitude(int idx) const
+{
+    const auto wps = m_waypoints.value();
+    if ((idx < 0) || (idx >= wps.size()))
+    {
+        return qQNaN();
+    }
+    return m_plannedAltitudes.value(waypointKey(wps.at(idx)), qQNaN());
+}
+
+void Navigation::FlightRoute::setPlannedAltitude(int idx, double altitudeM)
+{
+    const auto wps = m_waypoints.value();
+    if ((idx < 0) || (idx >= wps.size()))
+    {
+        return;
+    }
+    auto key = waypointKey(wps.at(idx));
+    if (qIsNaN(altitudeM))
+    {
+        m_plannedAltitudes.remove(key);
+    }
+    else
+    {
+        m_plannedAltitudes.insert(key, altitudeM);
+    }
+    emit plannedAltitudesChanged();
 }
 
 auto Navigation::FlightRoute::save(const QString& fileName) const -> QString
@@ -609,10 +669,30 @@ auto Navigation::FlightRoute::toGeoJSON() const -> QByteArray
         }
     }
 
+    // Planned altitudes, owned by the route. Pruned to the keys of the current
+    // valid waypoints.
+    QJsonObject plannedAltitudes;
+    foreach(const auto& waypoint, m_waypoints.value())
+    {
+        if (!waypoint.isValid())
+        {
+            continue;
+        }
+        auto key = waypointKey(waypoint);
+        if (m_plannedAltitudes.contains(key))
+        {
+            plannedAltitudes.insert(key, m_plannedAltitudes.value(key));
+        }
+    }
+
     QJsonObject jsonObj;
     jsonObj.insert(QStringLiteral("type"), "FeatureCollection");
     jsonObj.insert(QStringLiteral("enroute"), GeoMaps::GeoJSON::indicatorFlightRoute());
     jsonObj.insert(QStringLiteral("features"), waypointArray);
+    if (!plannedAltitudes.isEmpty())
+    {
+        jsonObj.insert(QStringLiteral("plannedAltitudes"), plannedAltitudes);
+    }
 
     QJsonDocument doc;
     doc.setObject(jsonObj);

--- a/src/navigation/FlightRoute.h
+++ b/src/navigation/FlightRoute.h
@@ -329,6 +329,27 @@ namespace Navigation
         /*! \brief Reverse the route */
         Q_INVOKABLE void reverse();
 
+        /*! \brief Planned cruise altitude at a route waypoint
+         *
+         * The planned altitude is owned by the route (keyed by waypoint
+         * identity), not stored on the waypoint itself.
+         *
+         * @param idx Index of the waypoint in waypoints()
+         *
+         * @returns Planned altitude in meters AMSL, or NaN if none has been set
+         * for this waypoint.
+         */
+        [[nodiscard]] Q_INVOKABLE double plannedAltitude(int idx) const;
+
+        /*! \brief Set the planned cruise altitude at a route waypoint
+         *
+         * @param idx Index of the waypoint in waypoints()
+         *
+         * @param altitudeM Planned altitude in meters AMSL, or NaN to clear the
+         * value (so that the waypoint falls back to the default).
+         */
+        Q_INVOKABLE void setPlannedAltitude(int idx, double altitudeM);
+
         /*! \brief Saves flight route to a file
          *
          * This method saves the flight route as a GeoJSON file.  The file
@@ -408,6 +429,9 @@ namespace Navigation
         /*! \brief Notification signal for the property with the same name */
         void summaryChanged();
 
+        /*! \brief Notification signal, emitted when a planned altitude changes */
+        void plannedAltitudesChanged();
+
     private slots:
 
     private:
@@ -415,6 +439,14 @@ namespace Navigation
 
         // Helper function for method toGPX
         [[nodiscard]] auto gpxElements(const QString& indent, const QString& tag) const -> QString;
+
+        // Stable identity key for a waypoint, used to key m_plannedAltitudes so
+        // that planned altitudes follow their waypoint across reordering.
+        [[nodiscard]] static QString waypointKey(const GeoMaps::Waypoint& waypoint);
+
+        // Planned cruise altitudes, owned by the route. Keyed by waypointKey(),
+        // value is altitude in meters AMSL.
+        QMap<QString, double> m_plannedAltitudes;
 
         QProperty<QList<QGeoCoordinate>> m_geoPath;
         QList<QGeoCoordinate> computeGeoPath();

--- a/src/navigation/Navigator.cpp
+++ b/src/navigation/Navigator.cpp
@@ -86,6 +86,7 @@ Navigation::FlightRoute* Navigation::Navigator::flightRoute()
         m_flightRoute = new FlightRoute(this);
         m_flightRoute->load(m_flightRouteFileName);
         connect(m_flightRoute, &Navigation::FlightRoute::waypointsChanged, this, [this]() {if (m_flightRoute != nullptr) {(void)m_flightRoute->save(m_flightRouteFileName);}});
+        connect(m_flightRoute, &Navigation::FlightRoute::plannedAltitudesChanged, this, [this]() {if (m_flightRoute != nullptr) {(void)m_flightRoute->save(m_flightRouteFileName);}});
         QQmlEngine::setObjectOwnership(m_flightRoute, QQmlEngine::CppOwnership);
     }
     return m_flightRoute;

--- a/src/qml/items/ElevationInput.qml
+++ b/src/qml/items/ElevationInput.qml
@@ -26,8 +26,12 @@ import QtQuick.Layouts
 // Set currentIndex to 0 for "feet" and 1 for "meter"
 
 StackLayout {
+    id: elevationInput
 
     property double valueMeter: NaN
+
+    // Emitted when the user confirms the input with the Enter/Return key.
+    signal accepted()
 
     function setTexts() {
         if (isNaN(valueMeter)) {
@@ -38,6 +42,17 @@ StackLayout {
 
         ft_d.text = Math.round(valueMeter*3.281)
         m_d.text = Math.round(valueMeter)
+    }
+
+    // Commit the currently-visible field's text into valueMeter. Call this
+    // before reading valueMeter when the user may not have pressed Enter (e.g.
+    // when accepting a dialog by clicking OK).
+    function commit() {
+        if (currentIndex === 1) {
+            valueMeter = m_d.acceptableInput ? Number.fromLocaleString(Qt.locale(), m_d.text) : NaN
+        } else {
+            valueMeter = ft_d.acceptableInput ? Number.fromLocaleString(Qt.locale(), ft_d.text)/3.281 : NaN
+        }
     }
 
     Component.onCompleted: setTexts()
@@ -68,6 +83,7 @@ StackLayout {
                 else
                     valueMeter = NaN
             }
+            onAccepted: elevationInput.accepted()
         }
         Label {
             id: colorGlean
@@ -98,6 +114,7 @@ StackLayout {
                 else
                     valueMeter = NaN
             }
+            onAccepted: elevationInput.accepted()
         }
         Label { text: "m" }
     }

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -796,7 +796,7 @@ Map {
     MapPolyline {
         id: flightPath
         line.width: 4
-        line.color: "#ff00ff"
+        line.color: Global.flightRouteColor
         path: {
             var array = []
             //Looks weird, but is necessary. geoPath is an 'object' not an array

--- a/src/qml/items/Global.qml
+++ b/src/qml/items/Global.qml
@@ -35,6 +35,10 @@ Item {
     property vac currentVAC
     property vac defaultVAC
 
+    // Color used to draw the planned flight route, both on the moving map and
+    // in the sideview planned-altitude profile.
+    readonly property color flightRouteColor: "#ff00ff"
+
     //
     // GUI Warnings
     //

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -20,9 +20,11 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Shapes
 
 import akaflieg_freiburg.enroute
+import "../dialogs"
 
 SideviewQuickItem {
     id: rawSideView
@@ -427,6 +429,52 @@ SideviewQuickItem {
                     relativeY: 0.2*shp.animatedFiveMinuteBarY
                 }
             }
+
+            // Planned cruise-altitude profile (route mode only). Sloped segments
+            // connecting the planned altitude at each waypoint.
+            ShapePath {
+                strokeWidth: 3
+                strokeColor: Global.flightRouteColor
+                fillColor: "transparent"
+                PathPolyline { path: rawSideView.plannedProfile }
+            }
+        }
+
+        // Clickable altitude points, one per waypoint (route mode only). Tapping
+        // a point opens a popup to specify the planned altitude. Placed in
+        // Flickable content space, aligned with the profile polyline.
+        Repeater {
+            model: rawSideView.mode === SideviewQuickItem.Route ? rawSideView.plannedProfilePoints : 0
+
+            delegate: Item {
+                id: handle
+                required property int index
+                required property var modelData
+
+                width: 28
+                height: 28
+                x: modelData.x - width/2
+                y: modelData.y - height/2
+
+                // Same marker as the route turnpoints on the moving map.
+                Image {
+                    anchors.centerIn: parent
+                    source: "/icons/waypoints/WP-map.svg"
+                    sourceSize.width: 14
+                    sourceSize.height: 14
+                    scale: tapArea.pressed ? 1.25 : 1.0
+                }
+
+                MouseArea {
+                    id: tapArea
+                    anchors.fill: parent
+                    onDoubleClicked: {
+                        PlatformAdaptor.vibrateBrief()
+                        sideviewAltEditor.index = handle.index
+                        sideviewAltEditor.open()
+                    }
+                }
+            }
         }
 
         Image {
@@ -569,6 +617,46 @@ SideviewQuickItem {
             } else {
                 rawSideView.mode = SideviewQuickItem.Route
             }
+        }
+    }
+
+    // Popup to specify the planned altitude of a waypoint, opened by tapping a
+    // blue altitude point.
+    CenteringDialog {
+        id: sideviewAltEditor
+
+        property int index: -1 // Index of waypoint in flight route
+
+        title: qsTr("Planned Altitude")
+        modal: true
+        standardButtons: Dialog.Ok | Dialog.Cancel
+
+        onAboutToShow: {
+            var m = Navigator.flightRoute.plannedAltitude(sideviewAltEditor.index)
+            sideviewAltField.valueMeter = isNaN(m) ? Navigator.aircraft.cruiseAltitudeM : m
+        }
+
+        ColumnLayout {
+            width: parent.width
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: qsTr("Planned cruise altitude at this waypoint. Leave empty to use the aircraft's default cruise altitude.")
+            }
+
+            ElevationInput {
+                id: sideviewAltField
+                Layout.fillWidth: true
+                currentIndex: Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters ? 1 : 0
+                onAccepted: sideviewAltEditor.accept()
+            }
+        }
+
+        onAccepted: {
+            PlatformAdaptor.vibrateBrief()
+            sideviewAltField.commit()
+            Navigator.flightRoute.setPlannedAltitude(sideviewAltEditor.index, sideviewAltField.valueMeter)
         }
     }
 }

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -30,206 +30,441 @@ SideviewQuickItem {
     clip: true
     pixelPer10km: flightMap.pixelPer10km
 
+    // Feed the C++ backend the actual content width so it computes
+    // coordinates in the Flickable's content space.
+    renderWidth: flickable.contentWidth
+
+    // Full-area sky background (scale panels sit on top of it)
     Rectangle {
-        id: sky
         anchors.fill: parent
         color: "lightblue"
+        z: -1
     }
 
-    Shape {
-        id: shp
+    // -------------------------------------------------------------------------
+    // Unit helpers
+    // -------------------------------------------------------------------------
+    readonly property bool useFeet: Navigator.aircraft.verticalDistanceUnit === Aircraft.Feet
+    readonly property bool useNM:   Navigator.aircraft.horizontalDistanceUnit === Aircraft.NauticalMile
+    readonly property bool useSM:   Navigator.aircraft.horizontalDistanceUnit === Aircraft.StatuteMile
+    // km → display unit conversions
+    readonly property double kmToHDist: useNM ? 0.539957 : (useSM ? 0.621371 : 1.0)
+    readonly property string hDistUnit: useNM ? qsTr("NM") : (useSM ? qsTr("mi") : qsTr("km"))
+    // ft → display unit for altitude
+    readonly property double ftToVDist: useFeet ? 1.0 : 0.3048
+    readonly property string vDistUnit: useFeet ? qsTr("ft") : qsTr("m")
 
-        preferredRendererType: Shape.CurveRenderer
-        asynchronous: true
+    // -------------------------------------------------------------------------
+    // Y-axis scale (altitude) — fixed strip on the left, not scrolled
+    // -------------------------------------------------------------------------
+    readonly property int yScaleWidth: 54
+    readonly property int xScaleHeight: 20
 
-        ShapePath {
-            id: terrain
-            strokeWidth: -1
-            strokeColor: "saddlebrown"
-            fillColor: "brown"
+    Item {
+        id: yScalePanel
 
-            PathPolyline { path: rawSideView.terrain }
+        x: 0
+        y: 0
+        width: rawSideView.yScaleWidth
+        height: rawSideView.height - rawSideView.xScaleHeight
+        z: 20
+        clip: true
+
+        // Semi-transparent background
+        Rectangle {
+            anchors.fill: parent
+            color: "#99F0F0F0"
         }
 
-        ShapePath {
-            id: airspacesABorder
-            strokeWidth: 10
-            strokeColor: "#330000FF"
-            fillColor: "transparent"
+        // Tick marks and labels
+        Repeater {
+            id: yTicks
 
-            PathMultiline { paths: rawSideView.airspaces["A"] }
-        }
+            // Work in display units (ft or m)
+            readonly property double minDisp: rawSideView.scaleMinAltFt * rawSideView.ftToVDist
+            readonly property double maxDisp: rawSideView.scaleMaxAltFt * rawSideView.ftToVDist
+            readonly property double rangeH:  maxDisp - minDisp
 
-        ShapePath {
-            id: airspacesA
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["A"] }
-        }
-
-        ShapePath {
-            id: airspacesRBorder
-            strokeWidth: 10
-            strokeColor: "#33FF0000"
-            fillColor: "transparent"
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["R"] }
-        }
-
-        ShapePath {
-            id: airspacesR
-            strokeWidth: 2
-            strokeColor: "red"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["R"] }
-        }
-
-        ShapePath {
-            id: airspacesPJE
-            strokeWidth: 2
-            strokeColor: "red"
-            fillColor: "transparent"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-
-            PathMultiline { paths: rawSideView.airspaces["PJE"] }
-        }
-
-        ShapePath {
-            id: airspacesTMZ
-            strokeWidth: 2
-            strokeColor: "black"
-            fillColor: "transparent"
-            dashPattern: [4.0, 3.0, 0.5, 3.0]
-            strokeStyle: ShapePath.DashLine
-
-            PathMultiline { paths: rawSideView.airspaces["TMZ"] }
-        }
-
-        ShapePath {
-            id: airspacesNRABorder
-            strokeWidth: 10
-            strokeColor: "#3300FF00"
-            fillColor: "transparent"
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["NRA"] }
-        }
-
-        ShapePath {
-            id: airspacesNRA
-            strokeWidth: 2
-            strokeColor: "green"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["NRA"] }
-        }
-
-        ShapePath {
-            id: airspacesRMZ
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "#330000FF"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["RMZ"] }
-        }
-
-        ShapePath {
-            id: airspacesCTR
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "#33FF0000"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["CTR"] }
-        }
-
-        property double animatedFiveMinuteBarX: rawSideView.fiveMinuteBar.x
-        Behavior on animatedFiveMinuteBarX { NumberAnimation {duration: 1000} }
-        property double animatedFiveMinuteBarY: rawSideView.fiveMinuteBar.y
-        Behavior on animatedFiveMinuteBarY { NumberAnimation {duration: 1000} }
-
-        ShapePath {
-            id: fiveMinuteBar
-            strokeWidth: 3
-            strokeColor: "black"
-
-            startX: rawSideView.ownshipPosition.x
-            startY: rawSideView.ownshipPosition.y
-            PathLine {
-                relativeX: shp.animatedFiveMinuteBarX
-                relativeY: shp.animatedFiveMinuteBarY
+            // Pick a tick interval (in display units) giving roughly 4-8 ticks
+            readonly property double tickStep: {
+                var range = rangeH > 0 ? rangeH : 1000
+                var candidates = rawSideView.useFeet
+                    ? [100, 200, 500, 1000, 2000, 5000]
+                    : [50, 100, 200, 500, 1000, 2000]
+                for (var i = 0; i < candidates.length; i++) {
+                    if (range / candidates[i] <= 8) { return candidates[i] }
+                }
+                return candidates[candidates.length - 1]
             }
-        }
+            readonly property double firstTick: Math.ceil(minDisp / tickStep) * tickStep
+            readonly property int tickCount: rangeH > 0
+                ? Math.floor((maxDisp - firstTick) / tickStep) + 1
+                : 0
 
-        ShapePath {
-            id: fiveMinuteBar_1_2
-            strokeWidth: 2
-            strokeColor: "white"
+            model: (rangeH > 0 && tickCount > 0) ? tickCount : 0
 
-            startX: rawSideView.ownshipPosition.x + 0.2*shp.animatedFiveMinuteBarX
-            startY: rawSideView.ownshipPosition.y + 0.2*shp.animatedFiveMinuteBarY
-            PathLine {
-                relativeX: 0.2*shp.animatedFiveMinuteBarX
-                relativeY: 0.2*shp.animatedFiveMinuteBarY
-            }
-        }
+            delegate: Item {
+                required property int index
+                readonly property double altDisp: yTicks.firstTick + index * yTicks.tickStep
+                readonly property double frac: (altDisp - yTicks.minDisp) / yTicks.rangeH
+                readonly property double yPos: (1.0 - frac) * yScalePanel.height
 
-        ShapePath {
-            id: fiveMinuteBar_3_4
-            strokeWidth: 2
-            strokeColor: "white"
+                y: yPos - 7
+                x: 0
+                width: yScalePanel.width
+                height: 14
+                visible: yPos >= 0 && yPos <= yScalePanel.height
 
-            startX: rawSideView.ownshipPosition.x + 0.6*shp.animatedFiveMinuteBarX
-            startY: rawSideView.ownshipPosition.y + 0.6*shp.animatedFiveMinuteBarY
-            PathLine {
-                relativeX: 0.2*shp.animatedFiveMinuteBarX
-                relativeY: 0.2*shp.animatedFiveMinuteBarY
+                Rectangle {
+                    x: yScalePanel.width - 4
+                    y: 6
+                    width: 4
+                    height: 1
+                    color: "#80000000"
+                }
+
+                Label {
+                    x: 2; y: 0
+                    width: yScalePanel.width - 6
+                    height: 14
+                    text: qsTr("%1 %2").arg(Math.round(altDisp)).arg(rawSideView.vDistUnit)
+                    font.pixelSize: 9
+                    color: "#CC000000"
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideNone
+                }
             }
         }
     }
 
-    Image {
-        id: ownShip
+    // -------------------------------------------------------------------------
+    // X-axis scale (distance) — fixed strip at the bottom
+    // -------------------------------------------------------------------------
+    Item {
+        id: xScalePanel
 
-        x: rawSideView.ownshipPosition.x-width/2.0
-        y: rawSideView.ownshipPosition.y-height/2.0
-        rotation: {
-            if (shp.animatedFiveMinuteBarX > 2)
-            {
-                return 90 + 360*Math.atan( shp.animatedFiveMinuteBarY/shp.animatedFiveMinuteBarX )/(2*Math.PI)
-            }
-            return 90
+        x: rawSideView.yScaleWidth
+        y: rawSideView.height - rawSideView.xScaleHeight
+        width: rawSideView.width - rawSideView.yScaleWidth
+        height: rawSideView.xScaleHeight
+        z: 20
+        clip: true
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#99F0F0F0"
         }
 
-        source: {
-            var pInfo = PositionProvider.positionInfo
-            if (!pInfo.isValid()) {
-                return "/icons/self-noPosition.svg"
-            }
-            if (!pInfo.trueTrack().isFinite()) {
-                return "/icons/self-noDirection.svg"
-            }
-            return "/icons/self-withDirection.svg"
-        }
+        // Scrolling tick marks — shift opposite to Flickable.contentX
+        Item {
+            x: -flickable.contentX
+            width: flickable.contentWidth
+            height: xScalePanel.height
 
-        sourceSize.width: 25
-        sourceSize.height: 25
+            Repeater {
+                id: xTicks
+
+                readonly property double totalKm: rawSideView.scaleTotalDistKm
+                readonly property double contentW: flickable.contentWidth
+                readonly property bool isRouteMode: totalKm > 0
+
+                // distance (in display units) per pixel in content space
+                readonly property double dispPerPx: isRouteMode
+                    ? (totalKm * rawSideView.kmToHDist / contentW)
+                    : (10.0 * rawSideView.kmToHDist / rawSideView.pixelPer10km)
+
+                // pixels per display-unit
+                readonly property double pxPerDisp: dispPerPx > 0 ? 1.0 / dispPerPx : 0
+
+                // pick a nice tick interval (display units) giving ≥ 50 px between ticks
+                readonly property double tickDist: {
+                    if (pxPerDisp <= 0) { return 100 }
+                    var candidates = rawSideView.useNM
+                        ? [0.5, 1, 2, 5, 10, 20, 50, 100, 200]
+                        : [1, 2, 5, 10, 20, 50, 100, 200, 500]
+                    for (var i = 0; i < candidates.length; i++) {
+                        if (pxPerDisp * candidates[i] >= 50) { return candidates[i] }
+                    }
+                    return candidates[candidates.length - 1]
+                }
+
+                readonly property double totalDispShown: dispPerPx > 0 ? contentW * dispPerPx : 0
+                readonly property int tickCount: totalDispShown > 0
+                    ? Math.ceil(totalDispShown / tickDist) + 2
+                    : 0
+
+                model: tickCount
+
+                delegate: Item {
+                    required property int index
+                    // distance value this tick represents (in display units)
+                    readonly property double dist: {
+                        if (xTicks.isRouteMode) {
+                            return index * xTicks.tickDist
+                        }
+                        // track mode: pixel x=0 is 0.2*contentW*dispPerPx behind ownship
+                        var startDisp = -0.2 * xTicks.contentW * xTicks.dispPerPx
+                        return Math.ceil(startDisp / xTicks.tickDist) * xTicks.tickDist
+                               + index * xTicks.tickDist
+                    }
+                    readonly property double xPos: xTicks.isRouteMode
+                        ? (xTicks.pxPerDisp > 0 ? dist * xTicks.pxPerDisp : 0)
+                        : (xTicks.pxPerDisp > 0
+                           ? (dist + 0.2 * xTicks.contentW * xTicks.dispPerPx) * xTicks.pxPerDisp
+                           : 0)
+
+                    x: xPos - 1
+                    y: 0
+                    width: 2
+                    height: xScalePanel.height
+                    visible: xPos >= 0 && xPos <= xTicks.contentW
+
+                    Rectangle {
+                        x: 0; y: 0; width: 1; height: 4
+                        color: "#80000000"
+                    }
+
+                    Label {
+                        x: 2; y: 2
+                        font.pixelSize: 9
+                        color: "#CC000000"
+                        text: {
+                            var v = rawSideView.useNM
+                                    ? dist.toFixed(1)
+                                    : Math.round(dist)
+                            return xTicks.isRouteMode
+                                ? qsTr("%1 %2").arg(v).arg(rawSideView.hDistUnit)
+                                : (dist >= 0
+                                   ? qsTr("+%1 %2").arg(v).arg(rawSideView.hDistUnit)
+                                   : qsTr("%1 %2").arg(v).arg(rawSideView.hDistUnit))
+                        }
+                    }
+                }
+            }
+        }
     }
 
+    // -------------------------------------------------------------------------
+    // Flickable — horizontal scrolling for the content area
+    // -------------------------------------------------------------------------
+    Flickable {
+        id: flickable
+
+        x: rawSideView.yScaleWidth
+        y: 0
+        width: rawSideView.width - rawSideView.yScaleWidth
+        height: rawSideView.height - rawSideView.xScaleHeight
+
+        contentWidth: width * zoomFactor
+        contentHeight: height
+
+        flickableDirection: Flickable.HorizontalFlick
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+
+        property real zoomFactor: 1.0
+
+        Shape {
+            id: shp
+
+            width: flickable.contentWidth
+            height: flickable.contentHeight
+
+            preferredRendererType: Shape.CurveRenderer
+            asynchronous: true
+
+            ShapePath {
+                id: terrain
+                strokeWidth: -1
+                strokeColor: "saddlebrown"
+                fillColor: "brown"
+
+                PathPolyline { path: rawSideView.terrain }
+            }
+
+            ShapePath {
+                id: airspacesABorder
+                strokeWidth: 10
+                strokeColor: "#330000FF"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["A"] }
+            }
+
+            ShapePath {
+                id: airspacesA
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["A"] }
+            }
+
+            ShapePath {
+                id: airspacesRBorder
+                strokeWidth: 10
+                strokeColor: "#33FF0000"
+                fillColor: "transparent"
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["R"] }
+            }
+
+            ShapePath {
+                id: airspacesR
+                strokeWidth: 2
+                strokeColor: "red"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["R"] }
+            }
+
+            ShapePath {
+                id: airspacesPJE
+                strokeWidth: 2
+                strokeColor: "red"
+                fillColor: "transparent"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+
+                PathMultiline { paths: rawSideView.airspaces["PJE"] }
+            }
+
+            ShapePath {
+                id: airspacesTMZ
+                strokeWidth: 2
+                strokeColor: "black"
+                fillColor: "transparent"
+                dashPattern: [4.0, 3.0, 0.5, 3.0]
+                strokeStyle: ShapePath.DashLine
+
+                PathMultiline { paths: rawSideView.airspaces["TMZ"] }
+            }
+
+            ShapePath {
+                id: airspacesNRABorder
+                strokeWidth: 10
+                strokeColor: "#3300FF00"
+                fillColor: "transparent"
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["NRA"] }
+            }
+
+            ShapePath {
+                id: airspacesNRA
+                strokeWidth: 2
+                strokeColor: "green"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["NRA"] }
+            }
+
+            ShapePath {
+                id: airspacesRMZ
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "#330000FF"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["RMZ"] }
+            }
+
+            ShapePath {
+                id: airspacesCTR
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "#33FF0000"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["CTR"] }
+            }
+
+            property double animatedFiveMinuteBarX: rawSideView.fiveMinuteBar.x
+            Behavior on animatedFiveMinuteBarX { NumberAnimation {duration: 1000} }
+            property double animatedFiveMinuteBarY: rawSideView.fiveMinuteBar.y
+            Behavior on animatedFiveMinuteBarY { NumberAnimation {duration: 1000} }
+
+            ShapePath {
+                id: fiveMinuteBar
+                strokeWidth: 3
+                strokeColor: "black"
+
+                startX: rawSideView.ownshipPosition.x
+                startY: rawSideView.ownshipPosition.y
+                PathLine {
+                    relativeX: shp.animatedFiveMinuteBarX
+                    relativeY: shp.animatedFiveMinuteBarY
+                }
+            }
+
+            ShapePath {
+                id: fiveMinuteBar_1_2
+                strokeWidth: 2
+                strokeColor: "white"
+
+                startX: rawSideView.ownshipPosition.x + 0.2*shp.animatedFiveMinuteBarX
+                startY: rawSideView.ownshipPosition.y + 0.2*shp.animatedFiveMinuteBarY
+                PathLine {
+                    relativeX: 0.2*shp.animatedFiveMinuteBarX
+                    relativeY: 0.2*shp.animatedFiveMinuteBarY
+                }
+            }
+
+            ShapePath {
+                id: fiveMinuteBar_3_4
+                strokeWidth: 2
+                strokeColor: "white"
+
+                startX: rawSideView.ownshipPosition.x + 0.6*shp.animatedFiveMinuteBarX
+                startY: rawSideView.ownshipPosition.y + 0.6*shp.animatedFiveMinuteBarY
+                PathLine {
+                    relativeX: 0.2*shp.animatedFiveMinuteBarX
+                    relativeY: 0.2*shp.animatedFiveMinuteBarY
+                }
+            }
+        }
+
+        Image {
+            id: ownShip
+
+            x: rawSideView.ownshipPosition.x-width/2.0
+            y: rawSideView.ownshipPosition.y-height/2.0
+            rotation: {
+                if (shp.animatedFiveMinuteBarX > 2)
+                {
+                    return 90 + 360*Math.atan( shp.animatedFiveMinuteBarY/shp.animatedFiveMinuteBarX )/(2*Math.PI)
+                }
+                return 90
+            }
+
+            source: {
+                var pInfo = PositionProvider.positionInfo
+                if (!pInfo.isValid()) {
+                    return "/icons/self-noPosition.svg"
+                }
+                if (!pInfo.trueTrack().isFinite()) {
+                    return "/icons/self-noDirection.svg"
+                }
+                return "/icons/self-withDirection.svg"
+            }
+
+            sourceSize.width: 25
+            sourceSize.height: 25
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Labels (outside Flickable — anchored to the visible area)
+    // -------------------------------------------------------------------------
     Label {
         id: trackLabel
 
-        x: rawSideView.width*0.1
+        x: rawSideView.yScaleWidth + flickable.width*0.1
         text: rawSideView.track
         visible: rawSideView.track !== ""
     }
@@ -238,6 +473,7 @@ SideviewQuickItem {
         id: errorLabel
 
         anchors.centerIn: parent
+        anchors.horizontalCenterOffset: rawSideView.yScaleWidth / 2.0
 
         text: rawSideView.error
         visible: rawSideView.error !== ""
@@ -262,6 +498,77 @@ SideviewQuickItem {
                                    }
                                    )
             dialogLoader.active = true
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Zoom buttons — Route mode only
+    // -------------------------------------------------------------------------
+    Column {
+        id: zoomButtons
+
+        anchors.right: modeToggle.left
+        anchors.top:   parent.top
+        anchors.margins: 4
+        spacing: 2
+        z: 10
+
+        visible: rawSideView.mode === SideviewQuickItem.Route
+
+        RoundButton {
+            width:  28; height: 28; padding: 0
+            text: "+"
+            font.pixelSize: 16
+            opacity: 0.85
+            enabled: flickable.zoomFactor < 8.0
+            onClicked: flickable.zoomFactor = Math.min(8.0, flickable.zoomFactor * 2.0)
+        }
+
+        RoundButton {
+            width:  28; height: 28; padding: 0
+            text: "−"
+            font.pixelSize: 16
+            opacity: 0.85
+            enabled: flickable.zoomFactor > 1.0
+            onClicked: {
+                flickable.zoomFactor = Math.max(1.0, flickable.zoomFactor / 2.0)
+                if (flickable.contentWidth <= flickable.width) {
+                    flickable.contentX = 0
+                }
+            }
+        }
+    }
+
+    // Mode toggle button — rendered last so it sits above all other children
+    RoundButton {
+        id: modeToggle
+
+        anchors.right:   parent.right
+        anchors.top:     parent.top
+        anchors.margins: 4
+        z: 10
+
+        width:  32
+        height: 32
+        padding: 0
+
+        text: rawSideView.mode === SideviewQuickItem.Route ? "✈" : "⇢"
+        font.pixelSize: 16
+        opacity: 0.85
+
+        ToolTip.text: rawSideView.mode === SideviewQuickItem.Route
+                      ? qsTr("Showing planned route – tap for current track")
+                      : qsTr("Showing current track – tap for planned route")
+        ToolTip.visible: hovered
+
+        onClicked: {
+            if (rawSideView.mode === SideviewQuickItem.Route) {
+                rawSideView.mode = SideviewQuickItem.Track
+                flickable.zoomFactor = 1.0
+                flickable.contentX = 0
+            } else {
+                rawSideView.mode = SideviewQuickItem.Route
+            }
         }
     }
 }

--- a/src/qml/pages/AircraftPage.qml
+++ b/src/qml/pages/AircraftPage.qml
@@ -413,6 +413,20 @@ Page {
             Item { }
 
             Label {
+                text: qsTr("Cruise altitude")
+                Layout.alignment: Qt.AlignBaseline
+            }
+            ElevationInput {
+                id: cruiseAltField
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                currentIndex: Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters ? 1 : 0
+                valueMeter: Navigator.aircraft.cruiseAltitudeM
+                onValueMeterChanged: Navigator.aircraft.cruiseAltitudeM = valueMeter
+            }
+            Item { }
+
+            Label {
                 text: qsTr("Descent")
                 Layout.alignment: Qt.AlignBaseline
             }

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -39,6 +39,14 @@ Page {
     property angle staticAngle
     property speed staticSpeed
 
+    // Bumped whenever a planned altitude changes, so the per-row altitude
+    // labels (bound to the Q_INVOKABLE plannedAltitude) re-evaluate.
+    property int plannedAltRevision: 0
+    Connections {
+        target: Navigator.flightRoute
+        function onPlannedAltitudesChanged() { flightRoutePage.plannedAltRevision++ }
+    }
+
     Component {
         id: waypointComponent
 
@@ -53,6 +61,42 @@ Page {
             WaypointDelegate {
                 Layout.fillWidth: true
                 waypoint: waypointLayout.waypoint
+            }
+
+            ToolButton {
+                id: altButton
+
+                // Resolved planned altitude in meters: stored value, else the
+                // aircraft default. NaN if neither is set.
+                readonly property double resolvedM: {
+                    flightRoutePage.plannedAltRevision // dependency
+                    var m = Navigator.flightRoute.plannedAltitude(waypointLayout.index)
+                    if (!isNaN(m)) return m
+                    return Navigator.aircraft.cruiseAltitudeM
+                }
+                readonly property bool isDefault: {
+                    flightRoutePage.plannedAltRevision // dependency
+                    return isNaN(Navigator.flightRoute.plannedAltitude(waypointLayout.index))
+                }
+
+                contentItem: Label {
+                    text: {
+                        if (isNaN(altButton.resolvedM)) return "––"
+                        if (Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters)
+                            return Math.round(altButton.resolvedM) + " m"
+                        return Math.round(altButton.resolvedM * 3.281) + " ft"
+                    }
+                    color: altButton.isDefault ? "#808080" : Global.flightRouteColor
+                    font.pixelSize: flightRoutePage.font.pixelSize*0.9
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                onClicked: {
+                    PlatformAdaptor.vibrateBrief()
+                    altEditor.index = waypointLayout.index
+                    altEditor.open()
+                }
             }
 
             ToolButton {
@@ -957,6 +1001,44 @@ Page {
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
             Navigator.flightRoute.replaceWaypoint(index, newWP)
             wpEditor.close()
+        }
+    }
+
+    CenteringDialog {
+        id: altEditor
+
+        property int index: -1 // Index of waypoint in flight route
+
+        title: qsTr("Planned Altitude")
+        modal: true
+        standardButtons: Dialog.Ok | Dialog.Cancel
+
+        onAboutToShow: {
+            var m = Navigator.flightRoute.plannedAltitude(altEditor.index)
+            altField.valueMeter = isNaN(m) ? Navigator.aircraft.cruiseAltitudeM : m
+        }
+
+        ColumnLayout {
+            width: parent.width
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: qsTr("Planned cruise altitude at this waypoint. Leave empty to use the aircraft's default cruise altitude.")
+            }
+
+            ElevationInput {
+                id: altField
+                Layout.fillWidth: true
+                currentIndex: Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters ? 1 : 0
+                onAccepted: altEditor.accept()
+            }
+        }
+
+        onAccepted: {
+            PlatformAdaptor.vibrateBrief()
+            altField.commit()
+            Navigator.flightRoute.setPlannedAltitude(altEditor.index, altField.valueMeter)
         }
     }
 } // Page

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -50,6 +50,9 @@ Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
     notifiers.push_back(GlobalObject::navigator()->flightRoute()->bindableGeoPath().addNotifier([this]() {
         if (m_mode == Mode::Route) { updateProperties(); }
     }));
+    connect(GlobalObject::navigator()->flightRoute(), &Navigation::FlightRoute::plannedAltitudesChanged, this, [this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    });
 
     updateProperties();
 }
@@ -190,6 +193,8 @@ void Ui::SideviewQuickItem::updatePropertiesTrack()
     m_track = QString();
     m_error = QString();
     m_terrain = QPolygonF();
+    m_plannedProfile = QPolygonF();
+    m_plannedProfilePoints = QVariantList();
 
     QVariantMap newAirspaces;
     const QVector<QPolygonF> empty;
@@ -413,6 +418,8 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     m_track           = QString();
     m_error           = QString();
     m_terrain         = QPolygonF();
+    m_plannedProfile  = QPolygonF();
+    m_plannedProfilePoints = QVariantList();
 
     const QVector<QPolygonF> empty;
     QVariantMap newAirspaces;
@@ -526,6 +533,29 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     Units::Distance sideview_minAlt = minElevation - Units::Distance::fromFT(200);
     Units::Distance sideview_maxAlt = maxElevation + Units::Distance::fromFT(4000);
 
+    // -----------------------------------------------------------------------
+    // 6b. Resolve the planned altitude at each waypoint (stored value, else
+    //     aircraft cruise altitude, else terrain + 1000ft) and expand the
+    //     vertical extent so the whole profile is visible.
+    // -----------------------------------------------------------------------
+    auto* flightRoute = GlobalObject::navigator()->flightRoute();
+    const auto routeWaypoints = flightRoute->waypoints();
+    const Units::Distance defaultCruiseAlt = GlobalObject::navigator()->aircraft().cruiseAltitude();
+    const Units::Distance fallbackAlt = maxElevation + Units::Distance::fromFT(1000);
+
+    QList<Units::Distance> plannedAlts;
+    plannedAlts.reserve(routeWaypoints.size());
+    for (int i = 0; i < routeWaypoints.size(); i++)
+    {
+        double storedM = flightRoute->plannedAltitude(i);
+        Units::Distance alt = !qIsNaN(storedM) ? Units::Distance::fromM(storedM)
+                            : defaultCruiseAlt.isFinite() ? defaultCruiseAlt
+                            : fallbackAlt;
+        plannedAlts << alt;
+        sideview_maxAlt = qMax(sideview_maxAlt, alt + Units::Distance::fromFT(200));
+        sideview_minAlt = qMin(sideview_minAlt, alt - Units::Distance::fromFT(200));
+    }
+
     auto altToY = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt) {
         return ((double)height()) * (sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
     };
@@ -533,6 +563,22 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     m_scaleMinAltFt    = sideview_minAlt.toFeet();
     m_scaleMaxAltFt    = sideview_maxAlt.toFeet();
     m_scaleTotalDistKm = totalRouteLen / 1000.0;
+
+    // Build the planned-altitude polyline: one point per waypoint, at the
+    // waypoint's x position along the route.
+    QPolygonF profile;
+    QVariantList profilePoints;
+    profile.reserve(plannedAlts.size());
+    profilePoints.reserve(plannedAlts.size());
+    for (qsizetype i = 0; (i < plannedAlts.size()) && (i < cumulativeDist.size()); i++)
+    {
+        double x = (cumulativeDist[i] / totalRouteLen) * renderW;
+        QPointF pt(x, altToY(plannedAlts[i]));
+        profile << pt;
+        profilePoints << pt;
+    }
+    m_plannedProfile = profile;
+    m_plannedProfilePoints = profilePoints;
 
     // -----------------------------------------------------------------------
     // 7. Terrain polygon

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -21,6 +21,7 @@
 #include "GeoMapProvider.h"
 #include "PositionProvider.h"
 #include "SideviewQuickItem.h"
+#include "navigation/Navigator.h"
 #include "weather/WeatherDataProvider.h"
 
 using namespace Qt::Literals::StringLiterals;
@@ -40,7 +41,25 @@ Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
     notifiers.push_back(GlobalObject::positionProvider()->bindablePositionInfo().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(GlobalObject::positionProvider()->bindablePressureAltitude().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(m_pixelPer10km.addNotifier([this]() {updateProperties();}));
-    updateProperties();   
+    notifiers.push_back(m_renderWidth.addNotifier([this]() { emit renderWidthChanged(); updateProperties(); }));
+    notifiers.push_back(m_scaleMaxAltFt.addNotifier([this]() { emit scaleRangeChanged(); }));
+    notifiers.push_back(m_scaleMinAltFt.addNotifier([this]() { emit scaleRangeChanged(); }));
+    notifiers.push_back(m_scaleTotalDistKm.addNotifier([this]() { emit scaleRangeChanged(); }));
+
+    // React to route changes when in Route mode
+    notifiers.push_back(GlobalObject::navigator()->flightRoute()->bindableGeoPath().addNotifier([this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    }));
+
+    updateProperties();
+}
+
+void Ui::SideviewQuickItem::setMode(Mode newMode)
+{
+    if (m_mode == newMode) { return; }
+    m_mode = newMode;
+    emit modeChanged();
+    updateProperties();
 }
 
 void Ui::SideviewQuickItem::updateProperties()
@@ -61,10 +80,111 @@ void Ui::SideviewQuickItem::updateProperties()
     }
     m_elapsedTimer.start();
 
+    if (m_mode == Mode::Route)
+    {
+        updatePropertiesRoute();
+    }
+    else
+    {
+        updatePropertiesTrack();
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Shared helper: build airspace polygons along a sampled geo-path
+// ---------------------------------------------------------------------------
+QVariantMap Ui::SideviewQuickItem::buildAirspacePolygons(
+    const QList<int>& xCoordinates,
+    const QList<QGeoCoordinate>& geoCoordinates,
+    const QList<Units::Distance>& elevations,
+    Units::Distance ownshipGeometricAltitude,
+    Units::Distance ownshipPressureAltitude,
+    std::function<double(Units::Distance)> altToY)
+{
+    const QVector<QPolygonF> empty;
+    QVariantMap result;
+    result[u"A"_s]   = QVariant::fromValue(empty);
+    result[u"CTR"_s] = QVariant::fromValue(empty);
+    result[u"R"_s]   = QVariant::fromValue(empty);
+    result[u"RMZ"_s] = QVariant::fromValue(empty);
+    result[u"NRA"_s] = QVariant::fromValue(empty);
+    result[u"PJE"_s] = QVariant::fromValue(empty);
+    result[u"TMZ"_s] = QVariant::fromValue(empty);
+
+    auto QNH = GlobalObject::weatherDataProvider()->QNH();
+    if (!QNH.isFinite()) { return result; }
+
+    QVector<QPolygonF> polyA, polyCTR, polyR, polyRMZ, polyNRA, polyPJE, polyTMZ;
+
+    auto airspaces = GlobalObject::geoMapProvider()->airspaces();
+    QGeoRectangle const viewBBox(QList({geoCoordinates.constFirst(), geoCoordinates.constLast()}));
+
+    for (const auto& airspace : std::as_const(airspaces))
+    {
+        if (!airspaceCategories.contains(airspace.CAT())) { continue; }
+        if (!airspace.polygon().boundingGeoRectangle().intersects(viewBBox)) { continue; }
+
+        QList<QPointF> upper, lower;
+        auto airspacePolygon = airspace.polygon();
+
+        for (int i = 0; i < xCoordinates.size(); i++)
+        {
+            auto x = xCoordinates[i];
+            const auto& gc = geoCoordinates[i];
+            if ((i != xCoordinates.size()-1) && airspacePolygon.contains(gc))
+            {
+                auto u = airspace.estimatedUpperBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
+                auto l = airspace.estimatedLowerBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
+                if (l < u)
+                {
+                    upper << QPointF(x, altToY(u));
+                    lower << QPointF(x, altToY(l));
+                    continue;
+                }
+            }
+
+            if (!upper.isEmpty())
+            {
+                std::reverse(lower.begin(), lower.end());
+                QPolygonF poly(upper + lower);
+                poly << upper[0];
+
+                auto cat = airspace.CAT();
+                if (cat == u"A"_s || cat == u"B"_s || cat == u"C"_s || cat == u"D"_s) { polyA   << poly; }
+                if (cat == u"CTR"_s)                                                   { polyCTR << poly; }
+                if (cat == u"R"_s  || cat == u"P"_s  || cat == u"DNG"_s)              { polyR   << poly; }
+                if (cat == u"ATZ"_s|| cat == u"RMZ"_s|| cat == u"TIA"_s|| cat == u"TIZ"_s) { polyRMZ << poly; }
+                if (cat == u"NRA"_s)                                                   { polyNRA << poly; }
+                if (cat == u"PJE"_s|| cat == u"SUA"_s)                                { polyPJE << poly; }
+                if (cat == u"TMZ"_s)                                                   { polyTMZ << poly; }
+
+                upper.clear();
+                lower.clear();
+            }
+        }
+    }
+
+    result[u"A"_s]   = QVariant::fromValue(polyA);
+    result[u"CTR"_s] = QVariant::fromValue(polyCTR);
+    result[u"R"_s]   = QVariant::fromValue(polyR);
+    result[u"RMZ"_s] = QVariant::fromValue(polyRMZ);
+    result[u"NRA"_s] = QVariant::fromValue(polyNRA);
+    result[u"PJE"_s] = QVariant::fromValue(polyPJE);
+    result[u"TMZ"_s] = QVariant::fromValue(polyTMZ);
+    return result;
+}
+
+
+// ---------------------------------------------------------------------------
+// Mode::Track  — original logic, unchanged except extracted to own method
+// ---------------------------------------------------------------------------
+void Ui::SideviewQuickItem::updatePropertiesTrack()
+{
+    const QScopedPropertyUpdateGroup updateLock;
     //
     // Set all properties to default values. We update those depending on the data we have available.
     //
-    const QScopedPropertyUpdateGroup updateLock;
     m_fiveMinuteBar = {0, 0};
     m_ownshipPosition = {-100, -100};
     m_track = QString();
@@ -178,13 +298,14 @@ void Ui::SideviewQuickItem::updateProperties()
         }
     }
 
+    const double renderW = rw();
     //
     // Compute array of x-coordinates in pixels.
     //
     const int step = 4.0;
     QList<int> xCoordinates;
-    xCoordinates.reserve( qRound((width()+20)/step) );
-    for(int x = -10; x <= width()+10; x += step)
+    xCoordinates.reserve( qRound((renderW+20)/step) );
+    for(int x = -10; x <= renderW+10; x += step)
     {
         xCoordinates << x;
     }
@@ -196,7 +317,7 @@ void Ui::SideviewQuickItem::updateProperties()
     geoCoordinates.reserve(xCoordinates.size());
     for(auto x : std::as_const(xCoordinates))
     {
-        auto dist = 10000.0*(x-0.2*width())/(m_pixelPer10km.value());
+        auto dist = 10000.0*(x-0.2*renderW)/(m_pixelPer10km.value());
         auto geoCoordinate = ownshipCoordinate.atDistanceAndAzimuth(dist, ownshipTrack.toDEG());
         geoCoordinates << geoCoordinate;
     }
@@ -249,12 +370,16 @@ void Ui::SideviewQuickItem::updateProperties()
         return ((double)height())*(sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
     };
 
+    m_scaleMinAltFt  = sideview_minAlt.toFeet();
+    m_scaleMaxAltFt  = sideview_maxAlt.toFeet();
+    m_scaleTotalDistKm = 0.0;
+
     //
     // Compute graphics data
     //
 
     // Ownship position
-    m_ownshipPosition = {width()*0.2, altToYCoordinate(ownshipGeometricAltitude)};
+    m_ownshipPosition = {renderW*0.2, altToYCoordinate(ownshipGeometricAltitude)};
 
     // 5-Minute-Bar
     if (ownshipVSpeed.isFinite() && ownshipHSpeed.isFinite())
@@ -269,98 +394,247 @@ void Ui::SideviewQuickItem::updateProperties()
     {
         polygon << QPointF(xCoordinates[i], altToYCoordinate(elevations[i]));
     }
-    polygon  << QPointF(width(), height()+2000) << QPointF(-20, height()+2000);
+    polygon << QPointF(renderW, height()+2000) << QPointF(-20, height()+2000);
     m_terrain = polygon;
-    //qWarning() << "SideviewQuickItem terrain" << m_elapsedTimer.elapsed();
 
-    // Airspaces
-    auto airspaces = GlobalObject::geoMapProvider()->airspaces();
-    QVector<QPolygonF> airspacePolygonsA;
-    QVector<QPolygonF> airspacePolygonsCTR;
-    QVector<QPolygonF> airspacePolygonsR;
-    QVector<QPolygonF> airspacePolygonsRMZ;
-    QVector<QPolygonF> airspacePolygonsNRA;
-    QVector<QPolygonF> airspacePolygonsPJE;
-    QVector<QPolygonF> airspacePolygonsTMZ;
-    QList<QPointF> upper;
-    QList<QPointF> lower;
-    QGeoRectangle const viewBBox(QList({geoCoordinates.constFirst(), geoCoordinates.constLast()}));
-    for(const auto& airspace : std::as_const(airspaces))
+    m_airspaces = buildAirspacePolygons(xCoordinates, geoCoordinates, elevations,
+                                         ownshipGeometricAltitude, ownshipPressureAltitude, altToYCoordinate);
+}
+
+
+// ---------------------------------------------------------------------------
+// Mode::Route  — terrain/airspaces along the planned flight route
+// ---------------------------------------------------------------------------
+void Ui::SideviewQuickItem::updatePropertiesRoute()
+{
+    const QScopedPropertyUpdateGroup updateLock;
+    m_fiveMinuteBar   = {0, 0};
+    m_ownshipPosition = {-100, -100};
+    m_track           = QString();
+    m_error           = QString();
+    m_terrain         = QPolygonF();
+
+    const QVector<QPolygonF> empty;
+    QVariantMap newAirspaces;
+    newAirspaces[u"A"_s]   = QVariant::fromValue(empty);
+    newAirspaces[u"CTR"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"R"_s]   = QVariant::fromValue(empty);
+    newAirspaces[u"RMZ"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"NRA"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"PJE"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"TMZ"_s] = QVariant::fromValue(empty);
+    m_airspaces = newAirspaces;
+
+    if (height() < 5.0) { return; }
+
+    // -----------------------------------------------------------------------
+    // 1. Get the planned route
+    // -----------------------------------------------------------------------
+    auto geoPath = GlobalObject::navigator()->flightRoute()->geoPath();
+    if (geoPath.size() < 2)
     {
-        if (!airspaceCategories.contains(airspace.CAT()))
-        {
-            continue;
-        }
-        auto bbox = airspace.polygon().boundingGeoRectangle();
-        if (!bbox.intersects(viewBBox))
-        {
-            continue;
-        }
+        m_error = tr("Unable to show side view: No flight route. Please plan a route first.");
+        return;
+    }
 
-        auto airspacePolygon = airspace.polygon();
-        for(int i=0; i < xCoordinates.size(); i++)
+    // -----------------------------------------------------------------------
+    // 2. Build cumulative distance table along the route polyline
+    //    cumulativeDist[i] = distance from geoPath[0] to geoPath[i], in metres
+    // -----------------------------------------------------------------------
+    QList<double> cumulativeDist;
+    cumulativeDist.reserve(geoPath.size());
+    cumulativeDist << 0.0;
+    for (qsizetype i = 1; i < geoPath.size(); i++)
+    {
+        cumulativeDist << cumulativeDist.last() + geoPath[i-1].distanceTo(geoPath[i]);
+    }
+    const double totalRouteLen = cumulativeDist.last();
+    if (totalRouteLen < 1.0)
+    {
+        m_error = tr("Unable to show side view: Flight route is too short.");
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Helper: given a distance along the route, return the QGeoCoordinate
+    //    by linear interpolation between the nearest waypoints.
+    // -----------------------------------------------------------------------
+    auto coordAtDist = [&](double distM) -> QGeoCoordinate
+    {
+        distM = qBound(0.0, distM, totalRouteLen);
+        // Find the leg that contains distM
+        qsizetype seg = 0;
+        for (qsizetype i = 1; i < cumulativeDist.size(); i++)
         {
-            auto x = xCoordinates[i];
-            const auto& geoCoordinate = geoCoordinates[i];
-            if ((i != xCoordinates.size()-1) && airspacePolygon.contains(geoCoordinate))
+            if (cumulativeDist[i] >= distM)
             {
-                auto u = airspace.estimatedUpperBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
-                auto l = airspace.estimatedLowerBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
-                if (l < u)
-                {
-                    upper << QPointF(x, altToYCoordinate(u));
-                    lower << QPointF(x, altToYCoordinate(l));
-                    continue;
-                }
+                seg = i - 1;
+                break;
             }
+            seg = i - 1; // last segment
+        }
+        double segLen = cumulativeDist[seg+1] - cumulativeDist[seg];
+        if (segLen < 0.01) { return geoPath[seg]; }
+        double t = (distM - cumulativeDist[seg]) / segLen;
+        double az = geoPath[seg].azimuthTo(geoPath[seg+1]);
+        return geoPath[seg].atDistanceAndAzimuth(t * segLen, az);
+    };
 
-            if (!upper.isEmpty())
+    // -----------------------------------------------------------------------
+    // 4. Sample the route at pixel resolution
+    //    Each pixel column x maps to a distance proportional along the route.
+    // -----------------------------------------------------------------------
+    const double renderW = rw();
+    const int step = 4;
+    QList<int> xCoordinates;
+    xCoordinates.reserve(qRound((renderW+20)/step));
+    for (int x = -10; x <= renderW+10; x += step) { xCoordinates << x; }
+
+    QList<QGeoCoordinate> geoCoordinates;
+    geoCoordinates.reserve(xCoordinates.size());
+    for (auto x : std::as_const(xCoordinates))
+    {
+        double fraction = (double)x / renderW;
+        geoCoordinates << coordAtDist(fraction * totalRouteLen);
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Sample terrain elevations
+    // -----------------------------------------------------------------------
+    QList<Units::Distance> elevations;
+    elevations.reserve(geoCoordinates.size());
+    Units::Distance minElevation = Units::Distance::fromM(0.0);
+    Units::Distance maxElevation = Units::Distance::fromM(0.0);
+    bool firstElev = true;
+    for (const auto& gc : std::as_const(geoCoordinates))
+    {
+        auto elev = GlobalObject::geoMapProvider()->terrainElevationAMSL(gc);
+        if (!elev.isFinite())
+        {
+            elev = Units::Distance::fromM(0.0);
+            m_error = tr("Incomplete terrain data. Please install the relevant terrain maps.");
+        }
+        elevations << elev;
+        if (firstElev) { minElevation = maxElevation = elev; firstElev = false; }
+        else { minElevation = qMin(minElevation, elev); maxElevation = qMax(maxElevation, elev); }
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Determine vertical extent of the view
+    //    Centre vertically around the terrain + a comfortable margin above.
+    // -----------------------------------------------------------------------
+    Units::Distance sideview_minAlt = minElevation - Units::Distance::fromFT(200);
+    Units::Distance sideview_maxAlt = maxElevation + Units::Distance::fromFT(4000);
+
+    auto altToY = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt) {
+        return ((double)height()) * (sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
+    };
+
+    m_scaleMinAltFt    = sideview_minAlt.toFeet();
+    m_scaleMaxAltFt    = sideview_maxAlt.toFeet();
+    m_scaleTotalDistKm = totalRouteLen / 1000.0;
+
+    // -----------------------------------------------------------------------
+    // 7. Terrain polygon
+    // -----------------------------------------------------------------------
+    QPolygonF polygon;
+    polygon.reserve(elevations.size() + 4);
+    for (qsizetype i = 0; i < elevations.size(); i++)
+    {
+        polygon << QPointF(xCoordinates[i], altToY(elevations[i]));
+    }
+    polygon << QPointF(renderW, height()+2000) << QPointF(-10, height()+2000);
+    m_terrain = polygon;
+
+    // -----------------------------------------------------------------------
+    // 8. Ownship position — project current GPS fix onto the route polyline
+    //    by finding the closest point along all legs.
+    // -----------------------------------------------------------------------
+    auto ownshipCoordinate = Positioning::PositionProvider::lastValidCoordinate();
+    auto ownshipGeometricAltitude = Units::Distance::fromM(0.0);
+    auto ownshipPressureAltitude  = Units::Distance::fromM(0.0);
+
+    if (ownshipCoordinate.isValid())
+    {
+        // Find the leg with minimum perpendicular distance to ownship
+        double bestDistM = std::numeric_limits<double>::max();
+        double bestAlongRouteM = 0.0;
+
+        for (qsizetype i = 0; i+1 < geoPath.size(); i++)
+        {
+            // Project ownship onto this leg segment
+            double legLen = geoPath[i].distanceTo(geoPath[i+1]);
+            if (legLen < 1.0) { continue; }
+
+            double az      = geoPath[i].azimuthTo(geoPath[i+1]);
+            double azOwn   = geoPath[i].azimuthTo(ownshipCoordinate);
+            double distFromStart = geoPath[i].distanceTo(ownshipCoordinate);
+            double angleDiff = (azOwn - az) * M_PI / 180.0;
+            double along = distFromStart * std::cos(angleDiff);
+            along = qBound(0.0, along, legLen);
+
+            QGeoCoordinate projected = geoPath[i].atDistanceAndAzimuth(along, az);
+            double perp = projected.distanceTo(ownshipCoordinate);
+
+            if (perp < bestDistM)
             {
-                std::reverse(lower.begin(), lower.end());
-                QPolygonF polygon(upper + lower);
-                polygon << upper[0];
-                if ((airspace.CAT() == u"A"_s) || (airspace.CAT() == u"B"_s) || (airspace.CAT() == u"C"_s) || (airspace.CAT() == u"D"_s))
-                {
-                    airspacePolygonsA << polygon;
-                }
-                if (airspace.CAT() == u"CTR"_s)
-                {
-                    airspacePolygonsCTR << polygon;
-                }
-                if ((airspace.CAT() == u"R"_s) || (airspace.CAT() == u"P"_s) || (airspace.CAT() == u"DNG"_s))
-                {
-                    airspacePolygonsR << polygon;
-                }
-                if ((airspace.CAT() == u"ATZ"_s) || (airspace.CAT() == u"RMZ"_s) || (airspace.CAT() == u"TIA"_s) || (airspace.CAT() == u"TIZ"_s))
-                {
-                    airspacePolygonsRMZ << polygon;
-                }
-                if (airspace.CAT() == u"NRA"_s)
-                {
-                    airspacePolygonsNRA << polygon;
-                }
-                if ((airspace.CAT() == u"PJE"_s) || (airspace.CAT() == u"SUA"_s))
-                {
-                    airspacePolygonsPJE << polygon;
-                }
-                if (airspace.CAT() == u"TMZ"_s)
-                {
-                    airspacePolygonsTMZ << polygon;
-                }
-                upper.clear();
-                lower.clear();
+                bestDistM = perp;
+                bestAlongRouteM = cumulativeDist[i] + along;
+            }
+        }
+
+        double ownX = (bestAlongRouteM / totalRouteLen) * renderW;
+
+        ownshipGeometricAltitude = Units::Distance::fromM(ownshipCoordinate.altitude());
+        if (!ownshipGeometricAltitude.isFinite()) { ownshipGeometricAltitude = minElevation; }
+
+        ownshipPressureAltitude = GlobalObject::positionProvider()->pressureAltitude();
+        if (!ownshipPressureAltitude.isFinite())
+        {
+            ownshipPressureAltitude = m_baroCache->estimatedPressureAltitude(ownshipGeometricAltitude);
+        }
+        if (!ownshipPressureAltitude.isFinite())
+        {
+            ownshipPressureAltitude = ownshipGeometricAltitude;
+            m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because barometric altitude information is not available. <a href='xx'>Click here</a> for more information.");
+        }
+
+        // Clamp to terrain
+        auto ownTerrainElev = GlobalObject::geoMapProvider()->terrainElevationAMSL(ownshipCoordinate);
+        if (ownTerrainElev.isFinite() && ownshipGeometricAltitude < ownTerrainElev)
+        {
+            ownshipGeometricAltitude = ownTerrainElev;
+        }
+
+        double ownY = altToY(ownshipGeometricAltitude);
+        m_ownshipPosition = {ownX, ownY};
+
+        // 5-minute bar: use current speed/vspeed projected along the route
+        auto posInfo = GlobalObject::positionProvider()->positionInfo();
+        if (posInfo.isValid())
+        {
+            auto hSpeed = posInfo.groundSpeed();
+            auto vSpeed = posInfo.verticalSpeed();
+            if (hSpeed.isFinite() && hSpeed >= Units::Speed::fromKN(10) && vSpeed.isFinite())
+            {
+                double dxPixels = (hSpeed.toMPS() * 5.0 * 60.0 / totalRouteLen) * renderW;
+                double dyPixels = -height() * vSpeed.toFPM() * 5.0 / (sideview_maxAlt - sideview_minAlt).toFeet();
+                m_fiveMinuteBar = {dxPixels, dyPixels};
             }
         }
     }
 
-    newAirspaces[u"A"_s] = QVariant::fromValue(airspacePolygonsA);
-    newAirspaces[u"CTR"_s] = QVariant::fromValue(airspacePolygonsCTR);
-    newAirspaces[u"R"_s] = QVariant::fromValue(airspacePolygonsR);
-    newAirspaces[u"RMZ"_s] = QVariant::fromValue(airspacePolygonsRMZ);
-    newAirspaces[u"NRA"_s] = QVariant::fromValue(airspacePolygonsNRA);
-    newAirspaces[u"PJE"_s] = QVariant::fromValue(airspacePolygonsPJE);
-    newAirspaces[u"TMZ"_s] = QVariant::fromValue(airspacePolygonsTMZ);
-
-    m_airspaces = newAirspaces;
-    //qWarning() << "SideviewQuickItem full" << m_elapsedTimer.elapsed();
+    // -----------------------------------------------------------------------
+    // 9. Airspace polygons
+    // -----------------------------------------------------------------------
+    if (!GlobalObject::weatherDataProvider()->QNH().isFinite())
+    {
+        m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because the QNH is not available. Please wait while QNH information is downloaded from the internet.");
+        // Still show terrain — don't return early
+    }
+    else
+    {
+        m_airspaces = buildAirspacePolygons(xCoordinates, geoCoordinates, elevations,
+                                             ownshipGeometricAltitude, ownshipPressureAltitude, altToY);
+    }
 }

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -42,6 +42,14 @@ class SideviewQuickItem : public QQuickItem
     QML_NAMED_ELEMENT(SideviewQuickItem)
 
 public:
+
+    /*! \brief Display mode for the side view */
+    enum class Mode {
+        Track, /*!< Show terrain/airspaces along current position and track (default) */
+        Route  /*!< Show terrain/airspaces along the planned flight route */
+    };
+    Q_ENUM(Mode)
+
     explicit SideviewQuickItem(QQuickItem *parent = nullptr);
 
     ~SideviewQuickItem() override = default;
@@ -83,6 +91,16 @@ public:
      */
     Q_PROPERTY(QPointF fiveMinuteBar READ fiveMinuteBar BINDABLE bindableFiveMinuteBar)
 
+    /*! \brief Display mode
+     *
+     * Controls whether the side view is computed along the current track
+     * (Mode::Track, default) or along the planned flight route (Mode::Route).
+     * In Route mode the ownship marker is placed at the aircraft's projected
+     * position along the route; the horizontal extent of the view covers the
+     * full route from first to last waypoint.
+     */
+    Q_PROPERTY(Mode mode READ mode WRITE setMode NOTIFY modeChanged)
+
     /*! \brief Position of the own aircraft
      *
      * This property holds the position of the own aircraft, in pixel
@@ -96,6 +114,22 @@ public:
      * flightmap in order to synchronize the scales.
      */
     Q_PROPERTY(double pixelPer10km READ pixelPer10km WRITE setPixelPer10km BINDABLE bindablePixelPer10km REQUIRED)
+
+    /*! \brief Width (in pixels) used for horizontal coordinate computation.
+     *
+     * Set this to the Flickable contentWidth to enable horizontal scrolling.
+     * When ≤ 0 the item's own width() is used instead.
+     */
+    Q_PROPERTY(double renderWidth READ renderWidth WRITE setRenderWidth NOTIFY renderWidthChanged)
+
+    /*! \brief Maximum altitude shown on the Y axis, in feet */
+    Q_PROPERTY(double scaleMaxAltFt READ scaleMaxAltFt NOTIFY scaleRangeChanged)
+
+    /*! \brief Minimum altitude shown on the Y axis, in feet */
+    Q_PROPERTY(double scaleMinAltFt READ scaleMinAltFt NOTIFY scaleRangeChanged)
+
+    /*! \brief Total route length shown on the X axis, in kilometres (0 in Track mode) */
+    Q_PROPERTY(double scaleTotalDistKm READ scaleTotalDistKm NOTIFY scaleRangeChanged)
 
     /*! \brief Terrain polygons
      *
@@ -153,6 +187,9 @@ public:
      */
     QBindable<QPointF> bindableFiveMinuteBar() const {return &m_fiveMinuteBar;}
 
+    Mode mode() const { return m_mode; }
+    void setMode(Mode newMode);
+
     /*! \brief Getter method for property with the same name
      *
      *  @returns Property ownshipPosition
@@ -183,6 +220,13 @@ public:
      */
     void setPixelPer10km(double newVal) {m_pixelPer10km = newVal;}
 
+    double renderWidth() const { auto v = m_renderWidth.value(); return v > 0 ? v : width(); }
+    void setRenderWidth(double v) { m_renderWidth = v; }
+
+    double scaleMaxAltFt() const { return m_scaleMaxAltFt.value(); }
+    double scaleMinAltFt() const { return m_scaleMinAltFt.value(); }
+    double scaleTotalDistKm() const { return m_scaleTotalDistKm.value(); }
+
     /*! \brief Getter method for property with the same name
      *
      *  @returns Property track
@@ -207,6 +251,10 @@ public:
      */
     QBindable<QPolygonF> bindableTerrain() const {return &m_terrain;}
 
+signals:
+    void modeChanged();
+    void renderWidthChanged();
+    void scaleRangeChanged();
 
 private:
     Q_DISABLE_COPY_MOVE(SideviewQuickItem)
@@ -219,7 +267,25 @@ private:
 
     // Compute
     void updateProperties();
+    void updatePropertiesTrack();
+    void updatePropertiesRoute();
 
+    // Returns renderWidth if set, else actual item width.
+    double rw() const { auto v = m_renderWidth.value(); return v > 0 ? v : width(); }
+
+    // Shared helper: build airspace polygons along a sampled geo-path.
+    // xCoordinates and geoCoordinates must be the same length.
+    // elevations must be the same length.
+    // Returns a QVariantMap with the same keys as m_airspaces.
+    QVariantMap buildAirspacePolygons(
+        const QList<int>& xCoordinates,
+        const QList<QGeoCoordinate>& geoCoordinates,
+        const QList<Units::Distance>& elevations,
+        Units::Distance ownshipGeometricAltitude,
+        Units::Distance ownshipPressureAltitude,
+        std::function<double(Units::Distance)> altToY);
+
+    Mode m_mode {Mode::Track};
 
     QProperty<QString> m_error;
 
@@ -235,10 +301,15 @@ private:
 
     QProperty<QVariantMap> m_airspaces;
 
+    QProperty<double> m_renderWidth   {0.0};
+    QProperty<double> m_scaleMaxAltFt {0.0};
+    QProperty<double> m_scaleMinAltFt {0.0};
+    QProperty<double> m_scaleTotalDistKm {0.0};
+
     Navigation::BaroCache* m_baroCache;
 
     std::vector<QPropertyNotifier> notifiers;
-
+    
 };
 
 } // namespace Ui

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -138,6 +138,22 @@ public:
      */
     Q_PROPERTY(QPolygonF terrain READ terrain BINDABLE bindableTerrain)
 
+    /*! \brief Planned altitude profile (route mode only)
+     *
+     * A polyline of (x, y) points in content-pixel coordinates, one point per
+     * route waypoint, representing the planned cruise altitude. Used to draw the
+     * profile line. Empty in Track mode.
+     */
+    Q_PROPERTY(QPolygonF plannedProfile READ plannedProfile BINDABLE bindablePlannedProfile)
+
+    /*! \brief Planned altitude profile points, as a list (route mode only)
+     *
+     * The same points as plannedProfile, but as a QVariantList of QPointF so
+     * that a QML Repeater can iterate them to place the clickable altitude
+     * markers. Empty in Track mode.
+     */
+    Q_PROPERTY(QVariantList plannedProfilePoints READ plannedProfilePoints BINDABLE bindablePlannedProfilePoints)
+
     /*! \brief Track string
      *
      * If the own aircraft is not moving sufficiently fast, this property holds
@@ -251,6 +267,30 @@ public:
      */
     QBindable<QPolygonF> bindableTerrain() const {return &m_terrain;}
 
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfile
+     */
+    QPolygonF plannedProfile() const {return m_plannedProfile.value();}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfile
+     */
+    QBindable<QPolygonF> bindablePlannedProfile() const {return &m_plannedProfile;}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfilePoints
+     */
+    QVariantList plannedProfilePoints() const {return m_plannedProfilePoints.value();}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfilePoints
+     */
+    QBindable<QVariantList> bindablePlannedProfilePoints() const {return &m_plannedProfilePoints;}
+
 signals:
     void modeChanged();
     void renderWidthChanged();
@@ -298,6 +338,10 @@ private:
     QProperty<QPointF> m_fiveMinuteBar;
 
     QProperty<QPolygonF> m_terrain;
+
+    QProperty<QPolygonF> m_plannedProfile;
+
+    QProperty<QVariantList> m_plannedProfilePoints;
 
     QProperty<QVariantMap> m_airspaces;
 


### PR DESCRIPTION
Route mode (Mode::Route):
- Terrain and airspaces are sampled along the full planned flight route instead of ahead of the current track.
- Ownship marker is projected onto the nearest route leg.
- 5-minute bar is scaled proportionally to route length.
- Mode toggle button (✈ / ⇢) switches between Track and Route mode.
- Route changes are tracked via a bindable notifier.

Axis scales (QML overlay):
- Y axis (left panel): altitude ticks in the aircraft's configured vertical unit (ft or m), auto-spaced to 4–8 ticks.
- X axis (bottom panel): distance ticks in the aircraft's configured horizontal unit (NM, km, or mi), scrolls with content.

Horizontal scrolling (Route mode only):
- A Flickable wraps the content area; zoom buttons (+ / −) double or halve the zoom factor (1× – 8×).
- New renderWidth property: C++ uses it instead of width() for X coordinate computation, so terrain and airspaces stay correctly positioned at any zoom level.
- Switching back to Track mode resets zoom and scroll position.

New C++ properties on SideviewQuickItem:
- mode (read/write): Track or Route.
- renderWidth (read/write): content width for coordinate computation.
- scaleMinAltFt / scaleMaxAltFt: altitude range exposed to QML.
- scaleTotalDistKm: total route length (Route) or 0 (Track).

Airspace polygon building is extracted into buildAirspacePolygons(), a shared helper called by both updatePropertiesTrack() and updatePropertiesRoute().