### PR TITLE
Add weather layer with METAR flight-category dots and wind barbs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ set(SOURCES
     units/VolumeFlow.h
     weather/Decoder.h
     weather/DensityAltitude.h
+    weather/ForecastMapProvider.h
     weather/METAR.h
     weather/Observer.h
     weather/ObserverList.h
@@ -229,6 +230,7 @@ set(SOURCES
     units/VolumeFlow.cpp
     weather/Decoder.cpp
     weather/DensityAltitude.cpp
+    weather/ForecastMapProvider.cpp
     weather/METAR.cpp
     weather/Observer.cpp
     weather/ObserverList.cpp
@@ -604,6 +606,7 @@ qt_add_qml_module(${PROJECT_NAME}
     qml/items/AppWindow.qml
     qml/items/+Material/AppWindow.qml
     qml/items/AutoSizingMenu.qml
+    qml/items/ColorScaleLegend.qml
     qml/items/DecoratedListView.qml
     qml/items/DecoratedScrollView.qml
     qml/items/DegreeInput.qml

--- a/src/qml/items/ColorScaleLegend.qml
+++ b/src/qml/items/ColorScaleLegend.qml
@@ -18,7 +18,7 @@ Item {
     // Gradient bar
     Rectangle {
         id: bar
-        anchors { left: parent.left; right: parent.right }
+        width: root.width
         height: 10
         radius: 2
         border.color: Qt.rgba(0, 0, 0, 0.15)
@@ -36,7 +36,8 @@ Item {
     // Tick labels: vmin | stop1 | stop2 | vmax [units]
     Row {
         id: ticks
-        anchors { left: parent.left; right: parent.right; top: bar.bottom; topMargin: 2 }
+        width: root.width
+        anchors { top: bar.bottom; topMargin: 2 }
 
         readonly property double range: root.vmax - root.vmin
         readonly property double v1: root.vmin + range * 0.33

--- a/src/qml/items/ColorScaleLegend.qml
+++ b/src/qml/items/ColorScaleLegend.qml
@@ -1,0 +1,80 @@
+// Color scale legend bar with labeled tick marks at each color stop.
+// Expects 4 colors at positions 0, 0.33, 0.66, 1.0 matching the server colormaps.
+
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    id: root
+
+    property var    colors: []
+    property double vmin: 0
+    property double vmax: 1
+    property string units: ""
+
+    implicitHeight: bar.height + ticks.height + 2
+    implicitWidth:  200
+
+    // Gradient bar
+    Rectangle {
+        id: bar
+        anchors { left: parent.left; right: parent.right }
+        height: 10
+        radius: 2
+        border.color: Qt.rgba(0, 0, 0, 0.15)
+        border.width: 1
+
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+            GradientStop { position: 0.0;  color: root.colors[0] ?? "transparent" }
+            GradientStop { position: 0.33; color: root.colors[1] ?? "transparent" }
+            GradientStop { position: 0.66; color: root.colors[2] ?? "transparent" }
+            GradientStop { position: 1.0;  color: root.colors[3] ?? "transparent" }
+        }
+    }
+
+    // Tick labels: vmin | stop1 | stop2 | vmax [units]
+    Row {
+        id: ticks
+        anchors { left: parent.left; right: parent.right; top: bar.bottom; topMargin: 2 }
+
+        readonly property double range: root.vmax - root.vmin
+        readonly property double v1: root.vmin + range * 0.33
+        readonly property double v2: root.vmin + range * 0.66
+
+        function fmt(v) {
+            return v >= 1000 ? Math.round(v).toString()
+                 : v < 1    ? v.toFixed(1)
+                 :             Math.round(v).toString()
+        }
+
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(root.vmin)
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignLeft
+            opacity: 0.7
+        }
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(ticks.v1)
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignHCenter
+            opacity: 0.7
+        }
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(ticks.v2)
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignHCenter
+            opacity: 0.7
+        }
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(root.vmax) + (root.units ? " " + root.units : "")
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignRight
+            opacity: 0.7
+        }
+    }
+}

--- a/src/qml/items/ColorScaleLegend.qml
+++ b/src/qml/items/ColorScaleLegend.qml
@@ -11,6 +11,9 @@ Item {
     property double vmin: 0
     property double vmax: 1
     property string units: ""
+    // Optional custom label formatter: function(value, isLast) → string
+    // When set, overrides the default fmt() + units logic
+    property var    labelFunc: null
 
     implicitHeight: bar.height + ticks.height + 2
     implicitWidth:  200
@@ -43,36 +46,38 @@ Item {
         readonly property double v1: root.vmin + range * 0.33
         readonly property double v2: root.vmin + range * 0.66
 
-        function fmt(v) {
-            return v >= 1000 ? Math.round(v).toString()
-                 : v < 1    ? v.toFixed(1)
-                 :             Math.round(v).toString()
+        function fmt(v, isLast) {
+            if (root.labelFunc) return root.labelFunc(v)
+            var s = v >= 1000 ? Math.round(v).toString()
+                  : v < 1    ? v.toFixed(1)
+                  :             Math.round(v).toString()
+            return isLast && root.units ? s + " " + root.units : s
         }
 
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(root.vmin)
+            text: ticks.fmt(root.vmin, false)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignLeft
             opacity: 0.7
         }
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(ticks.v1)
+            text: ticks.fmt(ticks.v1, false)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignHCenter
             opacity: 0.7
         }
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(ticks.v2)
+            text: ticks.fmt(ticks.v2, false)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignHCenter
             opacity: 0.7
         }
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(root.vmax) + (root.units ? " " + root.units : "")
+            text: ticks.fmt(root.vmax, true)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignRight
             opacity: 0.7

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -756,19 +756,19 @@ Map {
         }
 
         LayerParameter {
-            id: forecastRainLayer
-            styleId: "forecastRainLayer"
-            type: "raster"
-            property string source: "forecastRain"
-            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
             id: forecastCloudbaseLayer
             styleId: "forecastCloudbaseLayer"
             type: "raster"
             property string source: "forecastCloudbase"
             layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastRainLayer
+            styleId: "forecastRainLayer"
+            type: "raster"
+            property string source: "forecastRain"
+            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
         }
 
         LayerParameter {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -681,6 +681,11 @@ Map {
                 "visibility": 'visible', // GeoMapProvider.currentRasterMap !== "" ? 'visible' : 'none'
                 "raster-resampling": 'linear'
             }
+
+            paint: ({
+                "raster-opacity":         flightMap.showWindLayer ? 0.35 : 1.0,
+                "raster-brightness-max":  flightMap.showWindLayer ? 0.7  : 1.0
+            })
         }
 
         LayerParameter {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -40,6 +40,9 @@ Map {
     */
     property real pixelPer10km: 0.0
 
+    /*! \brief Show METAR weather layer (flight category dots + wind barbs) */
+    property bool showWeatherLayer: false
+
     /* Handle changes in zoom level */
     onZoomLevelChanged: {
         var vec1 = flightMap.fromCoordinate(flightMap.center, false)
@@ -934,6 +937,117 @@ Map {
         id: midFieldWaypoints
         model: Navigator.flightRoute.midFieldWaypoints
         delegate: waypointComponent
+    }
+
+    ObserverList {
+        id: weatherObservers
+    }
+
+    MapItemView { // METAR flight category dots and wind barbs
+        visible: flightMap.showWeatherLayer
+        model: weatherObservers.observers
+        delegate: Component {
+            MapQuickItem {
+                id: metarItem
+
+                property var obs: modelData
+                property var met: obs.metar
+
+                anchorPoint.x: 14
+                anchorPoint.y: 14
+                coordinate: met.coordinate
+                visible: met.isValid
+
+                sourceItem: Canvas {
+                    id: metarCanvas
+                    width: 70
+                    height: 70
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+
+                        // Flight category dot with transparency
+                        var dotColor = met.flightCategoryColor === "transparent" ? "gray" : met.flightCategoryColor
+                        ctx.beginPath()
+                        ctx.arc(14, 14, 12, 0, 2*Math.PI)
+                        ctx.globalAlpha = 0.55
+                        ctx.fillStyle = dotColor
+                        ctx.fill()
+                        ctx.globalAlpha = 1.0
+                        ctx.strokeStyle = "white"
+                        ctx.lineWidth = 2
+                        ctx.stroke()
+
+                        // Wind barb
+                        if (!met.windSpeed.isFinite() || !met.windDirection.isFinite()) return
+                        var spd = met.windSpeed.toKN()
+                        if (spd < 1) return
+
+                        var dirRad = met.windDirection.toRAD() + Math.PI // barb points into wind
+                        var cx = 14, cy = 14
+                        var len = 32
+                        var ex = cx + len * Math.sin(dirRad)
+                        var ey = cy - len * Math.cos(dirRad)
+
+                        // Staff
+                        ctx.beginPath()
+                        ctx.moveTo(cx, cy)
+                        ctx.lineTo(ex, ey)
+                        ctx.strokeStyle = "black"
+                        ctx.lineWidth = 2
+                        ctx.stroke()
+
+                        // Barbs: each full barb = 10 kt, half barb = 5 kt, pennant = 50 kt
+                        var remaining = Math.round(spd)
+                        var perpX = Math.cos(dirRad)
+                        var perpY = Math.sin(dirRad)
+                        var bx = ex, by = ey
+                        var stepX = -Math.sin(dirRad) * 6
+                        var stepY =  Math.cos(dirRad) * 6
+                        var barbLen = 13
+
+                        // Pennants (50 kt)
+                        while (remaining >= 50) {
+                            ctx.beginPath()
+                            ctx.moveTo(bx, by)
+                            ctx.lineTo(bx + stepX*2 + perpX*barbLen, by + stepY*2 + perpY*barbLen)
+                            ctx.lineTo(bx + stepX*2, by + stepY*2)
+                            ctx.closePath()
+                            ctx.fillStyle = "black"
+                            ctx.fill()
+                            bx += stepX*2; by += stepY*2
+                            remaining -= 50
+                        }
+                        // Full barbs (10 kt)
+                        while (remaining >= 10) {
+                            ctx.beginPath()
+                            ctx.moveTo(bx, by)
+                            ctx.lineTo(bx + perpX*barbLen, by + perpY*barbLen)
+                            ctx.strokeStyle = "black"
+                            ctx.lineWidth = 2
+                            ctx.stroke()
+                            bx += stepX; by += stepY
+                            remaining -= 10
+                        }
+                        // Half barb (5 kt)
+                        if (remaining >= 5) {
+                            ctx.beginPath()
+                            ctx.moveTo(bx, by)
+                            ctx.lineTo(bx + perpX*barbLen*0.5, by + perpY*barbLen*0.5)
+                            ctx.stroke()
+                        }
+                    }
+
+                    Connections {
+                        target: metarItem.obs
+                        function onMetarChanged() { metarCanvas.requestPaint() }
+                    }
+
+                    Component.onCompleted: requestPaint()
+                }
+            }
+        }
     }
 
 } // End of FlightMap

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -682,10 +682,6 @@ Map {
                 "raster-resampling": 'linear'
             }
 
-            paint: ({
-                "raster-opacity":         flightMap.showWindLayer ? 0.35 : 1.0,
-                "raster-brightness-max":  flightMap.showWindLayer ? 0.7  : 1.0
-            })
         }
 
         LayerParameter {
@@ -774,6 +770,15 @@ Map {
         }
     }
 
+
+    // Dim the base map when the wind layer is active so barbs stand out
+    Rectangle {
+        anchors.fill: parent
+        color: "white"
+        opacity: flightMap.showWindLayer ? 0.55 : 0.0
+        z: 0
+        Behavior on opacity { NumberAnimation { duration: 300 } }
+    }
 
     //
     // Additional Map Items

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -701,7 +701,7 @@ Map {
             styleId: "ofmDimmer"
             type: "background"
             layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
-            paint: { "background-color": "white", "background-opacity": 0.55 }
+            paint: { "background-color": "white", "background-opacity": 0.68 }
         }
 
         LayerParameter {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -43,6 +43,15 @@ Map {
     /*! \brief Show METAR weather layer (flight category dots + wind barbs) */
     property bool showWeatherLayer: false
 
+    /*! \brief Show Météo-France rain forecast layer */
+    property bool showRainLayer: false
+
+    /*! \brief Show Météo-France cloud base forecast layer */
+    property bool showCloudbaseLayer: false
+
+    /*! \brief Show Météo-France wind forecast layer */
+    property bool showWindLayer: false
+
     /* Handle changes in zoom level */
     onZoomLevelChanged: {
         var vec1 = flightMap.fromCoordinate(flightMap.center, false)
@@ -108,6 +117,31 @@ Map {
                 // return [ [7, 48], [8, 48], [8, 47], [7, 47] ]
             }
 
+        }
+
+        // Météo-France forecast image sources (fixed bounding box: 10W–15E, 38N–55N)
+        SourceParameter {
+            id: forecastRainSource
+            styleId: "forecastRain"
+            type: "image"
+            property string url: ForecastMapProvider.currentRainMap !== "" ? "file://" + ForecastMapProvider.currentRainMap : "qrc:/icons/appIcon.png"
+            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
+        }
+
+        SourceParameter {
+            id: forecastCloudbaseSource
+            styleId: "forecastCloudbase"
+            type: "image"
+            property string url: ForecastMapProvider.currentCloudbaseMap !== "" ? "file://" + ForecastMapProvider.currentCloudbaseMap : "qrc:/icons/appIcon.png"
+            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
+        }
+
+        SourceParameter {
+            id: forecastWindSource
+            styleId: "forecastWind"
+            type: "image"
+            property string url: ForecastMapProvider.currentWindMap !== "" ? "file://" + ForecastMapProvider.currentWindMap : "qrc:/icons/appIcon.png"
+            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
         }
 
         SourceParameter {
@@ -662,6 +696,30 @@ Map {
         }
 
         LayerParameter {
+            id: forecastRainLayer
+            styleId: "forecastRainLayer"
+            type: "raster"
+            property string source: "forecastRain"
+            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastCloudbaseLayer
+            styleId: "forecastCloudbaseLayer"
+            type: "raster"
+            property string source: "forecastCloudbase"
+            layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastWindLayer
+            styleId: "forecastWindLayer"
+            type: "raster"
+            property string source: "forecastWind"
+            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
             id: waypointLibParam
 
             styleId: "waypoint-layer"
@@ -952,16 +1010,17 @@ Map {
 
                 property var obs: modelData
                 property var met: obs.metar
+                onMetChanged: metarCanvas.requestPaint()
 
-                anchorPoint.x: 14
-                anchorPoint.y: 14
+                anchorPoint.x: 40
+                anchorPoint.y: 40
                 coordinate: met.coordinate
                 visible: met.isValid
 
                 sourceItem: Canvas {
                     id: metarCanvas
-                    width: 70
-                    height: 70
+                    width: 80
+                    height: 80
 
                     onPaint: {
                         var ctx = getContext("2d")
@@ -970,7 +1029,7 @@ Map {
                         // Flight category dot with transparency
                         var dotColor = met.flightCategoryColor === "transparent" ? "gray" : met.flightCategoryColor
                         ctx.beginPath()
-                        ctx.arc(14, 14, 12, 0, 2*Math.PI)
+                        ctx.arc(40, 40, 12, 0, 2*Math.PI)
                         ctx.globalAlpha = 0.55
                         ctx.fillStyle = dotColor
                         ctx.fill()
@@ -984,8 +1043,8 @@ Map {
                         var spd = met.windSpeed.toKN()
                         if (spd < 1) return
 
-                        var dirRad = met.windDirection.toRAD() + Math.PI // barb points into wind
-                        var cx = 14, cy = 14
+                        var dirRad = met.windDirection.toRAD() // staff points toward wind source; barbs drawn at tip
+                        var cx = 40, cy = 40
                         var len = 32
                         var ex = cx + len * Math.sin(dirRad)
                         var ey = cy - len * Math.cos(dirRad)
@@ -1037,11 +1096,6 @@ Map {
                             ctx.lineTo(bx + perpX*barbLen*0.5, by + perpY*barbLen*0.5)
                             ctx.stroke()
                         }
-                    }
-
-                    Connections {
-                        target: metarItem.obs
-                        function onMetarChanged() { metarCanvas.requestPaint() }
                     }
 
                     Component.onCompleted: requestPaint()

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -705,6 +705,7 @@ Map {
             property string source: "waypointlib"
 
             layout: {
+                "visibility": flightMap.showWindLayer ? 'none' : 'visible',
                 "icon-image": '["get", "CAT"]',
                 "text-field": '["get", "NAM"]',
                 "text-size": 0.85*GlobalSettings.fontSize,
@@ -729,6 +730,7 @@ Map {
             property string source: "notams"
 
             layout: {
+                "visibility": flightMap.showWindLayer ? 'none' : 'visible',
                 "icon-ignore-placement": true,
                 "icon-image": ["get", "CAT"],
                 "text-field": ["get", "NAM"],
@@ -745,7 +747,7 @@ Map {
             }
         }
 
-        // White veil between OFM/NOTAMs and forecast layers — dims everything below when wind is active
+        // White veil between OFM tiles and forecast layers — dims the chart when wind is active
         LayerParameter {
             styleId: "ofmDimmer"
             type: "background"

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -729,6 +729,13 @@ Map {
         }
 
         LayerParameter {
+            styleId: "notamDimmer"
+            type: "background"
+            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
+            paint: { "background-color": "white", "background-opacity": 0.45 }
+        }
+
+        LayerParameter {
             id: waypointLibParam
 
             styleId: "waypoint-layer"

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -696,6 +696,14 @@ Map {
             }
         }
 
+        // White veil between OFM tiles and forecast layers — dims the chart without touching overlays
+        LayerParameter {
+            styleId: "ofmDimmer"
+            type: "background"
+            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
+            paint: { "background-color": "white", "background-opacity": 0.55 }
+        }
+
         LayerParameter {
             id: forecastRainLayer
             styleId: "forecastRainLayer"
@@ -770,15 +778,6 @@ Map {
         }
     }
 
-
-    // Dim the base map when the wind layer is active so barbs stand out
-    Rectangle {
-        anchors.fill: parent
-        color: "white"
-        opacity: flightMap.showWindLayer ? 0.55 : 0.0
-        z: 0
-        Behavior on opacity { NumberAnimation { duration: 300 } }
-    }
 
     //
     // Additional Map Items

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -696,45 +696,6 @@ Map {
             }
         }
 
-        // White veil between OFM tiles and forecast layers — dims the chart without touching overlays
-        LayerParameter {
-            styleId: "ofmDimmer"
-            type: "background"
-            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
-            paint: { "background-color": "white", "background-opacity": 0.68 }
-        }
-
-        LayerParameter {
-            id: forecastRainLayer
-            styleId: "forecastRainLayer"
-            type: "raster"
-            property string source: "forecastRain"
-            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
-            id: forecastCloudbaseLayer
-            styleId: "forecastCloudbaseLayer"
-            type: "raster"
-            property string source: "forecastCloudbase"
-            layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
-            id: forecastWindLayer
-            styleId: "forecastWindLayer"
-            type: "raster"
-            property string source: "forecastWind"
-            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
-            styleId: "notamDimmer"
-            type: "background"
-            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
-            paint: { "background-color": "white", "background-opacity": 0.45 }
-        }
-
         LayerParameter {
             id: waypointLibParam
 
@@ -782,6 +743,38 @@ Map {
                 "text-halo-width": 2,
                 "text-halo-color": "white"
             }
+        }
+
+        // White veil between OFM/NOTAMs and forecast layers — dims everything below when wind is active
+        LayerParameter {
+            styleId: "ofmDimmer"
+            type: "background"
+            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
+            paint: { "background-color": "white", "background-opacity": 0.68 }
+        }
+
+        LayerParameter {
+            id: forecastRainLayer
+            styleId: "forecastRainLayer"
+            type: "raster"
+            property string source: "forecastRain"
+            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastCloudbaseLayer
+            styleId: "forecastCloudbaseLayer"
+            type: "raster"
+            property string source: "forecastCloudbase"
+            layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastWindLayer
+            styleId: "forecastWindLayer"
+            type: "raster"
+            property string source: "forecastWind"
+            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
         }
     }
 

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -612,6 +612,22 @@ Item {
                         }
 
                         MapButton {
+                            id: weatherLayerButton
+
+                            checkable: true
+                            checked: flightMap.showWeatherLayer
+                            icon.source: "/icons/material/ic_cloud_queue.svg"
+
+                            onClicked: {
+                                PlatformAdaptor.vibrateBrief()
+                                flightMap.showWeatherLayer = !flightMap.showWeatherLayer
+                                if (flightMap.showWeatherLayer) {
+                                    WeatherDataProvider.requestUpdate()
+                                }
+                            }
+                        }
+
+                        MapButton {
                             id: rasterMapButton
 
                             icon.source: "/icons/material/ic_layers.svg"

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -760,10 +760,16 @@ Item {
                                         }
                                         Label {
                                             visible: ForecastMapProvider.referenceTimeLabel !== ""
-                                            text: qsTr("Model run: ") + ForecastMapProvider.referenceTimeLabel
+                                            text: "AROME " + ForecastMapProvider.referenceTimeLabel
                                             anchors.horizontalCenter: parent.horizontalCenter
                                             font.pixelSize: parent.font ? parent.font.pixelSize * 0.85 : 11
                                             opacity: 0.7
+                                        }
+                                        Label {
+                                            text: "© Météo-France"
+                                            anchors.horizontalCenter: parent.horizontalCenter
+                                            font.pixelSize: parent.font ? parent.font.pixelSize * 0.8 : 10
+                                            opacity: 0.5
                                         }
                                     }
                                 }

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -623,9 +623,19 @@ Item {
                                 weatherMenu.popup()
                             }
 
+                            // Cheated but pilot-friendly FL labels for the 4 AROME pressure levels
                             function hpaToFL(hpa) {
-                                var ft = (1 - Math.pow(parseFloat(hpa) / 1013.25, 0.190284)) * 145366.45
-                                return "FL" + Math.round(ft / 100).toString().padStart(3, "0")
+                                var lookup = { "1000": "FL000", "900": "FL033", "800": "FL065", "700": "FL100" }
+                                return lookup[String(Math.round(parseFloat(hpa)))] ?? ("FL" + Math.round(
+                                    (1 - Math.pow(parseFloat(hpa)/1013.25, 0.190284)) * 145366.45 / 100
+                                ).toString().padStart(3,"0"))
+                            }
+
+                            // Convert cloudbase metres to the aircraft's configured altitude unit
+                            function cbLabel(metres) {
+                                if (Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters)
+                                    return metres.toFixed(0) + " m"
+                                return Math.round(metres * 3.28084) + " ft"
                             }
 
                             AutoSizingMenu {
@@ -674,7 +684,7 @@ Item {
                                         colors: ForecastMapProvider.cloudbaseColors
                                         vmin: ForecastMapProvider.cloudbaseVmin
                                         vmax: ForecastMapProvider.cloudbaseVmax
-                                        units: ForecastMapProvider.cloudbaseUnits
+                                        labelFunc: function(v) { return weatherLayerButton.cbLabel(v) }
                                     }
                                 }
 

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -623,6 +623,11 @@ Item {
                                 weatherMenu.popup()
                             }
 
+                            function hpaToFL(hpa) {
+                                var ft = (1 - Math.pow(parseFloat(hpa) / 1013.25, 0.190284)) * 145366.45
+                                return "FL" + Math.round(ft / 100).toString().padStart(3, "0")
+                            }
+
                             AutoSizingMenu {
                                 id: weatherMenu
 
@@ -642,7 +647,7 @@ Item {
                                 }
 
                                 ItemDelegate {
-                                    visible: flightMap.showRainLayer && ForecastMapProvider.rainColors.length >= 4
+                                    visible: flightMap.showRainLayer
                                     implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
@@ -661,7 +666,7 @@ Item {
                                 }
 
                                 ItemDelegate {
-                                    visible: flightMap.showCloudbaseLayer && ForecastMapProvider.cloudbaseColors.length >= 4
+                                    visible: flightMap.showCloudbaseLayer
                                     implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
@@ -688,7 +693,8 @@ Item {
                                         spacing: 2
                                         Label {
                                             width: parent.width
-                                            text: ForecastMapProvider.currentWindPressureLevel + " hPa"
+                                            text: weatherLayerButton.hpaToFL(ForecastMapProvider.currentWindPressureLevel)
+                                                  + "  (" + ForecastMapProvider.currentWindPressureLevel + " hPa)"
                                             font.pixelSize: 9
                                             horizontalAlignment: Text.AlignHCenter
                                             opacity: 0.7
@@ -708,7 +714,7 @@ Item {
                                                 model: ForecastMapProvider.windPressureLevels
                                                 Label {
                                                     width: parent.width / ForecastMapProvider.windPressureLevels.length
-                                                    text: modelData + " hPa"
+                                                    text: weatherLayerButton.hpaToFL(modelData)
                                                     font.pixelSize: 9
                                                     horizontalAlignment: index === 0 ? Text.AlignLeft
                                                         : index === ForecastMapProvider.windPressureLevels.length - 1 ? Text.AlignRight

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -643,9 +643,10 @@ Item {
 
                                 ItemDelegate {
                                     visible: flightMap.showRainLayer && ForecastMapProvider.rainColors.length >= 4
-                                    width: parent ? parent.width : 300
+                                    implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
+                                        width: parent.width
                                         colors: ForecastMapProvider.rainColors
                                         vmin: ForecastMapProvider.rainVmin
                                         vmax: ForecastMapProvider.rainVmax
@@ -661,9 +662,10 @@ Item {
 
                                 ItemDelegate {
                                     visible: flightMap.showCloudbaseLayer && ForecastMapProvider.cloudbaseColors.length >= 4
-                                    width: parent ? parent.width : 300
+                                    implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
+                                        width: parent.width
                                         colors: ForecastMapProvider.cloudbaseColors
                                         vmin: ForecastMapProvider.cloudbaseVmin
                                         vmax: ForecastMapProvider.cloudbaseVmax
@@ -679,9 +681,10 @@ Item {
 
                                 ItemDelegate {
                                     visible: flightMap.showWindLayer && ForecastMapProvider.windPressureLevels.length > 1
-                                    width: parent ? parent.width : 300
+                                    implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: Column {
+                                        width: parent.width
                                         spacing: 2
                                         Label {
                                             width: parent.width

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -636,54 +636,38 @@ Item {
                                 }
 
                                 CheckDelegate {
-                                    text: qsTr("Rain forecast") + (ForecastMapProvider.rainUnits ? "  [" + ForecastMapProvider.rainUnits + "]" : "")
+                                    text: qsTr("Rain forecast")
                                     checked: flightMap.showRainLayer
                                     onClicked: flightMap.showRainLayer = checked
-                                    contentItem: Row {
-                                        spacing: 8
-                                        Label {
-                                            text: parent.parent.text
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            elide: Text.ElideRight
-                                        }
-                                        Rectangle {
-                                            visible: ForecastMapProvider.rainColors.length > 1
-                                            width: 60; height: 8
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            gradient: Gradient {
-                                                orientation: Gradient.Horizontal
-                                                GradientStop { position: 0.0; color: ForecastMapProvider.rainColors[0] || "transparent" }
-                                                GradientStop { position: 0.33; color: ForecastMapProvider.rainColors[1] || "transparent" }
-                                                GradientStop { position: 0.66; color: ForecastMapProvider.rainColors[2] || "transparent" }
-                                                GradientStop { position: 1.0; color: ForecastMapProvider.rainColors[3] || "transparent" }
-                                            }
-                                        }
+                                }
+
+                                ItemDelegate {
+                                    visible: flightMap.showRainLayer && ForecastMapProvider.rainColors.length >= 4
+                                    width: parent ? parent.width : 300
+                                    topPadding: 0; bottomPadding: 6
+                                    contentItem: ColorScaleLegend {
+                                        colors: ForecastMapProvider.rainColors
+                                        vmin: ForecastMapProvider.rainVmin
+                                        vmax: ForecastMapProvider.rainVmax
+                                        units: ForecastMapProvider.rainUnits
                                     }
                                 }
 
                                 CheckDelegate {
-                                    text: qsTr("Cloud base forecast") + (ForecastMapProvider.cloudbaseUnits ? "  [" + ForecastMapProvider.cloudbaseUnits + "]" : "")
+                                    text: qsTr("Cloud base forecast")
                                     checked: flightMap.showCloudbaseLayer
                                     onClicked: flightMap.showCloudbaseLayer = checked
-                                    contentItem: Row {
-                                        spacing: 8
-                                        Label {
-                                            text: parent.parent.text
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            elide: Text.ElideRight
-                                        }
-                                        Rectangle {
-                                            visible: ForecastMapProvider.cloudbaseColors.length > 1
-                                            width: 60; height: 8
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            gradient: Gradient {
-                                                orientation: Gradient.Horizontal
-                                                GradientStop { position: 0.0; color: ForecastMapProvider.cloudbaseColors[0] || "transparent" }
-                                                GradientStop { position: 0.33; color: ForecastMapProvider.cloudbaseColors[1] || "transparent" }
-                                                GradientStop { position: 0.66; color: ForecastMapProvider.cloudbaseColors[2] || "transparent" }
-                                                GradientStop { position: 1.0; color: ForecastMapProvider.cloudbaseColors[3] || "transparent" }
-                                            }
-                                        }
+                                }
+
+                                ItemDelegate {
+                                    visible: flightMap.showCloudbaseLayer && ForecastMapProvider.cloudbaseColors.length >= 4
+                                    width: parent ? parent.width : 300
+                                    topPadding: 0; bottomPadding: 6
+                                    contentItem: ColorScaleLegend {
+                                        colors: ForecastMapProvider.cloudbaseColors
+                                        vmin: ForecastMapProvider.cloudbaseVmin
+                                        vmax: ForecastMapProvider.cloudbaseVmax
+                                        units: ForecastMapProvider.cloudbaseUnits
                                     }
                                 }
 

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -677,18 +677,44 @@ Item {
                                     onClicked: flightMap.showWindLayer = checked
                                 }
 
-                                MenuSeparator { visible: flightMap.showWindLayer }
-
-                                Instantiator {
-                                    model: ForecastMapProvider.windPressureLevels
-                                    delegate: RadioDelegate {
-                                        visible: flightMap.showWindLayer
-                                        text: modelData + " hPa"
-                                        checked: ForecastMapProvider.currentWindPressureLevel === modelData
-                                        onClicked: ForecastMapProvider.currentWindPressureLevel = modelData
+                                ItemDelegate {
+                                    visible: flightMap.showWindLayer && ForecastMapProvider.windPressureLevels.length > 1
+                                    width: parent ? parent.width : 300
+                                    topPadding: 0; bottomPadding: 6
+                                    contentItem: Column {
+                                        spacing: 2
+                                        Label {
+                                            width: parent.width
+                                            text: ForecastMapProvider.currentWindPressureLevel + " hPa"
+                                            font.pixelSize: 9
+                                            horizontalAlignment: Text.AlignHCenter
+                                            opacity: 0.7
+                                        }
+                                        Slider {
+                                            width: parent.width
+                                            from: 0
+                                            to: Math.max(0, ForecastMapProvider.windPressureLevels.length - 1)
+                                            stepSize: 1
+                                            value: ForecastMapProvider.windPressureLevels.indexOf(ForecastMapProvider.currentWindPressureLevel)
+                                            onMoved: ForecastMapProvider.currentWindPressureLevel =
+                                                ForecastMapProvider.windPressureLevels[Math.round(value)]
+                                        }
+                                        Row {
+                                            width: parent.width
+                                            Repeater {
+                                                model: ForecastMapProvider.windPressureLevels
+                                                Label {
+                                                    width: parent.width / ForecastMapProvider.windPressureLevels.length
+                                                    text: modelData + " hPa"
+                                                    font.pixelSize: 9
+                                                    horizontalAlignment: index === 0 ? Text.AlignLeft
+                                                        : index === ForecastMapProvider.windPressureLevels.length - 1 ? Text.AlignRight
+                                                        : Text.AlignHCenter
+                                                    opacity: ForecastMapProvider.currentWindPressureLevel === modelData ? 1.0 : 0.5
+                                                }
+                                            }
+                                        }
                                     }
-                                    onObjectAdded: (index, object) => weatherMenu.insertItem(index + 5, object)
-                                    onObjectRemoved: (index, object) => weatherMenu.removeItem(object)
                                 }
 
                                 MenuSeparator {

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -615,14 +615,147 @@ Item {
                             id: weatherLayerButton
 
                             checkable: true
-                            checked: flightMap.showWeatherLayer
+                            checked: flightMap.showWeatherLayer || flightMap.showRainLayer || flightMap.showCloudbaseLayer || flightMap.showWindLayer
                             icon.source: "/icons/material/ic_cloud_queue.svg"
 
                             onClicked: {
                                 PlatformAdaptor.vibrateBrief()
-                                flightMap.showWeatherLayer = !flightMap.showWeatherLayer
-                                if (flightMap.showWeatherLayer) {
-                                    WeatherDataProvider.requestUpdate()
+                                weatherMenu.popup()
+                            }
+
+                            AutoSizingMenu {
+                                id: weatherMenu
+
+                                CheckDelegate {
+                                    text: qsTr("METAR (flight category + wind)")
+                                    checked: flightMap.showWeatherLayer
+                                    onClicked: {
+                                        flightMap.showWeatherLayer = checked
+                                        if (checked) { WeatherDataProvider.requestUpdate() }
+                                    }
+                                }
+
+                                CheckDelegate {
+                                    text: qsTr("Rain forecast") + (ForecastMapProvider.rainUnits ? "  [" + ForecastMapProvider.rainUnits + "]" : "")
+                                    checked: flightMap.showRainLayer
+                                    onClicked: flightMap.showRainLayer = checked
+                                    contentItem: Row {
+                                        spacing: 8
+                                        Label {
+                                            text: parent.parent.text
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            elide: Text.ElideRight
+                                        }
+                                        Rectangle {
+                                            visible: ForecastMapProvider.rainColors.length > 1
+                                            width: 60; height: 8
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            gradient: Gradient {
+                                                orientation: Gradient.Horizontal
+                                                GradientStop { position: 0.0; color: ForecastMapProvider.rainColors[0] || "transparent" }
+                                                GradientStop { position: 0.33; color: ForecastMapProvider.rainColors[1] || "transparent" }
+                                                GradientStop { position: 0.66; color: ForecastMapProvider.rainColors[2] || "transparent" }
+                                                GradientStop { position: 1.0; color: ForecastMapProvider.rainColors[3] || "transparent" }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                CheckDelegate {
+                                    text: qsTr("Cloud base forecast") + (ForecastMapProvider.cloudbaseUnits ? "  [" + ForecastMapProvider.cloudbaseUnits + "]" : "")
+                                    checked: flightMap.showCloudbaseLayer
+                                    onClicked: flightMap.showCloudbaseLayer = checked
+                                    contentItem: Row {
+                                        spacing: 8
+                                        Label {
+                                            text: parent.parent.text
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            elide: Text.ElideRight
+                                        }
+                                        Rectangle {
+                                            visible: ForecastMapProvider.cloudbaseColors.length > 1
+                                            width: 60; height: 8
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            gradient: Gradient {
+                                                orientation: Gradient.Horizontal
+                                                GradientStop { position: 0.0; color: ForecastMapProvider.cloudbaseColors[0] || "transparent" }
+                                                GradientStop { position: 0.33; color: ForecastMapProvider.cloudbaseColors[1] || "transparent" }
+                                                GradientStop { position: 0.66; color: ForecastMapProvider.cloudbaseColors[2] || "transparent" }
+                                                GradientStop { position: 1.0; color: ForecastMapProvider.cloudbaseColors[3] || "transparent" }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                CheckDelegate {
+                                    text: qsTr("Wind forecast") + (ForecastMapProvider.windUnits ? "  [" + ForecastMapProvider.windUnits + "]" : "")
+                                    checked: flightMap.showWindLayer
+                                    onClicked: flightMap.showWindLayer = checked
+                                }
+
+                                MenuSeparator { visible: flightMap.showWindLayer }
+
+                                Instantiator {
+                                    model: ForecastMapProvider.windPressureLevels
+                                    delegate: RadioDelegate {
+                                        visible: flightMap.showWindLayer
+                                        text: modelData + " hPa"
+                                        checked: ForecastMapProvider.currentWindPressureLevel === modelData
+                                        onClicked: ForecastMapProvider.currentWindPressureLevel = modelData
+                                    }
+                                    onObjectAdded: (index, object) => weatherMenu.insertItem(index + 5, object)
+                                    onObjectRemoved: (index, object) => weatherMenu.removeItem(object)
+                                }
+
+                                MenuSeparator {
+                                    visible: flightMap.showRainLayer || flightMap.showCloudbaseLayer || flightMap.showWindLayer
+                                }
+
+                                ItemDelegate {
+                                    visible: flightMap.showRainLayer || flightMap.showCloudbaseLayer || flightMap.showWindLayer
+                                    width: parent ? parent.width : 300
+                                    contentItem: Column {
+                                        spacing: 4
+                                        Label {
+                                            text: ForecastMapProvider.currentTimestampLabel
+                                            anchors.horizontalCenter: parent.horizontalCenter
+                                            font.bold: true
+                                        }
+                                        Slider {
+                                            width: parent.width
+                                            from: 0
+                                            to: Math.max(0, ForecastMapProvider.timestamps.length - 1)
+                                            stepSize: 1
+                                            value: ForecastMapProvider.currentIndex
+                                            onMoved: ForecastMapProvider.currentIndex = Math.round(value)
+                                        }
+                                        Label {
+                                            visible: ForecastMapProvider.referenceTimeLabel !== ""
+                                            text: qsTr("Model run: ") + ForecastMapProvider.referenceTimeLabel
+                                            anchors.horizontalCenter: parent.horizontalCenter
+                                            font.pixelSize: parent.font ? parent.font.pixelSize * 0.85 : 11
+                                            opacity: 0.7
+                                        }
+                                    }
+                                }
+
+                                MenuSeparator {}
+
+                                ItemDelegate {
+                                    width: parent ? parent.width : 300
+                                    contentItem: Row {
+                                        spacing: 8
+                                        ToolButton {
+                                            icon.source: "/icons/material/ic_refresh.svg"
+                                            enabled: ForecastMapProvider.status !== 1  // not Refreshing
+                                            onClicked: ForecastMapProvider.refresh()
+                                        }
+                                        Label {
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            text: ForecastMapProvider.lastRefreshLabel
+                                            color: ForecastMapProvider.status === 2 ? "red" : palette.text  // Error
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -390,12 +390,12 @@ Page {
                 font.bold: true
             }
 
-            Icon {
-                source: "/icons/material/ic_cloud.svg"
-            }
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 0
+                Layout.columnSpan: 2
+                Layout.leftMargin: settingsPage.font.pixelSize
+                Layout.rightMargin: settingsPage.font.pixelSize
+                spacing: 4
 
                 Label {
                     text: qsTr("Server URL")
@@ -421,17 +421,13 @@ Page {
                     color: "#606060"
                     font.pixelSize: settingsPage.font.pixelSize * 0.85
                 }
-            }
-
-            Item { Layout.preferredHeight: 4 }  // spacer
-
-            Item { /* empty icon column */ }
-            Button {
-                text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
-                      ? qsTr("Refreshing…") : qsTr("Refresh now")
-                enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
-                         && ForecastMapProvider.serverUrl !== ""
-                onClicked: ForecastMapProvider.refresh()
+                Button {
+                    text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
+                          ? qsTr("Refreshing…") : qsTr("Refresh now")
+                    enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
+                             && ForecastMapProvider.serverUrl !== ""
+                    onClicked: ForecastMapProvider.refresh()
+                }
             }
 
             Item { // Spacer

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -385,6 +385,63 @@ Page {
             Label {
                 Layout.leftMargin: settingsPage.font.pixelSize
                 Layout.columnSpan: 2
+                text: qsTr("Forecast Maps")
+                font.pixelSize: settingsPage.font.pixelSize*1.2
+                font.bold: true
+            }
+
+            Icon {
+                source: "/icons/material/ic_cloud.svg"
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                Label {
+                    text: qsTr("Server URL")
+                    font.pixelSize: settingsPage.font.pixelSize
+                }
+                TextField {
+                    id: serverUrlField
+                    Layout.fillWidth: true
+                    placeholderText: "http://192.168.1.x:8765/meteo"
+                    text: ForecastMapProvider.serverUrl
+                    inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoPredictiveText
+                    onEditingFinished: ForecastMapProvider.serverUrl = text.trim()
+                }
+                Label {
+                    visible: ForecastMapProvider.status === ForecastMapProvider.Error
+                    text: qsTr("Last refresh failed — showing cached data")
+                    color: "red"
+                    font.pixelSize: settingsPage.font.pixelSize * 0.85
+                }
+                Label {
+                    visible: ForecastMapProvider.status !== ForecastMapProvider.Error
+                    text: qsTr("Last updated: ") + ForecastMapProvider.lastRefreshLabel
+                    color: "#606060"
+                    font.pixelSize: settingsPage.font.pixelSize * 0.85
+                }
+            }
+
+            Item { Layout.preferredHeight: 4 }  // spacer
+
+            Item { /* empty icon column */ }
+            Button {
+                text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
+                      ? qsTr("Refreshing…") : qsTr("Refresh now")
+                enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
+                         && ForecastMapProvider.serverUrl !== ""
+                onClicked: ForecastMapProvider.refresh()
+            }
+
+            Item { // Spacer
+                Layout.columnSpan: 2
+                Layout.preferredHeight: 3
+            }
+
+            Label {
+                Layout.leftMargin: settingsPage.font.pixelSize
+                Layout.columnSpan: 2
                 text: qsTr("Help")
                 font.pixelSize: settingsPage.font.pixelSize*1.2
                 font.bold: true

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -392,9 +392,7 @@ Page {
 
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.columnSpan: 2
                 Layout.leftMargin: settingsPage.font.pixelSize
-                Layout.rightMargin: settingsPage.font.pixelSize
                 spacing: 4
 
                 Label {
@@ -421,12 +419,14 @@ Page {
                     color: "#606060"
                     font.pixelSize: settingsPage.font.pixelSize * 0.85
                 }
-                Button {
-                    text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
-                          ? qsTr("Refreshing…") : qsTr("Refresh now")
-                    enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
-                             && ForecastMapProvider.serverUrl !== ""
-                    onClicked: ForecastMapProvider.refresh()
+            }
+            ToolButton {
+                icon.source: "/icons/material/ic_refresh.svg"
+                enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
+                         && ForecastMapProvider.serverUrl !== ""
+                onClicked: {
+                    PlatformAdaptor.vibrateBrief()
+                    ForecastMapProvider.refresh()
                 }
             }
 

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -402,6 +402,7 @@ Page {
                 TextField {
                     id: serverUrlField
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                     placeholderText: "http://192.168.1.x:8765/meteo"
                     text: ForecastMapProvider.serverUrl
                     inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoPredictiveText

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -48,6 +48,10 @@ static const QRegularExpression re_wind(
 Weather::ForecastMapProvider::ForecastMapProvider(QObject* parent)
     : QObject(parent)
 {
+    // Default colors match config.py LAYER_META (Qt #AARRGGBB format)
+    m_rainColors      = {u"#9900B2E6"_s, u"#990000CC"_s, u"#9900CC00"_s, u"#9900CCCC"_s};
+    m_cloudbaseColors = {u"#40404040"_s, u"#40808080"_s, u"#40BFBFBF"_s, u"#00FFFFFF"_s};
+
     QSettings s;
     m_serverUrl       = s.value(u"ForecastMapProvider/serverUrl"_s).toString();
     m_lastRefreshTime = s.value(u"ForecastMapProvider/lastRefreshTime"_s).toDateTime();

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -81,6 +81,29 @@ void Weather::ForecastMapProvider::refresh()
         setStatus(Status::Error);
         return;
     }
+
+    // Local directory mode: file:///path/to/generated_maps
+    const QUrl url(m_serverUrl);
+    if (url.isLocalFile()) {
+        setStatus(Status::Refreshing);
+        m_localScanDir = url.toLocalFile();
+
+        // Parse index.json from the local directory if present
+        QFile idxFile(m_localScanDir + u"/index.json"_s);
+        if (idxFile.open(QIODevice::ReadOnly)) {
+            const auto doc = QJsonDocument::fromJson(idxFile.readAll());
+            if (doc.isObject())
+                parseMetadata(doc.object());
+        }
+
+        m_lastRefreshTime = QDateTime::currentDateTimeUtc();
+        QSettings().setValue(u"ForecastMapProvider/lastRefreshTime"_s, m_lastRefreshTime);
+        setStatus(Status::Idle);
+        emit lastRefreshLabelChanged();
+        scan();
+        return;
+    }
+
     setStatus(Status::Refreshing);
     fetchIndex();
 }
@@ -108,9 +131,13 @@ void Weather::ForecastMapProvider::fetchIndex()
             return;
         }
 
+        const auto root = doc.object();
+
         QStringList serverFiles;
-        for (const auto& v : doc.object()[u"files"_s].toArray())
+        for (const auto& v : root[u"files"_s].toArray())
             serverFiles << v.toString();
+
+        parseMetadata(root);
 
         // Only download files not already in cache
         const QDir dir(cacheDir());
@@ -202,6 +229,47 @@ void Weather::ForecastMapProvider::abortRefresh()
 
 
 // ---------------------------------------------------------------------------
+// Metadata parsing
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::parseMetadata(const QJsonObject& root)
+{
+    m_referenceTime = root[u"reference_time"_s].toString();
+
+    const auto layers = root[u"layers"_s].toObject();
+
+    auto readColors = [](const QJsonObject& layer) {
+        QStringList out;
+        for (const auto& v : layer[u"colors"_s].toArray())
+            out << v.toString();
+        return out;
+    };
+
+    const auto rain = layers[u"rain"_s].toObject();
+    if (!rain.isEmpty()) {
+        m_rainUnits  = rain[u"units"_s].toString(m_rainUnits);
+        m_rainVmin   = rain[u"vmin"_s].toDouble(m_rainVmin);
+        m_rainVmax   = rain[u"vmax"_s].toDouble(m_rainVmax);
+        m_rainColors = readColors(rain);
+    }
+
+    const auto cb = layers[u"cloudbase"_s].toObject();
+    if (!cb.isEmpty()) {
+        m_cloudbaseUnits  = cb[u"units"_s].toString(m_cloudbaseUnits);
+        m_cloudbaseVmin   = cb[u"vmin"_s].toDouble(m_cloudbaseVmin);
+        m_cloudbaseVmax   = cb[u"vmax"_s].toDouble(m_cloudbaseVmax);
+        m_cloudbaseColors = readColors(cb);
+    }
+
+    const auto wind = layers[u"wind"_s].toObject();
+    if (!wind.isEmpty())
+        m_windUnits = wind[u"units"_s].toString(m_windUnits);
+
+    emit metadataChanged();
+}
+
+
+// ---------------------------------------------------------------------------
 // Directory scan
 // ---------------------------------------------------------------------------
 
@@ -211,7 +279,7 @@ void Weather::ForecastMapProvider::scan()
     m_cloudbaseMaps.clear();
     m_windMaps.clear();
 
-    const QDir dir(cacheDir());
+    const QDir dir(m_localScanDir.isEmpty() ? cacheDir() : m_localScanDir);
     for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files)) {
         auto m = re_rain.match(name);
         if (m.hasMatch()) {
@@ -270,6 +338,8 @@ void Weather::ForecastMapProvider::setServerUrl(const QString& url)
 {
     if (m_serverUrl == url) return;
     m_serverUrl = url;
+    if (!QUrl(url).isLocalFile())
+        m_localScanDir.clear();
     QSettings().setValue(u"ForecastMapProvider/serverUrl"_s, url);
     emit serverUrlChanged();
 }
@@ -294,6 +364,16 @@ void Weather::ForecastMapProvider::setCurrentWindPressureLevel(const QString& le
 // ---------------------------------------------------------------------------
 // Getters
 // ---------------------------------------------------------------------------
+
+QString Weather::ForecastMapProvider::referenceTimeLabel() const
+{
+    if (m_referenceTime.isEmpty())
+        return {};
+    const auto dt = QDateTime::fromString(m_referenceTime, Qt::ISODate);
+    if (!dt.isValid())
+        return m_referenceTime;
+    return dt.toUTC().toString(u"ddd dd MMM HH:mm"_s) + u" UTC"_s;
+}
 
 QString Weather::ForecastMapProvider::lastRefreshLabel() const
 {

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -376,7 +376,7 @@ QString Weather::ForecastMapProvider::referenceTimeLabel() const
     const auto dt = QDateTime::fromString(m_referenceTime, Qt::ISODate);
     if (!dt.isValid())
         return m_referenceTime;
-    return dt.toUTC().toString(u"ddd dd MMM HH:mm"_s) + u" UTC"_s;
+    return dt.toUTC().toString(u"dd MMM HH:mm'Z'"_s);
 }
 
 QString Weather::ForecastMapProvider::lastRefreshLabel() const

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -310,10 +310,10 @@ void Weather::ForecastMapProvider::scan()
     m_timestamps = tsSet.values();
     m_timestamps.sort();
 
-    // Wind pressure levels sorted ascending (700 first = highest altitude)
+    // Wind pressure levels sorted descending (1000 first = FL000 on left of slider)
     QStringList levels = m_windMaps.keys();
     std::sort(levels.begin(), levels.end(),
-              [](const QString& a, const QString& b) { return a.toDouble() < b.toDouble(); });
+              [](const QString& a, const QString& b) { return a.toDouble() > b.toDouble(); });
     m_windPressureLevels = levels;
 
     if (m_currentWindPressureLevel.isEmpty() && !levels.isEmpty())

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -64,7 +64,7 @@ Weather::ForecastMapProvider* Weather::ForecastMapProvider::create(QQmlEngine*, 
 
 QString Weather::ForecastMapProvider::cacheDir() const
 {
-    return QStandardPaths::writableLocation(QStandardPaths::AppCacheLocation)
+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
            + u"/meteo_france"_s;
 }
 

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -1,0 +1,333 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Quentin Bossard                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "weather/ForecastMapProvider.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QRegularExpression>
+#include <QSet>
+#include <QSettings>
+#include <QStandardPaths>
+
+using namespace Qt::Literals::StringLiterals;
+
+static const QRegularExpression re_rain(
+    u"^rain_map_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
+static const QRegularExpression re_cloudbase(
+    u"^cloudbase_map_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
+static const QRegularExpression re_wind(
+    u"^wind_map_(\\d+(?:\\.\\d+)?)hPa_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
+
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+Weather::ForecastMapProvider::ForecastMapProvider(QObject* parent)
+    : QObject(parent)
+{
+    QSettings s;
+    m_serverUrl       = s.value(u"ForecastMapProvider/serverUrl"_s).toString();
+    m_lastRefreshTime = s.value(u"ForecastMapProvider/lastRefreshTime"_s).toDateTime();
+
+    QDir().mkpath(cacheDir());
+    scan();
+}
+
+Weather::ForecastMapProvider* Weather::ForecastMapProvider::create(QQmlEngine*, QJSEngine*)
+{
+    static ForecastMapProvider instance;
+    return &instance;
+}
+
+QString Weather::ForecastMapProvider::cacheDir() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::AppCacheLocation)
+           + u"/meteo_france"_s;
+}
+
+
+// ---------------------------------------------------------------------------
+// Public slots
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::refresh()
+{
+    if (m_status == Status::Refreshing)
+        return;
+    if (m_serverUrl.isEmpty()) {
+        setStatus(Status::Error);
+        return;
+    }
+    setStatus(Status::Refreshing);
+    fetchIndex();
+}
+
+
+// ---------------------------------------------------------------------------
+// Network: fetch index
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::fetchIndex()
+{
+    auto* reply = m_nam.get(QNetworkRequest(QUrl(m_serverUrl + u"/index.json"_s)));
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+
+        if (reply->error() != QNetworkReply::NoError) {
+            abortRefresh();
+            return;
+        }
+
+        const auto doc = QJsonDocument::fromJson(reply->readAll());
+        if (doc.isNull() || !doc.isObject()) {
+            abortRefresh();
+            return;
+        }
+
+        QStringList serverFiles;
+        for (const auto& v : doc.object()[u"files"_s].toArray())
+            serverFiles << v.toString();
+
+        // Only download files not already in cache
+        const QDir dir(cacheDir());
+        QStringList toDownload;
+        for (const auto& fname : std::as_const(serverFiles))
+            if (!dir.exists(fname))
+                toDownload << fname;
+
+        if (toDownload.isEmpty()) {
+            finalizeRefresh(serverFiles);
+            return;
+        }
+
+        startDownloads(toDownload, serverFiles);
+    });
+}
+
+
+// ---------------------------------------------------------------------------
+// Network: download individual files
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::startDownloads(
+    const QStringList& filenames,
+    const QStringList& serverFiles)
+{
+    m_pendingDownloads = filenames.size();
+    m_serverFileList   = serverFiles;
+
+    for (const auto& fname : filenames) {
+        auto* reply = m_nam.get(QNetworkRequest(QUrl(m_serverUrl + u"/"_s + fname)));
+
+        connect(reply, &QNetworkReply::finished, this, [this, reply, fname]() {
+            reply->deleteLater();
+
+            if (reply->error() == QNetworkReply::NoError) {
+                // Atomic write: tmp → final, so a partial download never appears in scan()
+                const QString tmp   = cacheDir() + u"/"_s + fname + u".tmp"_s;
+                const QString final = cacheDir() + u"/"_s + fname;
+                QFile f(tmp);
+                if (f.open(QIODevice::WriteOnly)) {
+                    f.write(reply->readAll());
+                    f.close();
+                    QFile::rename(tmp, final);
+                }
+            }
+            // Count down regardless — a missing file just won't appear in scan()
+            if (--m_pendingDownloads == 0)
+                finalizeRefresh(m_serverFileList);
+        });
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Post-refresh bookkeeping
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::finalizeRefresh(const QStringList& serverFiles)
+{
+    // Purge cache entries no longer on the server — only on a successful full refresh
+    const QSet<QString> keep(serverFiles.begin(), serverFiles.end());
+    QDir dir(cacheDir());
+    for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files))
+        if (!keep.contains(name))
+            dir.remove(name);
+    // Clean up any leftover .tmp files from crashed downloads
+    for (const auto& name : dir.entryList(QStringList{u"*.tmp"_s}, QDir::Files))
+        dir.remove(name);
+
+    m_lastRefreshTime = QDateTime::currentDateTimeUtc();
+    QSettings().setValue(u"ForecastMapProvider/lastRefreshTime"_s, m_lastRefreshTime);
+
+    setStatus(Status::Idle);
+    emit lastRefreshLabelChanged();
+    scan();
+}
+
+void Weather::ForecastMapProvider::abortRefresh()
+{
+    // Clean up any .tmp files from the aborted attempt
+    QDir dir(cacheDir());
+    for (const auto& name : dir.entryList(QStringList{u"*.tmp"_s}, QDir::Files))
+        dir.remove(name);
+
+    setStatus(Status::Error);
+    scan(); // expose whatever is in cache
+}
+
+
+// ---------------------------------------------------------------------------
+// Directory scan
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::scan()
+{
+    m_rainMaps.clear();
+    m_cloudbaseMaps.clear();
+    m_windMaps.clear();
+
+    const QDir dir(cacheDir());
+    for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files)) {
+        auto m = re_rain.match(name);
+        if (m.hasMatch()) {
+            m_rainMaps[m.captured(1)] = dir.absoluteFilePath(name);
+            continue;
+        }
+        m = re_cloudbase.match(name);
+        if (m.hasMatch()) {
+            m_cloudbaseMaps[m.captured(1)] = dir.absoluteFilePath(name);
+            continue;
+        }
+        m = re_wind.match(name);
+        if (m.hasMatch())
+            m_windMaps[m.captured(1)][m.captured(2)] = dir.absoluteFilePath(name);
+    }
+
+    // Union of all timestamps across all map types
+    QSet<QString> tsSet;
+    for (const auto& k : m_rainMaps.keys())      tsSet << k;
+    for (const auto& k : m_cloudbaseMaps.keys()) tsSet << k;
+    for (const auto& level : std::as_const(m_windMaps))
+        for (const auto& k : level.keys())       tsSet << k;
+
+    m_timestamps = tsSet.values();
+    m_timestamps.sort();
+
+    // Wind pressure levels sorted ascending (700 first = highest altitude)
+    QStringList levels = m_windMaps.keys();
+    std::sort(levels.begin(), levels.end(),
+              [](const QString& a, const QString& b) { return a.toDouble() < b.toDouble(); });
+    m_windPressureLevels = levels;
+
+    if (m_currentWindPressureLevel.isEmpty() && !levels.isEmpty())
+        m_currentWindPressureLevel = levels.first();
+
+    m_currentIndex = qBound(0, m_currentIndex, qMax(0, int(m_timestamps.size()) - 1));
+
+    emit timestampsChanged();
+    emit currentIndexChanged();
+    emit currentWindMapChanged();
+}
+
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::setStatus(Status s)
+{
+    if (m_status == s) return;
+    m_status = s;
+    emit statusChanged();
+}
+
+void Weather::ForecastMapProvider::setServerUrl(const QString& url)
+{
+    if (m_serverUrl == url) return;
+    m_serverUrl = url;
+    QSettings().setValue(u"ForecastMapProvider/serverUrl"_s, url);
+    emit serverUrlChanged();
+}
+
+void Weather::ForecastMapProvider::setCurrentIndex(int idx)
+{
+    idx = qBound(0, idx, qMax(0, int(m_timestamps.size()) - 1));
+    if (m_currentIndex == idx) return;
+    m_currentIndex = idx;
+    emit currentIndexChanged();
+    emit currentWindMapChanged();
+}
+
+void Weather::ForecastMapProvider::setCurrentWindPressureLevel(const QString& level)
+{
+    if (m_currentWindPressureLevel == level) return;
+    m_currentWindPressureLevel = level;
+    emit currentWindMapChanged();
+}
+
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+QString Weather::ForecastMapProvider::lastRefreshLabel() const
+{
+    if (!m_lastRefreshTime.isValid())
+        return u"Never"_s;
+    const auto secs = m_lastRefreshTime.secsTo(QDateTime::currentDateTimeUtc());
+    if (secs < 60)   return u"Just now"_s;
+    if (secs < 3600) return QString::number(secs / 60) + u" min ago"_s;
+    return QString::number(secs / 3600) + u" h ago"_s;
+}
+
+QString Weather::ForecastMapProvider::currentTimestampLabel() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
+    const auto dt = QDateTime::fromString(m_timestamps[m_currentIndex], Qt::ISODate);
+    if (!dt.isValid()) return m_timestamps[m_currentIndex];
+    return dt.toUTC().toString(u"ddd dd MMM HH:mm"_s) + u" UTC"_s;
+}
+
+QString Weather::ForecastMapProvider::currentRainMap() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
+    return m_rainMaps.value(m_timestamps[m_currentIndex]);
+}
+
+QString Weather::ForecastMapProvider::currentCloudbaseMap() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
+    return m_cloudbaseMaps.value(m_timestamps[m_currentIndex]);
+}
+
+QString Weather::ForecastMapProvider::currentWindMap() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()
+            || m_currentWindPressureLevel.isEmpty()) return {};
+    return m_windMaps.value(m_currentWindPressureLevel).value(m_timestamps[m_currentIndex]);
+}

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -141,6 +141,14 @@ void Weather::ForecastMapProvider::fetchIndex()
         for (const auto& v : root[u"files"_s].toArray())
             serverFiles << v.toString();
 
+        // If the model run changed, wipe the cache so stale files are replaced
+        const QString newRefTime = root[u"reference_time"_s].toString();
+        if (!newRefTime.isEmpty() && newRefTime != m_referenceTime) {
+            QDir dir(cacheDir());
+            for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files))
+                dir.remove(name);
+        }
+
         parseMetadata(root);
 
         // Only download files not already in cache

--- a/src/weather/ForecastMapProvider.h
+++ b/src/weather/ForecastMapProvider.h
@@ -1,0 +1,203 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Quentin Bossard                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QDateTime>
+#include <QJsonObject>
+#include <QMap>
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QQmlEngine>
+#include <QStringList>
+
+namespace Weather {
+
+/*! \brief Downloads and exposes Météo-France forecast PNG maps from a local HTTP server.
+ *
+ * On refresh(), fetches index.json from the configured server, downloads any
+ * new PNGs into the app cache, then scans the cache so QML can display them.
+ * Falls back to whatever is already in cache on connection failure.
+ */
+class ForecastMapProvider : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    enum class Status {
+        Idle,        ///< Ready, showing cached data
+        Refreshing,  ///< Fetching index or downloading files
+        Error        ///< Last refresh failed; showing stale cache
+    };
+    Q_ENUM(Status)
+
+    explicit ForecastMapProvider(QObject* parent = nullptr);
+    static Weather::ForecastMapProvider* create(QQmlEngine*, QJSEngine*);
+
+    //
+    // Map data properties
+    //
+
+    Q_PROPERTY(QStringList timestamps READ timestamps NOTIFY timestampsChanged)
+    Q_PROPERTY(int currentIndex READ currentIndex WRITE setCurrentIndex NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentTimestampLabel READ currentTimestampLabel NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentRainMap READ currentRainMap NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentCloudbaseMap READ currentCloudbaseMap NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentWindMap READ currentWindMap NOTIFY currentWindMapChanged)
+    Q_PROPERTY(QStringList windPressureLevels READ windPressureLevels NOTIFY timestampsChanged)
+    Q_PROPERTY(QString currentWindPressureLevel READ currentWindPressureLevel WRITE setCurrentWindPressureLevel NOTIFY currentWindMapChanged)
+
+    //
+    // Layer metadata (from index.json)
+    //
+
+    /*! \brief Model run time that produced the current maps, e.g. "Thu 11 Jun 12:00 UTC" */
+    Q_PROPERTY(QString referenceTimeLabel READ referenceTimeLabel NOTIFY metadataChanged)
+
+    /*! \brief Units string for the rain layer, e.g. "mm/h" */
+    Q_PROPERTY(QString rainUnits READ rainUnits NOTIFY metadataChanged)
+    /*! \brief Color stops for the rain legend, as "#RRGGBBAA" strings, low→high */
+    Q_PROPERTY(QStringList rainColors READ rainColors NOTIFY metadataChanged)
+    /*! \brief vmin for rain color scale */
+    Q_PROPERTY(double rainVmin READ rainVmin NOTIFY metadataChanged)
+    /*! \brief vmax for rain color scale */
+    Q_PROPERTY(double rainVmax READ rainVmax NOTIFY metadataChanged)
+
+    /*! \brief Units string for the cloudbase layer, e.g. "m" */
+    Q_PROPERTY(QString cloudbaseUnits READ cloudbaseUnits NOTIFY metadataChanged)
+    /*! \brief Color stops for the cloudbase legend */
+    Q_PROPERTY(QStringList cloudbaseColors READ cloudbaseColors NOTIFY metadataChanged)
+    /*! \brief vmin for cloudbase color scale */
+    Q_PROPERTY(double cloudbaseVmin READ cloudbaseVmin NOTIFY metadataChanged)
+    /*! \brief vmax for cloudbase color scale */
+    Q_PROPERTY(double cloudbaseVmax READ cloudbaseVmax NOTIFY metadataChanged)
+
+    /*! \brief Units string for the wind layer, e.g. "kt" */
+    Q_PROPERTY(QString windUnits READ windUnits NOTIFY metadataChanged)
+
+    //
+    // Sync / connectivity properties
+    //
+
+    /*! \brief Base URL of the forecast server, e.g. "http://192.168.1.10:8765/meteo" */
+    Q_PROPERTY(QString serverUrl READ serverUrl WRITE setServerUrl NOTIFY serverUrlChanged)
+
+    /*! \brief Current sync state */
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+
+    /*! \brief Human-readable time since last successful refresh, e.g. "42 min ago" */
+    Q_PROPERTY(QString lastRefreshLabel READ lastRefreshLabel NOTIFY lastRefreshLabelChanged)
+
+
+    //
+    // Getters
+    //
+
+    [[nodiscard]] QStringList timestamps() const { return m_timestamps; }
+    [[nodiscard]] int currentIndex() const { return m_currentIndex; }
+    [[nodiscard]] QString currentTimestampLabel() const;
+    [[nodiscard]] QString currentRainMap() const;
+    [[nodiscard]] QString currentCloudbaseMap() const;
+    [[nodiscard]] QString currentWindMap() const;
+    [[nodiscard]] QStringList windPressureLevels() const { return m_windPressureLevels; }
+    [[nodiscard]] QString currentWindPressureLevel() const { return m_currentWindPressureLevel; }
+    [[nodiscard]] QString serverUrl() const { return m_serverUrl; }
+    [[nodiscard]] Status status() const { return m_status; }
+    [[nodiscard]] QString lastRefreshLabel() const;
+
+    [[nodiscard]] QString referenceTimeLabel() const;
+    [[nodiscard]] QString rainUnits() const      { return m_rainUnits; }
+    [[nodiscard]] QStringList rainColors() const { return m_rainColors; }
+    [[nodiscard]] double rainVmin() const        { return m_rainVmin; }
+    [[nodiscard]] double rainVmax() const        { return m_rainVmax; }
+    [[nodiscard]] QString cloudbaseUnits() const      { return m_cloudbaseUnits; }
+    [[nodiscard]] QStringList cloudbaseColors() const { return m_cloudbaseColors; }
+    [[nodiscard]] double cloudbaseVmin() const        { return m_cloudbaseVmin; }
+    [[nodiscard]] double cloudbaseVmax() const        { return m_cloudbaseVmax; }
+    [[nodiscard]] QString windUnits() const      { return m_windUnits; }
+
+
+    //
+    // Setters
+    //
+
+    void setCurrentIndex(int idx);
+    void setCurrentWindPressureLevel(const QString& level);
+    void setServerUrl(const QString& url);
+
+    /*! \brief Fetch index.json from the server and download new maps. No-op if already refreshing. */
+    Q_INVOKABLE void refresh();
+
+
+signals:
+    void timestampsChanged();
+    void currentIndexChanged();
+    void currentWindMapChanged();
+    void serverUrlChanged();
+    void statusChanged();
+    void lastRefreshLabelChanged();
+    void metadataChanged();
+
+
+private:
+    void scan();
+    void fetchIndex();
+    void startDownloads(const QStringList& filenames, const QStringList& serverFiles);
+    void finalizeRefresh(const QStringList& serverFiles);
+    void abortRefresh();
+    void parseMetadata(const QJsonObject& root);
+
+    void setStatus(Status s);
+    [[nodiscard]] QString cacheDir() const;
+
+    QNetworkAccessManager m_nam;
+
+    QString m_serverUrl;
+    QString m_localScanDir;   ///< non-empty when serverUrl is a file:// URL
+    Status  m_status          {Status::Idle};
+    QDateTime m_lastRefreshTime;
+
+    // Tracks in-flight downloads during a refresh cycle
+    int         m_pendingDownloads {0};
+    QStringList m_serverFileList;
+
+    // Map data
+    QStringList m_timestamps;
+    int         m_currentIndex {0};
+    QMap<QString, QString>                  m_rainMaps;
+    QMap<QString, QString>                  m_cloudbaseMaps;
+    QMap<QString, QMap<QString, QString>>   m_windMaps;      ///< outer key: pressure level string
+    QStringList m_windPressureLevels;
+    QString     m_currentWindPressureLevel;
+
+    // Layer metadata from index.json
+    QString     m_referenceTime;
+    QString     m_rainUnits       {QStringLiteral("mm/h")};
+    QStringList m_rainColors;
+    double      m_rainVmin        {0.1};
+    double      m_rainVmax        {10.0};
+    QString     m_cloudbaseUnits  {QStringLiteral("m")};
+    QStringList m_cloudbaseColors;
+    double      m_cloudbaseVmin   {0.0};
+    double      m_cloudbaseVmax   {4000.0};
+    QString     m_windUnits       {QStringLiteral("kt")};
+};
+
+} // namespace Weather

--- a/src/weather/METAR.cpp
+++ b/src/weather/METAR.cpp
@@ -97,6 +97,14 @@ Weather::METAR::METAR(QXmlStreamReader& xml)
             continue;
         }
 
+        // Wind direction
+        if (xml.isStartElement() && name == u"wind_dir_degrees"_s)
+        {
+            auto content = xml.readElementText();
+            m_windDirection = Units::Angle::fromDEG(content.toDouble());
+            continue;
+        }
+
         // Gust
         if (xml.isStartElement() && name == u"wind_gust_kt"_s)
         {
@@ -411,6 +419,7 @@ QDataStream& Weather::operator<<(QDataStream& outstream, const Weather::METAR& m
     outstream << metar.m_qnh;
     outstream << metar.m_rawText;
     outstream << metar.m_wind;
+    outstream << metar.m_windDirection.toDEG();
     outstream << metar.m_gust;
     outstream << metar.m_temperature;
     outstream << metar.m_dewpoint;
@@ -429,6 +438,7 @@ QDataStream& Weather::operator>>(QDataStream& instream, Weather::METAR& metar)
     instream >> metar.m_qnh;
     instream >> metar.m_rawText;
     instream >> metar.m_wind;
+    double windDirDeg; instream >> windDirDeg; metar.m_windDirection = Units::Angle::fromDEG(windDirDeg);
     instream >> metar.m_gust;
     instream >> metar.m_temperature;
     instream >> metar.m_dewpoint;

--- a/src/weather/METAR.h
+++ b/src/weather/METAR.h
@@ -26,6 +26,7 @@
 #include <QXmlStreamReader>
 
 #include "navigation/Aircraft.h"
+#include "units/Angle.h"
 #include "units/Distance.h"
 #include "units/Pressure.h"
 #include "units/Speed.h"
@@ -179,6 +180,18 @@ public:
      */
     Q_PROPERTY(QString rawText READ rawText CONSTANT)
 
+    /*! \brief Wind direction (true north)
+     *
+     * Set to NaN if wind direction is not reported (calm or variable).
+     */
+    Q_PROPERTY(Units::Angle windDirection READ windDirection CONSTANT)
+
+    /*! \brief Wind speed
+     *
+     * Set to NaN if no wind data is available.
+     */
+    Q_PROPERTY(Units::Speed windSpeed READ windSpeed CONSTANT)
+
 
     //
     // Getter Methods
@@ -256,6 +269,24 @@ public:
         return m_rawText;
     }
 
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property windDirection
+     */
+    [[nodiscard]] Units::Angle windDirection() const
+    {
+        return m_windDirection;
+    }
+
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property windSpeed
+     */
+    [[nodiscard]] Units::Speed windSpeed() const
+    {
+        return m_wind;
+    }
+
 
     //
     // Methods
@@ -330,6 +361,9 @@ private:
 
     // Raw METAR text, as returned by the Aviation Weather Center
     QString m_rawText;
+
+    // Wind direction (true north), as returned by the Aviation Weather Center
+    Units::Angle m_windDirection;
 
     // Wind speed, as returned by the Aviation Weather Center
     Units::Speed m_wind;


### PR DESCRIPTION
- METAR: parse wind_dir_degrees XML field into new m_windDirection (Units::Angle); expose windDirection and windSpeed as Q_PROPERTYs; serialize/deserialize alongside existing wind fields
- FlightMap: add showWeatherLayer property; ObserverList + MapItemView draws a semi-transparent flight-category dot and standard wind barb (half/full/pennant) for each valid METAR station
- MFM: add toggleable cloud button next to the raster-map layers button; triggers WeatherDataProvider.requestUpdate() on first activation