### PR TITLE
Wind field integration: vector wind layer, route integration, sideview projection

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -108,7 +108,7 @@ jobs:
           -DCMAKE_BUILD_TYPE:STRING=Debug
         cmake --build build-enroute
     - name: Upload to developerBuilds
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
       run: |
         gh release upload --clobber developerBuilds ../build-enroute/src/android-build//build/outputs/apk/debug/android-build-debug.apk
       env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,6 +16,9 @@ on:
     branches: [ main, develop ]
     paths-ignore: *paths-ignore
 
+permissions:
+  contents: write
+
 jobs:
   build:
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,7 @@
 name: Compile on Android
 
 on:
+  workflow_dispatch:
   push:
     branches: [ develop ]
     paths-ignore: &paths-ignore

--- a/CHANGES-weather.md
+++ b/CHANGES-weather.md
@@ -1,0 +1,41 @@
+# Enroute — Weather Layer Changes (feature/weather-layer)
+
+## Foundation
+
+- **Weather layer QML item**: METAR flight-category dots and wind barbs on the map
+- **ForecastMapProvider**: C++ singleton that downloads forecast PNGs from a local HTTP server, scans the cache, and exposes current map paths to QML
+- **SettingsPage**: Forecast Maps section with server URL field and refresh button
+- **Filename regex**: optional Z suffix support in forecast map filename matching
+
+## METAR wind barbs
+
+- **Direction fix**: removed erroneous `+Math.PI` inversion; moved dot anchor from (14,14) to (40,40) in 80×80 canvas so all directions fit
+- **Reactive repaint**: switched from `onMetarChanged` to `onMetChanged` to match `QProperty`-based binding
+
+## Weather menu (MFM.qml)
+
+- **Color scale legends** (`ColorScaleLegend.qml`): gradient bar with 4 labeled tick marks, matching server-side color stops; shown for rain and cloudbase layers
+- **Layer metadata from index.json**: colors, units, vmin/vmax read from server and reflected in client legends
+- **Model run attribution**: "AROME dd MMM HH:mmZ" + "© Météo-France" replacing generic "Model run" label
+- **Wind level slider**: replaced pressure radio buttons with a slider; levels labeled in approximate FL (FL000/FL033/FL065/FL100)
+- **Cloudbase units**: displayed in aircraft's vertical distance unit (ft or m)
+- **Refresh button**: moved into weather menu with "last refreshed" label
+- **Layout fixes**: explicit `implicitWidth: 280` on custom `ItemDelegate`s to prevent `AutoSizingMenu` from collapsing
+
+## Settings layout
+
+- **URL TextField**: `Layout.preferredWidth: 0` to prevent column inflation in `GridLayout`
+
+## Map layer ordering and dimming
+
+- **OFM dimming**: `background` LayerParameter between OFM tiles and forecast layers dims the base chart to 68% white when wind layer is active
+- **Layer order**: cloudbase → rain → wind (wind on top, rain above cloudbase)
+- **NOTAM/waypoint hiding**: `layout.visibility` set to `none` when wind layer active (symbol layers cannot be dimmed via MapLibre stack position)
+
+## Local file:// testing mode
+
+- `ForecastMapProvider` detects `file://` server URL, reads `index.json` from local directory, scans PNGs directly — no network required for development
+
+## Cache management
+
+- **Cache invalidation**: when `reference_time` in `index.json` changes (new model run), all cached PNGs are wiped before downloading the fresh set — prevents serving stale maps from an older run

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,6 +132,7 @@ set(SOURCES
     weather/TAF.h
     weather/WeatherDataProvider.h
     weather/Wind.h
+    weather/WindFieldProvider.h
 
     # C++ files
     ../3rdParty/sunset/src/sunset.cpp
@@ -237,6 +238,7 @@ set(SOURCES
     weather/TAF.cpp
     weather/WeatherDataProvider.cpp
     weather/Wind.cpp
+    weather/WindFieldProvider.cpp
 
     ${HEADERS}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,7 @@ set(SOURCES
     units/VolumeFlow.h
     weather/Decoder.h
     weather/DensityAltitude.h
+    weather/ForecastMapProvider.h
     weather/METAR.h
     weather/Observer.h
     weather/ObserverList.h
@@ -229,6 +230,7 @@ set(SOURCES
     units/VolumeFlow.cpp
     weather/Decoder.cpp
     weather/DensityAltitude.cpp
+    weather/ForecastMapProvider.cpp
     weather/METAR.cpp
     weather/Observer.cpp
     weather/ObserverList.cpp
@@ -604,6 +606,7 @@ qt_add_qml_module(${PROJECT_NAME}
     qml/items/AppWindow.qml
     qml/items/+Material/AppWindow.qml
     qml/items/AutoSizingMenu.qml
+    qml/items/ColorScaleLegend.qml
     qml/items/DecoratedListView.qml
     qml/items/DecoratedScrollView.qml
     qml/items/DegreeInput.qml

--- a/src/GlobalSettings.cpp
+++ b/src/GlobalSettings.cpp
@@ -239,6 +239,16 @@ void GlobalSettings::setShowAltitudeAGL(bool newShowAltitudeAGL)
     emit showAltitudeAGLChanged();
 }
 
+void GlobalSettings::setShowWindLayer(bool newShowWindLayer)
+{
+    if (newShowWindLayer == showWindLayer())
+    {
+        return;
+    }
+    m_settings.setValue(QStringLiteral("showWindLayer"), newShowWindLayer);
+    emit showWindLayerChanged();
+}
+
 
 void GlobalSettings::setVoiceNotifications(uint newVoiceNotifications)
 {

--- a/src/GlobalSettings.h
+++ b/src/GlobalSettings.h
@@ -156,6 +156,9 @@ public:
     /*! \brief Show Altitude AGL */
     Q_PROPERTY(bool showAltitudeAGL READ showAltitudeAGL WRITE setShowAltitudeAGL NOTIFY showAltitudeAGLChanged)
 
+    /*! \brief Global toggle for the wind forecast layer (map and side view) */
+    Q_PROPERTY(bool showWindLayer READ showWindLayer WRITE setShowWindLayer NOTIFY showWindLayerChanged)
+
     /*! \brief Voice notifications that should be played
      *
      *  This property is an "or" of the entries of Notifications::Notification::Importance. It determines
@@ -263,6 +266,9 @@ public:
      * @returns Property positioningByTrafficDataReceiver
      */
     [[nodiscard]] auto showAltitudeAGL() const -> bool { return m_settings.value(QStringLiteral("showAltitudeAGL"), false).toBool(); }
+
+    /*! \brief Getter function for property of the same name */
+    [[nodiscard]] auto showWindLayer() const -> bool { return m_settings.value(QStringLiteral("showWindLayer"), false).toBool(); }
 
     /*! \brief Getter function for property of the same name
      *
@@ -372,6 +378,12 @@ public:
 
     /*! \brief Setter function for property of the same name
      *
+     * @param newShowWindLayer Property showWindLayer
+     */
+    void setShowWindLayer(bool newShowWindLayer);
+
+    /*! \brief Setter function for property of the same name
+     *
      * @param newVoiceNotifications Property voiceNotifications
      */
     void setVoiceNotifications(uint newVoiceNotifications);
@@ -423,6 +435,9 @@ signals:
 
     /*! \brief Notifier signal */
     void showAltitudeAGLChanged();
+
+    /*! \brief Notifier signal */
+    void showWindLayerChanged();
 
     /*! \brief Notifier signal */
     void voiceNotificationsChanged();

--- a/src/navigation/Aircraft.cpp
+++ b/src/navigation/Aircraft.cpp
@@ -233,6 +233,7 @@ QString Navigation::Aircraft::loadFromJSON(const QByteArray &JSON)
     }
 
     setCabinPressureEqualsStaticPressure( content[QStringLiteral("cabinPressureEqualsStaticPressure")].toBool(false) );
+    setCruiseAltitude( Units::Distance::fromM( content[QStringLiteral("cruiseAltitude_m")].toDouble(NAN) ));
     setCruiseSpeed( Units::Speed::fromMPS( content[QStringLiteral("cruiseSpeed_mps")].toDouble(NAN) ));
     setDescentSpeed( Units::Speed::fromMPS( content[QStringLiteral("descentSpeed_mps")].toDouble(NAN) ));
     setFuelConsumption( Units::VolumeFlow::fromLPH( content[QStringLiteral("fuelConsumption_lph")].toDouble(NAN) ));
@@ -274,6 +275,7 @@ QByteArray Navigation::Aircraft::toJSON() const
     jsonObj.insert(QStringLiteral("content"), "aircraft");
 
     jsonObj.insert(QStringLiteral("cabinPressureEqualsStaticPressure"), m_cabinPressureEqualsStaticPressure);
+    jsonObj.insert(QStringLiteral("cruiseAltitude_m"), m_cruiseAltitude.toM());
     jsonObj.insert(QStringLiteral("cruiseSpeed_mps"), m_cruiseSpeed.toMPS());
     jsonObj.insert(QStringLiteral("descentSpeed_mps"), m_descentSpeed.toMPS());
     jsonObj.insert(QStringLiteral("fuelConsumption_lph"), m_fuelConsumption.toLPH());

--- a/src/navigation/Aircraft.h
+++ b/src/navigation/Aircraft.h
@@ -78,6 +78,17 @@ public:
     /*! \brief Preferred units of measurement for vertical distances */
     Q_PROPERTY(bool cabinPressureEqualsStaticPressure READ cabinPressureEqualsStaticPressure WRITE setCabinPressureEqualsStaticPressure)
 
+    /*! \brief Default cruise altitude
+     *
+     * This property holds the default planned cruise altitude of the aircraft.
+     * It is used as the fallback when a route waypoint has no explicit planned
+     * altitude set. The value is NaN if no default has been set.
+     */
+    Q_PROPERTY(Units::Distance cruiseAltitude READ cruiseAltitude WRITE setCruiseAltitude)
+
+    /*! \brief Default cruise altitude in meters (NaN if not set), for QML use */
+    Q_PROPERTY(double cruiseAltitudeM READ cruiseAltitudeM WRITE setCruiseAltitudeM)
+
     /*! \brief Cruise Speed
      *
      * This property holds the cruise speed of the aircraft. This lies in the interval [minAircraftSpeed,
@@ -161,6 +172,18 @@ public:
 
     /*! \brief Getter function for property of the same name
      *
+     * @returns Property cruiseAltitude (NaN if not set)
+     */
+    [[nodiscard]] Units::Distance cruiseAltitude() const { return m_cruiseAltitude; }
+
+    /*! \brief Getter function for property of the same name
+     *
+     * @returns Property cruiseAltitudeM (NaN if not set)
+     */
+    [[nodiscard]] double cruiseAltitudeM() const { return m_cruiseAltitude.toM(); }
+
+    /*! \brief Getter function for property of the same name
+     *
      * @returns Property descentSpeed
      */
     [[nodiscard]] Units::Speed descentSpeed() const { return m_descentSpeed; }
@@ -227,6 +250,18 @@ public:
      * @param newSpeed Property cruise speed
      */
     void setCruiseSpeed(Units::Speed newSpeed);
+
+    /*! \brief Setter function for property of the same name
+     *
+     * @param newAltitude Default cruise altitude (NaN to clear)
+     */
+    void setCruiseAltitude(Units::Distance newAltitude) { m_cruiseAltitude = newAltitude; }
+
+    /*! \brief Setter function for property of the same name
+     *
+     * @param altitudeM Default cruise altitude in meters (NaN to clear)
+     */
+    void setCruiseAltitudeM(double altitudeM) { m_cruiseAltitude = Units::Distance::fromM(altitudeM); }
 
     /*! \brief Setter function for property of the same name
      *
@@ -415,6 +450,7 @@ private:
     static constexpr Units::VolumeFlow maxValidFuelConsumption = Units::VolumeFlow::fromLPH(300.0);
 
     bool m_cabinPressureEqualsStaticPressure {false};
+    Units::Distance m_cruiseAltitude {};
     Units::Speed m_cruiseSpeed {};
     Units::Speed m_descentSpeed {};
     Units::VolumeFlow m_fuelConsumption {};

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -34,62 +34,64 @@ using namespace Qt::Literals::StringLiterals;
 
 
 //
-// ETA-aware wind
+// ETA-aware, wind-integrated leg nav
 //
 
-Weather::Wind Navigation::FlightRoute::legWind(int index,
-                                               const Weather::WindFieldProvider* wfp,
-                                               Weather::Wind manualWind,
-                                               const Navigation::Aircraft& aircraft,
-                                               const QDateTime& departure,
-                                               double altFt) const
+QVariantMap Navigation::FlightRoute::legNav(int index,
+                                            const Weather::WindFieldProvider* wfp,
+                                            Weather::Wind manualWind,
+                                            const Navigation::Aircraft& aircraft,
+                                            const QDateTime& departure) const
 {
     const auto theLegs = m_legs.value();
     if (index < 0 || index >= theLegs.size())
     {
-        return manualWind;
+        return {};
     }
 
-    const bool haveField = (wfp != nullptr) && wfp->isUsable();
-    QDateTime t = departure.isValid() ? departure : QDateTime::currentDateTimeUtc();
-
-    // Wind for one leg at a given start time: sampled at the leg's mid-time.
-    // A single fixed-point step refines the mid-time using a first ETE estimate.
-    auto windForLeg = [&](const Navigation::Leg& leg, const QDateTime& start) -> Weather::Wind {
-        if (!haveField)
+    // Planned altitude (ft) at waypoint wpIdx: stored value, else aircraft
+    // default cruise, else a sane fallback so the field can still be sampled.
+    auto altFtAt = [&](int wpIdx) -> double {
+        double m = plannedAltitude(wpIdx);
+        if (!qIsFinite(m))
         {
-            return manualWind;
+            m = aircraft.cruiseAltitudeM();
         }
-        auto w0 = leg.averageWind(wfp, altFt, start);
-        if (!w0.speed().isFinite() || !w0.directionFrom().isFinite())
+        if (!qIsFinite(m))
         {
-            return manualWind;
+            return 3000.0;
         }
-        const auto ete0 = leg.ETE(w0, aircraft);
-        if (!ete0.isFinite())
-        {
-            return w0;
-        }
-        const QDateTime mid = start.addSecs(qRound64(ete0.toS() / 2.0));
-        auto wMid = leg.averageWind(wfp, altFt, mid);
-        if (!wMid.speed().isFinite() || !wMid.directionFrom().isFinite())
-        {
-            return w0;
-        }
-        return wMid;
+        return Units::Distance::fromM(m).toFeet();
     };
 
-    // Accumulate to the requested leg
-    for (int k = 0; k < index; ++k)
+    QDateTime t = departure.isValid() ? departure : QDateTime::currentDateTimeUtc();
+
+    // Walk preceding legs to accumulate the start time of the requested leg
+    Navigation::LegIntegration res;
+    for (int k = 0; k <= index; ++k)
     {
-        const auto w = windForLeg(theLegs[k], t);
-        const auto ete = theLegs[k].ETE(w, aircraft);
-        if (ete.isFinite())
+        res = theLegs[k].integrate(wfp, manualWind, aircraft, t, altFtAt(k), altFtAt(k + 1));
+        if (k == index)
         {
-            t = t.addSecs(qRound64(ete.toS()));
+            break;
+        }
+        if (res.isValid && res.ete.isFinite())
+        {
+            t = t.addSecs(qRound64(res.ete.toS()));
         }
     }
-    return windForLeg(theLegs[index], t);
+
+    QVariantMap out;
+    out[u"ete"_s]  = QVariant::fromValue(res.ete);
+    out[u"gs"_s]   = QVariant::fromValue(res.gs);
+    out[u"wind"_s] = QVariant::fromValue(res.wind);
+    Units::Volume fuel;
+    if (aircraft.fuelConsumption().isFinite() && res.ete.isFinite())
+    {
+        fuel = aircraft.fuelConsumption() * res.ete;
+    }
+    out[u"fuel"_s] = QVariant::fromValue(fuel);
+    return out;
 }
 
 

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -429,6 +429,26 @@ auto Navigation::FlightRoute::load(const QString& fileName) -> QString
         }
     }
     m_waypoints = newWaypoints;
+
+    // Planned altitudes are stored as a top-level object in our own GeoJSON
+    // files. Read them back if present (other formats simply have none).
+    m_plannedAltitudes.clear();
+    {
+        QFile jsonFile(myFileName);
+        if (jsonFile.open(QIODevice::ReadOnly))
+        {
+            auto doc = QJsonDocument::fromJson(jsonFile.readAll());
+            if (doc.isObject())
+            {
+                auto altObj = doc.object().value(QStringLiteral("plannedAltitudes")).toObject();
+                for (auto it = altObj.constBegin(); it != altObj.constEnd(); ++it)
+                {
+                    m_plannedAltitudes.insert(it.key(), it.value().toDouble());
+                }
+            }
+        }
+    }
+    emit plannedAltitudesChanged();
     return {};
 }
 
@@ -499,6 +519,46 @@ void Navigation::FlightRoute::reverse()
     auto newWaypoints = m_waypoints.value();
     std::reverse(newWaypoints.begin(), newWaypoints.end());
     m_waypoints = newWaypoints;
+}
+
+QString Navigation::FlightRoute::waypointKey(const GeoMaps::Waypoint& waypoint)
+{
+    auto icao = waypoint.ICAOCode();
+    if (!icao.isEmpty())
+    {
+        return icao;
+    }
+    auto coord = waypoint.coordinate();
+    return u"%1,%2"_s.arg(coord.latitude(), 0, 'f', 6).arg(coord.longitude(), 0, 'f', 6);
+}
+
+double Navigation::FlightRoute::plannedAltitude(int idx) const
+{
+    const auto wps = m_waypoints.value();
+    if ((idx < 0) || (idx >= wps.size()))
+    {
+        return qQNaN();
+    }
+    return m_plannedAltitudes.value(waypointKey(wps.at(idx)), qQNaN());
+}
+
+void Navigation::FlightRoute::setPlannedAltitude(int idx, double altitudeM)
+{
+    const auto wps = m_waypoints.value();
+    if ((idx < 0) || (idx >= wps.size()))
+    {
+        return;
+    }
+    auto key = waypointKey(wps.at(idx));
+    if (qIsNaN(altitudeM))
+    {
+        m_plannedAltitudes.remove(key);
+    }
+    else
+    {
+        m_plannedAltitudes.insert(key, altitudeM);
+    }
+    emit plannedAltitudesChanged();
 }
 
 auto Navigation::FlightRoute::save(const QString& fileName) const -> QString
@@ -609,10 +669,30 @@ auto Navigation::FlightRoute::toGeoJSON() const -> QByteArray
         }
     }
 
+    // Planned altitudes, owned by the route. Pruned to the keys of the current
+    // valid waypoints.
+    QJsonObject plannedAltitudes;
+    foreach(const auto& waypoint, m_waypoints.value())
+    {
+        if (!waypoint.isValid())
+        {
+            continue;
+        }
+        auto key = waypointKey(waypoint);
+        if (m_plannedAltitudes.contains(key))
+        {
+            plannedAltitudes.insert(key, m_plannedAltitudes.value(key));
+        }
+    }
+
     QJsonObject jsonObj;
     jsonObj.insert(QStringLiteral("type"), "FeatureCollection");
     jsonObj.insert(QStringLiteral("enroute"), GeoMaps::GeoJSON::indicatorFlightRoute());
     jsonObj.insert(QStringLiteral("features"), waypointArray);
+    if (!plannedAltitudes.isEmpty())
+    {
+        jsonObj.insert(QStringLiteral("plannedAltitudes"), plannedAltitudes);
+    }
 
     QJsonDocument doc;
     doc.setObject(jsonObj);

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -34,6 +34,66 @@ using namespace Qt::Literals::StringLiterals;
 
 
 //
+// ETA-aware wind
+//
+
+Weather::Wind Navigation::FlightRoute::legWind(int index,
+                                               const Weather::WindFieldProvider* wfp,
+                                               Weather::Wind manualWind,
+                                               const Navigation::Aircraft& aircraft,
+                                               const QDateTime& departure,
+                                               double altFt) const
+{
+    const auto theLegs = m_legs.value();
+    if (index < 0 || index >= theLegs.size())
+    {
+        return manualWind;
+    }
+
+    const bool haveField = (wfp != nullptr) && wfp->isUsable();
+    QDateTime t = departure.isValid() ? departure : QDateTime::currentDateTimeUtc();
+
+    // Wind for one leg at a given start time: sampled at the leg's mid-time.
+    // A single fixed-point step refines the mid-time using a first ETE estimate.
+    auto windForLeg = [&](const Navigation::Leg& leg, const QDateTime& start) -> Weather::Wind {
+        if (!haveField)
+        {
+            return manualWind;
+        }
+        auto w0 = leg.averageWind(wfp, altFt, start);
+        if (!w0.speed().isFinite() || !w0.directionFrom().isFinite())
+        {
+            return manualWind;
+        }
+        const auto ete0 = leg.ETE(w0, aircraft);
+        if (!ete0.isFinite())
+        {
+            return w0;
+        }
+        const QDateTime mid = start.addSecs(qRound64(ete0.toS() / 2.0));
+        auto wMid = leg.averageWind(wfp, altFt, mid);
+        if (!wMid.speed().isFinite() || !wMid.directionFrom().isFinite())
+        {
+            return w0;
+        }
+        return wMid;
+    };
+
+    // Accumulate to the requested leg
+    for (int k = 0; k < index; ++k)
+    {
+        const auto w = windForLeg(theLegs[k], t);
+        const auto ete = theLegs[k].ETE(w, aircraft);
+        if (ete.isFinite())
+        {
+            t = t.addSecs(qRound64(ete.toS()));
+        }
+    }
+    return windForLeg(theLegs[index], t);
+}
+
+
+//
 // Constructors and destructors
 //
 

--- a/src/navigation/FlightRoute.cpp
+++ b/src/navigation/FlightRoute.cpp
@@ -95,6 +95,44 @@ QVariantMap Navigation::FlightRoute::legNav(int index,
 }
 
 
+QList<QDateTime> Navigation::FlightRoute::waypointETAs(const Weather::WindFieldProvider* wfp,
+                                                       Weather::Wind manualWind,
+                                                       const Navigation::Aircraft& aircraft,
+                                                       const QDateTime& departure) const
+{
+    const auto theLegs = m_legs.value();
+
+    auto altFtAt = [&](int wpIdx) -> double {
+        double m = plannedAltitude(wpIdx);
+        if (!qIsFinite(m))
+        {
+            m = aircraft.cruiseAltitudeM();
+        }
+        if (!qIsFinite(m))
+        {
+            return 3000.0;
+        }
+        return Units::Distance::fromM(m).toFeet();
+    };
+
+    QDateTime t = departure.isValid() ? departure : QDateTime::currentDateTimeUtc();
+
+    QList<QDateTime> etas;
+    etas.reserve(theLegs.size() + 1);
+    etas << t; // arrival at first waypoint = departure
+    for (int k = 0; k < theLegs.size(); ++k)
+    {
+        const auto res = theLegs[k].integrate(wfp, manualWind, aircraft, t, altFtAt(k), altFtAt(k + 1));
+        if (res.isValid && res.ete.isFinite())
+        {
+            t = t.addSecs(qRound64(res.ete.toS()));
+        }
+        etas << t;
+    }
+    return etas;
+}
+
+
 //
 // Constructors and destructors
 //

--- a/src/navigation/FlightRoute.h
+++ b/src/navigation/FlightRoute.h
@@ -219,6 +219,18 @@ namespace Navigation
                                                      const Navigation::Aircraft& aircraft,
                                                      const QDateTime& departure) const;
 
+        /*! \brief Estimated time of arrival at each waypoint.
+         *
+         *  Returns a list of size waypoints().size(): the departure time at the
+         *  first waypoint, then the accumulated ETA at each subsequent one,
+         *  using the same wind-integrated ETE as legNav(). Used to give the
+         *  side-view its ETA-aware sampling time at each point along the route.
+         */
+        [[nodiscard]] Q_INVOKABLE QList<QDateTime> waypointETAs(const Weather::WindFieldProvider* wfp,
+                                                               Weather::Wind manualWind,
+                                                               const Navigation::Aircraft& aircraft,
+                                                               const QDateTime& departure) const;
+
         /*! \brief Adds a waypoint to the end of the route
          *
          * @param waypoint Waypoint to be added

--- a/src/navigation/FlightRoute.h
+++ b/src/navigation/FlightRoute.h
@@ -27,6 +27,7 @@
 #include <QLocale>
 #include <QPointer>
 #include <QQmlEngine>
+#include <QVariant>
 #include <QXmlStreamReader>
 
 #include "geomaps/Waypoint.h"
@@ -194,26 +195,29 @@ namespace Navigation
         // METHODS
         //
 
-        /*! \brief ETA-aware wind for a leg, from a wind field.
+        /*! \brief ETA-aware, wind-integrated nav data for a leg.
          *
-         *  Walks the route from \a departure, accumulating ETE leg by leg using
-         *  the wind sampled at each leg's mid-time, and returns the wind used
-         *  for the leg at \a index. Falls back to \a manualWind when the field
-         *  has no usable data (or yields no sample) for a leg.
+         *  Walks the route from \a departure, integrating each leg's wind effect
+         *  (4-D field sampling, altitude ramping between the waypoints' planned
+         *  altitudes, advancing clock) to accumulate the start time of the leg
+         *  at \a index, then integrates that leg. Falls back to \a manualWind
+         *  where the field has no usable sample.
+         *
+         *  @returns A map with keys "ete" (Units::Timespan), "gs"
+         *  (Units::Speed), "wind" (Weather::Wind) and "fuel" (Units::Volume).
+         *  Empty when the leg index is invalid or inputs are insufficient.
          *
          *  @param index Leg index
          *  @param wfp Wind field provider (may be null)
          *  @param manualWind Fallback wind
          *  @param aircraft Aircraft in use
          *  @param departure Departure time (UTC)
-         *  @param altFt Cruise altitude in feet
          */
-        [[nodiscard]] Q_INVOKABLE Weather::Wind legWind(int index,
-                                                        const Weather::WindFieldProvider* wfp,
-                                                        Weather::Wind manualWind,
-                                                        const Navigation::Aircraft& aircraft,
-                                                        const QDateTime& departure,
-                                                        double altFt) const;
+        [[nodiscard]] Q_INVOKABLE QVariantMap legNav(int index,
+                                                     const Weather::WindFieldProvider* wfp,
+                                                     Weather::Wind manualWind,
+                                                     const Navigation::Aircraft& aircraft,
+                                                     const QDateTime& departure) const;
 
         /*! \brief Adds a waypoint to the end of the route
          *

--- a/src/navigation/FlightRoute.h
+++ b/src/navigation/FlightRoute.h
@@ -194,6 +194,27 @@ namespace Navigation
         // METHODS
         //
 
+        /*! \brief ETA-aware wind for a leg, from a wind field.
+         *
+         *  Walks the route from \a departure, accumulating ETE leg by leg using
+         *  the wind sampled at each leg's mid-time, and returns the wind used
+         *  for the leg at \a index. Falls back to \a manualWind when the field
+         *  has no usable data (or yields no sample) for a leg.
+         *
+         *  @param index Leg index
+         *  @param wfp Wind field provider (may be null)
+         *  @param manualWind Fallback wind
+         *  @param aircraft Aircraft in use
+         *  @param departure Departure time (UTC)
+         *  @param altFt Cruise altitude in feet
+         */
+        [[nodiscard]] Q_INVOKABLE Weather::Wind legWind(int index,
+                                                        const Weather::WindFieldProvider* wfp,
+                                                        Weather::Wind manualWind,
+                                                        const Navigation::Aircraft& aircraft,
+                                                        const QDateTime& departure,
+                                                        double altFt) const;
+
         /*! \brief Adds a waypoint to the end of the route
          *
          * @param waypoint Waypoint to be added

--- a/src/navigation/FlightRoute.h
+++ b/src/navigation/FlightRoute.h
@@ -329,6 +329,27 @@ namespace Navigation
         /*! \brief Reverse the route */
         Q_INVOKABLE void reverse();
 
+        /*! \brief Planned cruise altitude at a route waypoint
+         *
+         * The planned altitude is owned by the route (keyed by waypoint
+         * identity), not stored on the waypoint itself.
+         *
+         * @param idx Index of the waypoint in waypoints()
+         *
+         * @returns Planned altitude in meters AMSL, or NaN if none has been set
+         * for this waypoint.
+         */
+        [[nodiscard]] Q_INVOKABLE double plannedAltitude(int idx) const;
+
+        /*! \brief Set the planned cruise altitude at a route waypoint
+         *
+         * @param idx Index of the waypoint in waypoints()
+         *
+         * @param altitudeM Planned altitude in meters AMSL, or NaN to clear the
+         * value (so that the waypoint falls back to the default).
+         */
+        Q_INVOKABLE void setPlannedAltitude(int idx, double altitudeM);
+
         /*! \brief Saves flight route to a file
          *
          * This method saves the flight route as a GeoJSON file.  The file
@@ -408,6 +429,9 @@ namespace Navigation
         /*! \brief Notification signal for the property with the same name */
         void summaryChanged();
 
+        /*! \brief Notification signal, emitted when a planned altitude changes */
+        void plannedAltitudesChanged();
+
     private slots:
 
     private:
@@ -415,6 +439,14 @@ namespace Navigation
 
         // Helper function for method toGPX
         [[nodiscard]] auto gpxElements(const QString& indent, const QString& tag) const -> QString;
+
+        // Stable identity key for a waypoint, used to key m_plannedAltitudes so
+        // that planned altitudes follow their waypoint across reordering.
+        [[nodiscard]] static QString waypointKey(const GeoMaps::Waypoint& waypoint);
+
+        // Planned cruise altitudes, owned by the route. Keyed by waypointKey(),
+        // value is altitude in meters AMSL.
+        QMap<QString, double> m_plannedAltitudes;
 
         QProperty<QList<QGeoCoordinate>> m_geoPath;
         QList<QGeoCoordinate> computeGeoPath();

--- a/src/navigation/Leg.cpp
+++ b/src/navigation/Leg.cpp
@@ -289,6 +289,92 @@ auto Navigation::Leg::averageWind(const Weather::WindFieldProvider* wfp, double 
 }
 
 
+auto Navigation::Leg::integrate(const Weather::WindFieldProvider* wfp,
+                                Weather::Wind manualWind,
+                                const Navigation::Aircraft& aircraft,
+                                const QDateTime& startTime,
+                                double startAltFt,
+                                double endAltFt) const -> Navigation::LegIntegration
+{
+    LegIntegration r;
+    if (!isValid() || !aircraft.cruiseSpeed().isFinite()) {
+        return r;
+    }
+
+    const auto start = m_start.coordinate();
+    const auto end = m_end.coordinate();
+    const double distM = start.distanceTo(end);
+    const double tasMPS = aircraft.cruiseSpeed().toMPS();
+    if (tasMPS <= 0.0) {
+        return r;
+    }
+
+    const bool haveField = (wfp != nullptr) && wfp->isUsable();
+
+    auto sampleWind = [&](double lat, double lon, double altFt, const QDateTime& t) -> Weather::Wind {
+        if (haveField) {
+            auto w = wfp->windAt(lat, lon, altFt, t);
+            if (w.speed().isFinite() && w.directionFrom().isFinite()) {
+                return w;
+            }
+        }
+        return manualWind;
+    };
+
+    // Trivial short leg: single sample, GS from the wind triangle
+    if (distM < minLegLength.toM()) {
+        auto w = sampleWind(start.latitude(), start.longitude(), startAltFt, startTime);
+        auto gs = GS(w, aircraft);
+        const double gsMPS = gs.isFinite() ? gs.toMPS() : tasMPS;
+        r.wind = w;
+        r.gs = Units::Speed::fromMPS(gsMPS);
+        r.ete = Units::Timespan::fromS(distM / gsMPS);
+        r.isValid = true;
+        return r;
+    }
+
+    const double az = start.azimuthTo(end);
+    const int nSteps = qBound(4, int(distM / Units::Distance::fromNM(5.0).toM()), 24);
+    const double ds = distM / nSteps;
+
+    double totalSec = 0.0;
+    double sumU = 0.0; // knots, meteorological eastward
+    double sumV = 0.0; // knots, meteorological northward
+    int wc = 0;
+
+    for (int i = 0; i < nSteps; ++i) {
+        const double f = (i + 0.5) / nSteps;
+        const auto p = start.atDistanceAndAzimuth(f * distM, az);
+        const double altFt = startAltFt + (endAltFt - startAltFt) * f;
+        const QDateTime t = startTime.addSecs(qRound64(totalSec));
+
+        const auto w = sampleWind(p.latitude(), p.longitude(), altFt, t);
+        const auto gs = GS(w, aircraft);
+        const double gsMPS = gs.isFinite() ? gs.toMPS() : tasMPS;
+        if (gsMPS <= 0.0) {
+            return r; // headwind ≥ TAS: leg not flyable as planned
+        }
+        totalSec += ds / gsMPS;
+
+        if (w.speed().isFinite() && w.directionFrom().isFinite()) {
+            const double spd = w.speed().toKN();
+            const double dirRad = w.directionFrom().toDEG() * M_PI / 180.0;
+            sumU += -spd * sin(dirRad);
+            sumV += -spd * cos(dirRad);
+            ++wc;
+        }
+    }
+
+    r.ete = Units::Timespan::fromS(totalSec);
+    r.gs = Units::Speed::fromMPS(distM / totalSec);
+    if (wc > 0) {
+        r.wind = Weather::WindFieldProvider::windFromUV(sumU / wc, sumV / wc);
+    }
+    r.isValid = true;
+    return r;
+}
+
+
 auto Navigation::Leg::hasDataForWindTriangle(Weather::Wind wind, const Navigation::Aircraft& aircraft) -> bool
 {
 

--- a/src/navigation/Leg.cpp
+++ b/src/navigation/Leg.cpp
@@ -20,6 +20,8 @@
 
 #include "Leg.h"
 
+#include "weather/WindFieldProvider.h"
+
 #include <utility>
 
 
@@ -245,6 +247,45 @@ auto Navigation::Leg::description(Weather::Wind wind, const Navigation::Aircraft
     }
 
     return result;
+}
+
+
+auto Navigation::Leg::averageWind(const Weather::WindFieldProvider* wfp, double altFt) const -> Weather::Wind
+{
+    if ((wfp == nullptr) || !wfp->isUsable() || !isValid()) {
+        return {};
+    }
+
+    const auto start = m_start.coordinate();
+    const auto end = m_end.coordinate();
+    const double distM = start.distanceTo(end);
+    if (distM < minLegLength.toM()) {
+        // Too short to sample meaningfully — use the start point only
+        const QPointF uv = wfp->uvKnotsAt(start.latitude(), start.longitude(), altFt);
+        return Weather::WindFieldProvider::windFromUV(uv.x(), uv.y());
+    }
+
+    const double az = start.azimuthTo(end);
+    const int nSamples = (distM > Units::Distance::fromNM(50.0).toM()) ? 5 : 3;
+
+    double sumU = 0.0;
+    double sumV = 0.0;
+    int count = 0;
+    for (int i = 0; i < nSamples; ++i) {
+        const double f = (i + 0.5) / nSamples; // sample at sub-segment midpoints
+        const auto p = start.atDistanceAndAzimuth(f * distM, az);
+        const QPointF uv = wfp->uvKnotsAt(p.latitude(), p.longitude(), altFt);
+        if (qIsFinite(uv.x()) && qIsFinite(uv.y())) {
+            sumU += uv.x();
+            sumV += uv.y();
+            ++count;
+        }
+    }
+
+    if (count == 0) {
+        return {};
+    }
+    return Weather::WindFieldProvider::windFromUV(sumU / count, sumV / count);
 }
 
 

--- a/src/navigation/Leg.cpp
+++ b/src/navigation/Leg.cpp
@@ -250,7 +250,7 @@ auto Navigation::Leg::description(Weather::Wind wind, const Navigation::Aircraft
 }
 
 
-auto Navigation::Leg::averageWind(const Weather::WindFieldProvider* wfp, double altFt) const -> Weather::Wind
+auto Navigation::Leg::averageWind(const Weather::WindFieldProvider* wfp, double altFt, const QDateTime& time) const -> Weather::Wind
 {
     if ((wfp == nullptr) || !wfp->isUsable() || !isValid()) {
         return {};
@@ -261,7 +261,7 @@ auto Navigation::Leg::averageWind(const Weather::WindFieldProvider* wfp, double 
     const double distM = start.distanceTo(end);
     if (distM < minLegLength.toM()) {
         // Too short to sample meaningfully — use the start point only
-        const QPointF uv = wfp->uvKnotsAt(start.latitude(), start.longitude(), altFt);
+        const QPointF uv = wfp->uvKnotsAt(start.latitude(), start.longitude(), altFt, time);
         return Weather::WindFieldProvider::windFromUV(uv.x(), uv.y());
     }
 
@@ -274,7 +274,7 @@ auto Navigation::Leg::averageWind(const Weather::WindFieldProvider* wfp, double 
     for (int i = 0; i < nSamples; ++i) {
         const double f = (i + 0.5) / nSamples; // sample at sub-segment midpoints
         const auto p = start.atDistanceAndAzimuth(f * distM, az);
-        const QPointF uv = wfp->uvKnotsAt(p.latitude(), p.longitude(), altFt);
+        const QPointF uv = wfp->uvKnotsAt(p.latitude(), p.longitude(), altFt, time);
         if (qIsFinite(uv.x()) && qIsFinite(uv.y())) {
             sumU += uv.x();
             sumV += uv.y();

--- a/src/navigation/Leg.h
+++ b/src/navigation/Leg.h
@@ -34,6 +34,14 @@
 
 namespace Navigation {
 
+/*! \brief Result of integrating wind effect along a leg */
+struct LegIntegration {
+    Units::Timespan ete;   ///< time enroute
+    Units::Speed    gs;    ///< effective (distance/time) ground speed
+    Weather::Wind   wind;  ///< track-representative wind (vector-averaged)
+    bool isValid {false};
+};
+
 /*! \brief Leg in a flight route */
 
 class Leg {
@@ -234,6 +242,29 @@ public:
     {
         return averageWind(wfp, altFt, QDateTime::currentDateTimeUtc());
     }
+
+    /*! \brief Integrate the wind effect along the leg.
+     *
+     *  Steps along the great circle; at each sub-segment the altitude ramps
+     *  linearly from \a startAltFt to \a endAltFt, the wind is sampled from the
+     *  field in 4-D (lat, lon, alt, time) with the clock advancing as the
+     *  integration proceeds, and the local ground speed comes from the wind
+     *  triangle. ETE is the integral of ds/GS. Falls back to \a manualWind
+     *  where the field has no usable sample.
+     *
+     *  @param wfp Wind field provider (may be null)
+     *  @param manualWind Fallback wind
+     *  @param aircraft Aircraft in use
+     *  @param startTime Clock at the start of the leg (UTC)
+     *  @param startAltFt Altitude at the leg's start waypoint (ft)
+     *  @param endAltFt Altitude at the leg's end waypoint (ft)
+     */
+    [[nodiscard]] LegIntegration integrate(const Weather::WindFieldProvider* wfp,
+                                           Weather::Wind manualWind,
+                                           const Navigation::Aircraft& aircraft,
+                                           const QDateTime& startTime,
+                                           double startAltFt,
+                                           double endAltFt) const;
 
 
     //

--- a/src/navigation/Leg.h
+++ b/src/navigation/Leg.h
@@ -29,6 +29,7 @@
 #include "units/Angle.h"
 #include "units/Units.h"
 #include "weather/Wind.h"
+#include "weather/WindFieldProvider.h"
 
 namespace Navigation {
 
@@ -212,6 +213,36 @@ public:
      *  @returns Estimated WCA on leg
      */
     [[nodiscard]] Q_INVOKABLE Units::Angle WCA(Weather::Wind wind, const Navigation::Aircraft& aircraft) const;
+
+
+    /*! \brief Track-averaged wind from a wind field, sampled along the leg.
+     *
+     *  Samples the field at several points along the leg's great circle at the
+     *  given cruise altitude and averages the (u, v) components. Returns an
+     *  invalid Wind when the provider is null or has no usable data.
+     *
+     *  @param wfp Wind field provider (may be null)
+     *  @param altFt Cruise altitude in feet
+     */
+    [[nodiscard]] Q_INVOKABLE Weather::Wind averageWind(const Weather::WindFieldProvider* wfp, double altFt) const;
+
+    /*! \brief ETE using a wind field at the given cruise altitude */
+    [[nodiscard]] Q_INVOKABLE Units::Timespan ETE(const Weather::WindFieldProvider* wfp, double altFt, const Navigation::Aircraft& aircraft) const
+    {
+        return ETE(averageWind(wfp, altFt), aircraft);
+    }
+
+    /*! \brief Estimated ground speed using a wind field at the given cruise altitude */
+    [[nodiscard]] Q_INVOKABLE Units::Speed GS(const Weather::WindFieldProvider* wfp, double altFt, const Navigation::Aircraft& aircraft) const
+    {
+        return GS(averageWind(wfp, altFt), aircraft);
+    }
+
+    /*! \brief Estimated fuel consumption using a wind field at the given cruise altitude */
+    [[nodiscard]] Q_INVOKABLE Units::Volume Fuel(const Weather::WindFieldProvider* wfp, double altFt, const Navigation::Aircraft& aircraft) const
+    {
+        return Fuel(averageWind(wfp, altFt), aircraft);
+    }
 
 
     //

--- a/src/navigation/Leg.h
+++ b/src/navigation/Leg.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <QDateTime>
 #include <QGeoPath>
 #include <QQmlEngine>
 
@@ -218,30 +219,20 @@ public:
     /*! \brief Track-averaged wind from a wind field, sampled along the leg.
      *
      *  Samples the field at several points along the leg's great circle at the
-     *  given cruise altitude and averages the (u, v) components. Returns an
-     *  invalid Wind when the provider is null or has no usable data.
+     *  given cruise altitude and forecast time, averaging the (u, v)
+     *  components. Returns an invalid Wind when the provider is null or has no
+     *  usable data.
      *
      *  @param wfp Wind field provider (may be null)
      *  @param altFt Cruise altitude in feet
+     *  @param time Forecast time at which to sample the field
      */
-    [[nodiscard]] Q_INVOKABLE Weather::Wind averageWind(const Weather::WindFieldProvider* wfp, double altFt) const;
+    [[nodiscard]] Weather::Wind averageWind(const Weather::WindFieldProvider* wfp, double altFt, const QDateTime& time) const;
 
-    /*! \brief ETE using a wind field at the given cruise altitude */
-    [[nodiscard]] Q_INVOKABLE Units::Timespan ETE(const Weather::WindFieldProvider* wfp, double altFt, const Navigation::Aircraft& aircraft) const
+    /*! \brief As above, sampling the field at the time nearest "now" */
+    [[nodiscard]] Q_INVOKABLE Weather::Wind averageWind(const Weather::WindFieldProvider* wfp, double altFt) const
     {
-        return ETE(averageWind(wfp, altFt), aircraft);
-    }
-
-    /*! \brief Estimated ground speed using a wind field at the given cruise altitude */
-    [[nodiscard]] Q_INVOKABLE Units::Speed GS(const Weather::WindFieldProvider* wfp, double altFt, const Navigation::Aircraft& aircraft) const
-    {
-        return GS(averageWind(wfp, altFt), aircraft);
-    }
-
-    /*! \brief Estimated fuel consumption using a wind field at the given cruise altitude */
-    [[nodiscard]] Q_INVOKABLE Units::Volume Fuel(const Weather::WindFieldProvider* wfp, double altFt, const Navigation::Aircraft& aircraft) const
-    {
-        return Fuel(averageWind(wfp, altFt), aircraft);
+        return averageWind(wfp, altFt, QDateTime::currentDateTimeUtc());
     }
 
 

--- a/src/navigation/Navigator.cpp
+++ b/src/navigation/Navigator.cpp
@@ -86,6 +86,7 @@ Navigation::FlightRoute* Navigation::Navigator::flightRoute()
         m_flightRoute = new FlightRoute(this);
         m_flightRoute->load(m_flightRouteFileName);
         connect(m_flightRoute, &Navigation::FlightRoute::waypointsChanged, this, [this]() {if (m_flightRoute != nullptr) {(void)m_flightRoute->save(m_flightRouteFileName);}});
+        connect(m_flightRoute, &Navigation::FlightRoute::plannedAltitudesChanged, this, [this]() {if (m_flightRoute != nullptr) {(void)m_flightRoute->save(m_flightRouteFileName);}});
         QQmlEngine::setObjectOwnership(m_flightRoute, QQmlEngine::CppOwnership);
     }
     return m_flightRoute;

--- a/src/navigation/Navigator.cpp
+++ b/src/navigation/Navigator.cpp
@@ -26,6 +26,7 @@
 #include "dataManagement/DataManager.h"
 #include "navigation/Navigator.h"
 #include "positioning/PositionProvider.h"
+#include "weather/WindFieldProvider.h"
 
 
 //
@@ -40,6 +41,7 @@ Navigation::Navigator::Navigator(QObject *parent) : GlobalObject(parent)
     QSettings const settings;
     m_wind.setSpeed(Units::Speed::fromKN(settings.value(QStringLiteral("Wind/windSpeedInKT"), qQNaN()).toDouble()));
     m_wind.setDirectionFrom( Units::Angle::fromDEG(settings.value(QStringLiteral("Wind/windDirectionInDEG"), qQNaN()).toDouble()) );
+    m_cruiseAltitudeFt = settings.value(QStringLiteral("Wind/cruiseAltitudeFt"), 5000.0).toDouble();
 
     // Restore aircraft
     QFile file(m_aircraftFileName);
@@ -69,7 +71,17 @@ void Navigation::Navigator::deferredInitialization()
     connect(GlobalObject::positionProvider(), &Positioning::PositionProvider::positionInfoChanged, this, &Navigation::Navigator::updateRemainingRouteInfo);
     connect(this, &Navigation::Navigator::aircraftChanged, this, [this](){ updateRemainingRouteInfo(); });
     connect(this, &Navigation::Navigator::windChanged, this, [this](){ updateRemainingRouteInfo(); });
+    connect(this, &Navigation::Navigator::cruiseAltitudeFtChanged, this, [this](){ updateRemainingRouteInfo(); });
     connect(flightRoute(), &Navigation::FlightRoute::waypointsChanged, this, [this](){ updateRemainingRouteInfo(); });
+
+    // When the wind field is (re)loaded, the active wind source and route info change
+    connect(Weather::WindFieldProvider::instance(), &Weather::WindFieldProvider::dataChanged, this, [this](){
+        emit windSourceChanged();
+        updateRemainingRouteInfo();
+    });
+
+    // Attempt an initial wind-field load (no-op if no server configured)
+    Weather::WindFieldProvider::instance()->refresh();
 
     m_hasAviationMapForCurrentLocation.setBinding([this]() {return computeHasAviationMapForCurrentLocation();});
 }
@@ -144,6 +156,47 @@ void Navigation::Navigator::setWind(Weather::Wind newWind)
     // Set new wind
     m_wind = newWind;
     emit windChanged();
+}
+
+
+void Navigation::Navigator::setCruiseAltitudeFt(double newAltFt)
+{
+    if (qFuzzyCompare(newAltFt, m_cruiseAltitudeFt))
+    {
+        return;
+    }
+    m_cruiseAltitudeFt = newAltFt;
+    QSettings().setValue(QStringLiteral("Wind/cruiseAltitudeFt"), newAltFt);
+    emit cruiseAltitudeFtChanged();
+}
+
+
+Weather::WindFieldProvider* Navigation::Navigator::windField() const
+{
+    auto* wfp = Weather::WindFieldProvider::instance();
+    QQmlEngine::setObjectOwnership(wfp, QQmlEngine::CppOwnership);
+    return wfp;
+}
+
+
+QString Navigation::Navigator::windSource() const
+{
+    return Weather::WindFieldProvider::instance()->isUsable() ? u"field"_s : u"manual"_s;
+}
+
+
+Weather::Wind Navigation::Navigator::effectiveWind(const Navigation::Leg& leg) const
+{
+    auto* wfp = Weather::WindFieldProvider::instance();
+    if (wfp->isUsable())
+    {
+        auto w = leg.averageWind(wfp, m_cruiseAltitudeFt);
+        if (w.speed().isFinite() && w.directionFrom().isFinite())
+        {
+            return w;
+        }
+    }
+    return m_wind;
 }
 
 
@@ -297,7 +350,7 @@ void Navigation::Navigator::updateRemainingRouteInfo()
     rri.status = RemainingRouteInfo::OnRoute;
     Leg const legToNextWP(info.coordinate(), legs[currentLeg].endPoint());
     auto dist = legToNextWP.distance();
-    auto ETE = legToNextWP.ETE(m_wind, m_aircraft);
+    auto ETE = legToNextWP.ETE(effectiveWind(legToNextWP), m_aircraft);
 
     // If bearing is less than +/- 30°, then use current ground speed to
     // estimate ETE for leg to next waypoint
@@ -329,7 +382,7 @@ void Navigation::Navigator::updateRemainingRouteInfo()
         for(auto i=currentLeg+1; i<legs.size(); i++)
         {
             dist += legs[i].distance();
-            ETE += legs[i].ETE(m_wind, m_aircraft);
+            ETE += legs[i].ETE(effectiveWind(legs[i]), m_aircraft);
         }
 
         rri.finalWP = legs.last().endPoint();
@@ -346,13 +399,16 @@ void Navigation::Navigator::updateRemainingRouteInfo()
     {
         complaints += tr("Cruise speed not specified.");
     }
-    if (!m_wind.speed().isFinite())
+    if (!Weather::WindFieldProvider::instance()->isUsable())
     {
-        complaints += tr("Wind speed not specified.");
-    }
-    if (!m_wind.directionFrom().isFinite())
-    {
-        complaints += tr("Wind direction not specified.");
+        if (!m_wind.speed().isFinite())
+        {
+            complaints += tr("Wind speed not specified.");
+        }
+        if (!m_wind.directionFrom().isFinite())
+        {
+            complaints += tr("Wind direction not specified.");
+        }
     }
     if (!complaints.isEmpty())
     {

--- a/src/navigation/Navigator.cpp
+++ b/src/navigation/Navigator.cpp
@@ -72,6 +72,7 @@ void Navigation::Navigator::deferredInitialization()
     connect(this, &Navigation::Navigator::aircraftChanged, this, [this](){ updateRemainingRouteInfo(); });
     connect(this, &Navigation::Navigator::windChanged, this, [this](){ updateRemainingRouteInfo(); });
     connect(this, &Navigation::Navigator::cruiseAltitudeFtChanged, this, [this](){ updateRemainingRouteInfo(); });
+    connect(this, &Navigation::Navigator::departureTimeChanged, this, [this](){ updateRemainingRouteInfo(); });
     connect(flightRoute(), &Navigation::FlightRoute::waypointsChanged, this, [this](){ updateRemainingRouteInfo(); });
 
     // When the wind field is (re)loaded, the active wind source and route info change
@@ -185,12 +186,23 @@ QString Navigation::Navigator::windSource() const
 }
 
 
-Weather::Wind Navigation::Navigator::effectiveWind(const Navigation::Leg& leg) const
+void Navigation::Navigator::setDepartureTime(const QDateTime& newTime)
+{
+    if (m_departureTime == newTime)
+    {
+        return;
+    }
+    m_departureTime = newTime;
+    emit departureTimeChanged();
+}
+
+
+Weather::Wind Navigation::Navigator::effectiveWindAtTime(const Navigation::Leg& leg, const QDateTime& time) const
 {
     auto* wfp = Weather::WindFieldProvider::instance();
     if (wfp->isUsable())
     {
-        auto w = leg.averageWind(wfp, m_cruiseAltitudeFt);
+        auto w = leg.averageWind(wfp, m_cruiseAltitudeFt, time);
         if (w.speed().isFinite() && w.directionFrom().isFinite())
         {
             return w;
@@ -348,9 +360,12 @@ void Navigation::Navigator::updateRemainingRouteInfo()
     //
     RemainingRouteInfo rri;
     rri.status = RemainingRouteInfo::OnRoute;
+    // ETA-aware: accumulate clock time from "now" as we walk the remaining route
+    QDateTime clock = QDateTime::currentDateTimeUtc();
+
     Leg const legToNextWP(info.coordinate(), legs[currentLeg].endPoint());
     auto dist = legToNextWP.distance();
-    auto ETE = legToNextWP.ETE(effectiveWind(legToNextWP), m_aircraft);
+    auto ETE = legToNextWP.ETE(effectiveWindAtTime(legToNextWP, clock), m_aircraft);
 
     // If bearing is less than +/- 30°, then use current ground speed to
     // estimate ETE for leg to next waypoint
@@ -379,10 +394,19 @@ void Navigation::Navigator::updateRemainingRouteInfo()
 
     if (currentLeg < legs.size()-1)
     {
+        if (ETE.isFinite())
+        {
+            clock = clock.addSecs(qRound64(ETE.toS()));
+        }
         for(auto i=currentLeg+1; i<legs.size(); i++)
         {
             dist += legs[i].distance();
-            ETE += legs[i].ETE(effectiveWind(legs[i]), m_aircraft);
+            auto legETE = legs[i].ETE(effectiveWindAtTime(legs[i], clock), m_aircraft);
+            ETE += legETE;
+            if (legETE.isFinite())
+            {
+                clock = clock.addSecs(qRound64(legETE.toS()));
+            }
         }
 
         rri.finalWP = legs.last().endPoint();

--- a/src/navigation/Navigator.h
+++ b/src/navigation/Navigator.h
@@ -138,6 +138,14 @@ public:
     [[nodiscard]] double cruiseAltitudeFt() const { return m_cruiseAltitudeFt; }
     void setCruiseAltitudeFt(double newAltFt);
 
+    /*! \brief Planned departure time (UTC), used for ETA-aware wind selection.
+     *
+     *  Defaults to the current time; not persisted across sessions.
+     */
+    Q_PROPERTY(QDateTime departureTime READ departureTime WRITE setDepartureTime NOTIFY departureTimeChanged)
+    [[nodiscard]] QDateTime departureTime() const { return m_departureTime; }
+    void setDepartureTime(const QDateTime& newTime);
+
     /*! \brief Active wind source: "field" (server wind field) or "manual" */
     Q_PROPERTY(QString windSource READ windSource NOTIFY windSourceChanged)
     [[nodiscard]] QString windSource() const;
@@ -171,6 +179,9 @@ signals:
 
     /*! \brief Notifier signal */
     void cruiseAltitudeFtChanged();
+
+    /*! \brief Notifier signal */
+    void departureTimeChanged();
 
     /*! \brief Notifier signal */
     void windSourceChanged();
@@ -207,11 +218,12 @@ private:
 
     Weather::Wind m_wind {};
 
-    // Effective wind for a leg: averaged field wind at cruise altitude when the
-    // wind field is usable, otherwise the manual wind m_wind.
-    [[nodiscard]] Weather::Wind effectiveWind(const Navigation::Leg& leg) const;
+    // Effective wind for a leg at a given time: averaged field wind at cruise
+    // altitude when the wind field is usable, otherwise the manual wind m_wind.
+    [[nodiscard]] Weather::Wind effectiveWindAtTime(const Navigation::Leg& leg, const QDateTime& time) const;
 
     double m_cruiseAltitudeFt {5000.0};
+    QDateTime m_departureTime {QDateTime::currentDateTimeUtc()};
 
     QString m_aircraftFileName;
 

--- a/src/navigation/Navigator.h
+++ b/src/navigation/Navigator.h
@@ -27,6 +27,7 @@
 #include "GlobalObject.h"
 #include "navigation/FlightRoute.h"
 #include "navigation/RemainingRouteInfo.h"
+#include "weather/WindFieldProvider.h"
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -127,10 +128,25 @@ public:
     [[nodiscard]] Navigation::RemainingRouteInfo remainingRouteInfo() const {return m_remainingRouteInfo.value();}
     [[nodiscard]] QBindable<Navigation::RemainingRouteInfo> bindableRemainingRouteInfo() {return &m_remainingRouteInfo;}
 
-    /*! \brief Current wind */
+    /*! \brief Current (manual) wind, used as fallback when no wind field is available */
     Q_PROPERTY(Weather::Wind wind READ wind WRITE setWind NOTIFY windChanged)
     [[nodiscard]] Weather::Wind wind() const { return m_wind; }
     void setWind(Weather::Wind newWind);
+
+    /*! \brief Planned cruise altitude in feet, used to sample the wind field */
+    Q_PROPERTY(double cruiseAltitudeFt READ cruiseAltitudeFt WRITE setCruiseAltitudeFt NOTIFY cruiseAltitudeFtChanged)
+    [[nodiscard]] double cruiseAltitudeFt() const { return m_cruiseAltitudeFt; }
+    void setCruiseAltitudeFt(double newAltFt);
+
+    /*! \brief Active wind source: "field" (server wind field) or "manual" */
+    Q_PROPERTY(QString windSource READ windSource NOTIFY windSourceChanged)
+    [[nodiscard]] QString windSource() const;
+
+    /*! \brief The application-wide wind field provider, for use in QML leg calls.
+     *
+     *  QML ownership set to CppOwnership; do not delete.
+     */
+    Q_INVOKABLE Weather::WindFieldProvider* windField() const;
 
 signals:
     /*! \brief Notifier signal */
@@ -152,6 +168,12 @@ signals:
 
     /*! \brief Notifier signal */
     void windChanged();
+
+    /*! \brief Notifier signal */
+    void cruiseAltitudeFtChanged();
+
+    /*! \brief Notifier signal */
+    void windSourceChanged();
 
 private slots:
     // Check if altitude limit for flight maps needs to be lifted. Connected to positioning source.
@@ -184,6 +206,12 @@ private:
     const QString m_flightRouteFileName {QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + u"/flight route.geojson"_s};
 
     Weather::Wind m_wind {};
+
+    // Effective wind for a leg: averaged field wind at cruise altitude when the
+    // wind field is usable, otherwise the manual wind m_wind.
+    [[nodiscard]] Weather::Wind effectiveWind(const Navigation::Leg& leg) const;
+
+    double m_cruiseAltitudeFt {5000.0};
 
     QString m_aircraftFileName;
 

--- a/src/qml/items/ColorScaleLegend.qml
+++ b/src/qml/items/ColorScaleLegend.qml
@@ -18,7 +18,7 @@ Item {
     // Gradient bar
     Rectangle {
         id: bar
-        anchors { left: parent.left; right: parent.right }
+        width: root.width
         height: 10
         radius: 2
         border.color: Qt.rgba(0, 0, 0, 0.15)
@@ -36,7 +36,8 @@ Item {
     // Tick labels: vmin | stop1 | stop2 | vmax [units]
     Row {
         id: ticks
-        anchors { left: parent.left; right: parent.right; top: bar.bottom; topMargin: 2 }
+        width: root.width
+        anchors { top: bar.bottom; topMargin: 2 }
 
         readonly property double range: root.vmax - root.vmin
         readonly property double v1: root.vmin + range * 0.33

--- a/src/qml/items/ColorScaleLegend.qml
+++ b/src/qml/items/ColorScaleLegend.qml
@@ -1,0 +1,80 @@
+// Color scale legend bar with labeled tick marks at each color stop.
+// Expects 4 colors at positions 0, 0.33, 0.66, 1.0 matching the server colormaps.
+
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    id: root
+
+    property var    colors: []
+    property double vmin: 0
+    property double vmax: 1
+    property string units: ""
+
+    implicitHeight: bar.height + ticks.height + 2
+    implicitWidth:  200
+
+    // Gradient bar
+    Rectangle {
+        id: bar
+        anchors { left: parent.left; right: parent.right }
+        height: 10
+        radius: 2
+        border.color: Qt.rgba(0, 0, 0, 0.15)
+        border.width: 1
+
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+            GradientStop { position: 0.0;  color: root.colors[0] ?? "transparent" }
+            GradientStop { position: 0.33; color: root.colors[1] ?? "transparent" }
+            GradientStop { position: 0.66; color: root.colors[2] ?? "transparent" }
+            GradientStop { position: 1.0;  color: root.colors[3] ?? "transparent" }
+        }
+    }
+
+    // Tick labels: vmin | stop1 | stop2 | vmax [units]
+    Row {
+        id: ticks
+        anchors { left: parent.left; right: parent.right; top: bar.bottom; topMargin: 2 }
+
+        readonly property double range: root.vmax - root.vmin
+        readonly property double v1: root.vmin + range * 0.33
+        readonly property double v2: root.vmin + range * 0.66
+
+        function fmt(v) {
+            return v >= 1000 ? Math.round(v).toString()
+                 : v < 1    ? v.toFixed(1)
+                 :             Math.round(v).toString()
+        }
+
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(root.vmin)
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignLeft
+            opacity: 0.7
+        }
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(ticks.v1)
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignHCenter
+            opacity: 0.7
+        }
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(ticks.v2)
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignHCenter
+            opacity: 0.7
+        }
+        Label {
+            width: parent.width * 0.25
+            text: ticks.fmt(root.vmax) + (root.units ? " " + root.units : "")
+            font.pixelSize: 9
+            horizontalAlignment: Text.AlignRight
+            opacity: 0.7
+        }
+    }
+}

--- a/src/qml/items/ColorScaleLegend.qml
+++ b/src/qml/items/ColorScaleLegend.qml
@@ -11,6 +11,9 @@ Item {
     property double vmin: 0
     property double vmax: 1
     property string units: ""
+    // Optional custom label formatter: function(value, isLast) → string
+    // When set, overrides the default fmt() + units logic
+    property var    labelFunc: null
 
     implicitHeight: bar.height + ticks.height + 2
     implicitWidth:  200
@@ -43,36 +46,38 @@ Item {
         readonly property double v1: root.vmin + range * 0.33
         readonly property double v2: root.vmin + range * 0.66
 
-        function fmt(v) {
-            return v >= 1000 ? Math.round(v).toString()
-                 : v < 1    ? v.toFixed(1)
-                 :             Math.round(v).toString()
+        function fmt(v, isLast) {
+            if (root.labelFunc) return root.labelFunc(v)
+            var s = v >= 1000 ? Math.round(v).toString()
+                  : v < 1    ? v.toFixed(1)
+                  :             Math.round(v).toString()
+            return isLast && root.units ? s + " " + root.units : s
         }
 
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(root.vmin)
+            text: ticks.fmt(root.vmin, false)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignLeft
             opacity: 0.7
         }
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(ticks.v1)
+            text: ticks.fmt(ticks.v1, false)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignHCenter
             opacity: 0.7
         }
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(ticks.v2)
+            text: ticks.fmt(ticks.v2, false)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignHCenter
             opacity: 0.7
         }
         Label {
             width: parent.width * 0.25
-            text: ticks.fmt(root.vmax) + (root.units ? " " + root.units : "")
+            text: ticks.fmt(root.vmax, true)
             font.pixelSize: 9
             horizontalAlignment: Text.AlignRight
             opacity: 0.7

--- a/src/qml/items/ElevationInput.qml
+++ b/src/qml/items/ElevationInput.qml
@@ -26,8 +26,12 @@ import QtQuick.Layouts
 // Set currentIndex to 0 for "feet" and 1 for "meter"
 
 StackLayout {
+    id: elevationInput
 
     property double valueMeter: NaN
+
+    // Emitted when the user confirms the input with the Enter/Return key.
+    signal accepted()
 
     function setTexts() {
         if (isNaN(valueMeter)) {
@@ -38,6 +42,17 @@ StackLayout {
 
         ft_d.text = Math.round(valueMeter*3.281)
         m_d.text = Math.round(valueMeter)
+    }
+
+    // Commit the currently-visible field's text into valueMeter. Call this
+    // before reading valueMeter when the user may not have pressed Enter (e.g.
+    // when accepting a dialog by clicking OK).
+    function commit() {
+        if (currentIndex === 1) {
+            valueMeter = m_d.acceptableInput ? Number.fromLocaleString(Qt.locale(), m_d.text) : NaN
+        } else {
+            valueMeter = ft_d.acceptableInput ? Number.fromLocaleString(Qt.locale(), ft_d.text)/3.281 : NaN
+        }
     }
 
     Component.onCompleted: setTexts()
@@ -68,6 +83,7 @@ StackLayout {
                 else
                     valueMeter = NaN
             }
+            onAccepted: elevationInput.accepted()
         }
         Label {
             id: colorGlean
@@ -98,6 +114,7 @@ StackLayout {
                 else
                     valueMeter = NaN
             }
+            onAccepted: elevationInput.accepted()
         }
         Label { text: "m" }
     }

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -756,19 +756,19 @@ Map {
         }
 
         LayerParameter {
-            id: forecastRainLayer
-            styleId: "forecastRainLayer"
-            type: "raster"
-            property string source: "forecastRain"
-            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
             id: forecastCloudbaseLayer
             styleId: "forecastCloudbaseLayer"
             type: "raster"
             property string source: "forecastCloudbase"
             layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastRainLayer
+            styleId: "forecastRainLayer"
+            type: "raster"
+            property string source: "forecastRain"
+            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
         }
 
         LayerParameter {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -55,6 +55,15 @@ Map {
     /*! \brief Altitude (ft) at which the wind-barb layer samples the wind field */
     property real windAltitudeFt: 3000
 
+    /*! \brief Forecast time driving the wind-barb layer (from the layer-menu time slider) */
+    property var windForecastTime: {
+        var ts = ForecastMapProvider.timestamps
+        var i = ForecastMapProvider.currentIndex
+        if (ts && ts.length > 0 && i >= 0 && i < ts.length)
+            return new Date(ts[i])
+        return new Date()
+    }
+
     /* Handle changes in zoom level */
     onZoomLevelChanged: {
         var vec1 = flightMap.fromCoordinate(flightMap.center, false)
@@ -1121,18 +1130,18 @@ Map {
                 return Math.abs(rl - Math.round(rl)) < 0.05 && Math.abs(ro - Math.round(ro)) < 0.05
             }
 
-            property var wind: WindFieldProvider.windAt(modelData.lat, modelData.lon, flightMap.windAltitudeFt)
+            property var wind: WindFieldProvider.windAt(modelData.lat, modelData.lon, flightMap.windAltitudeFt, flightMap.windForecastTime)
             onWindChanged: windCanvas.requestPaint()
 
             coordinate: QtPositioning.coordinate(modelData.lat, modelData.lon)
-            anchorPoint.x: 30
-            anchorPoint.y: 30
+            anchorPoint.x: 40
+            anchorPoint.y: 40
             visible: showHere && wind.speed.isFinite() && wind.directionFrom.isFinite()
 
             sourceItem: Canvas {
                 id: windCanvas
-                width: 60
-                height: 60
+                width: 80
+                height: 80
 
                 onPaint: {
                     var ctx = getContext("2d")
@@ -1142,25 +1151,25 @@ Map {
                         return
                     var spd = windItem.wind.speed.toKN()
 
-                    var cx = 30, cy = 30
+                    var cx = 40, cy = 40
                     // Calm: small circle
                     if (spd < 2.5) {
                         ctx.beginPath()
-                        ctx.arc(cx, cy, 3, 0, 2*Math.PI)
+                        ctx.arc(cx, cy, 4, 0, 2*Math.PI)
                         ctx.strokeStyle = "#1a3a8a"
-                        ctx.lineWidth = 1.5
+                        ctx.lineWidth = 1.8
                         ctx.stroke()
                         return
                     }
 
                     var dirRad = windItem.wind.directionFrom.toRAD() // staff toward wind source
-                    var len = 22
+                    var len = 30
                     var ex = cx + len * Math.sin(dirRad)
                     var ey = cy - len * Math.cos(dirRad)
 
                     ctx.strokeStyle = "#1a3a8a"
                     ctx.fillStyle = "#1a3a8a"
-                    ctx.lineWidth = 1.5
+                    ctx.lineWidth = 1.8
 
                     // Staff
                     ctx.beginPath()
@@ -1172,9 +1181,9 @@ Map {
                     var remaining = Math.round(spd / 5) * 5
                     var perpX = Math.cos(dirRad)
                     var perpY = Math.sin(dirRad)
-                    var stepX = -Math.sin(dirRad) * 5
-                    var stepY =  Math.cos(dirRad) * 5
-                    var barbLen = 11
+                    var stepX = -Math.sin(dirRad) * 6.5
+                    var stepY =  Math.cos(dirRad) * 6.5
+                    var barbLen = 15
                     var bx = ex, by = ey
 
                     while (remaining >= 50) {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -681,6 +681,11 @@ Map {
                 "visibility": 'visible', // GeoMapProvider.currentRasterMap !== "" ? 'visible' : 'none'
                 "raster-resampling": 'linear'
             }
+
+            paint: ({
+                "raster-opacity":         flightMap.showWindLayer ? 0.35 : 1.0,
+                "raster-brightness-max":  flightMap.showWindLayer ? 0.7  : 1.0
+            })
         }
 
         LayerParameter {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -1131,13 +1131,16 @@ Map {
                 return Math.abs(rl - Math.round(rl)) < 0.05 && Math.abs(ro - Math.round(ro)) < 0.05
             }
 
-            property var wind: WindFieldProvider.windAt(modelData.lat, modelData.lon, flightMap.windAltitudeFt, flightMap.windForecastTime)
+            // Only interpolate for points actually shown at this zoom level
+            property var wind: showHere
+                ? WindFieldProvider.windAt(modelData.lat, modelData.lon, flightMap.windAltitudeFt, flightMap.windForecastTime)
+                : null
             onWindChanged: windCanvas.requestPaint()
 
             coordinate: QtPositioning.coordinate(modelData.lat, modelData.lon)
             anchorPoint.x: 40
             anchorPoint.y: 40
-            visible: showHere && wind.speed.isFinite() && wind.directionFrom.isFinite()
+            visible: showHere && wind && wind.speed.isFinite() && wind.directionFrom.isFinite()
 
             sourceItem: Canvas {
                 id: windCanvas
@@ -1148,7 +1151,7 @@ Map {
                     var ctx = getContext("2d")
                     ctx.clearRect(0, 0, width, height)
 
-                    if (!windItem.wind.speed.isFinite() || !windItem.wind.directionFrom.isFinite())
+                    if (!windItem.wind || !windItem.wind.speed.isFinite() || !windItem.wind.directionFrom.isFinite())
                         return
                     var spd = windItem.wind.speed.toKN()
 

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -40,6 +40,9 @@ Map {
     */
     property real pixelPer10km: 0.0
 
+    /*! \brief Show METAR weather layer (flight category dots + wind barbs) */
+    property bool showWeatherLayer: false
+
     /* Handle changes in zoom level */
     onZoomLevelChanged: {
         var vec1 = flightMap.fromCoordinate(flightMap.center, false)
@@ -934,6 +937,117 @@ Map {
         id: midFieldWaypoints
         model: Navigator.flightRoute.midFieldWaypoints
         delegate: waypointComponent
+    }
+
+    ObserverList {
+        id: weatherObservers
+    }
+
+    MapItemView { // METAR flight category dots and wind barbs
+        visible: flightMap.showWeatherLayer
+        model: weatherObservers.observers
+        delegate: Component {
+            MapQuickItem {
+                id: metarItem
+
+                property var obs: modelData
+                property var met: obs.metar
+
+                anchorPoint.x: 14
+                anchorPoint.y: 14
+                coordinate: met.coordinate
+                visible: met.isValid
+
+                sourceItem: Canvas {
+                    id: metarCanvas
+                    width: 70
+                    height: 70
+
+                    onPaint: {
+                        var ctx = getContext("2d")
+                        ctx.clearRect(0, 0, width, height)
+
+                        // Flight category dot with transparency
+                        var dotColor = met.flightCategoryColor === "transparent" ? "gray" : met.flightCategoryColor
+                        ctx.beginPath()
+                        ctx.arc(14, 14, 12, 0, 2*Math.PI)
+                        ctx.globalAlpha = 0.55
+                        ctx.fillStyle = dotColor
+                        ctx.fill()
+                        ctx.globalAlpha = 1.0
+                        ctx.strokeStyle = "white"
+                        ctx.lineWidth = 2
+                        ctx.stroke()
+
+                        // Wind barb
+                        if (!met.windSpeed.isFinite() || !met.windDirection.isFinite()) return
+                        var spd = met.windSpeed.toKN()
+                        if (spd < 1) return
+
+                        var dirRad = met.windDirection.toRAD() + Math.PI // barb points into wind
+                        var cx = 14, cy = 14
+                        var len = 32
+                        var ex = cx + len * Math.sin(dirRad)
+                        var ey = cy - len * Math.cos(dirRad)
+
+                        // Staff
+                        ctx.beginPath()
+                        ctx.moveTo(cx, cy)
+                        ctx.lineTo(ex, ey)
+                        ctx.strokeStyle = "black"
+                        ctx.lineWidth = 2
+                        ctx.stroke()
+
+                        // Barbs: each full barb = 10 kt, half barb = 5 kt, pennant = 50 kt
+                        var remaining = Math.round(spd)
+                        var perpX = Math.cos(dirRad)
+                        var perpY = Math.sin(dirRad)
+                        var bx = ex, by = ey
+                        var stepX = -Math.sin(dirRad) * 6
+                        var stepY =  Math.cos(dirRad) * 6
+                        var barbLen = 13
+
+                        // Pennants (50 kt)
+                        while (remaining >= 50) {
+                            ctx.beginPath()
+                            ctx.moveTo(bx, by)
+                            ctx.lineTo(bx + stepX*2 + perpX*barbLen, by + stepY*2 + perpY*barbLen)
+                            ctx.lineTo(bx + stepX*2, by + stepY*2)
+                            ctx.closePath()
+                            ctx.fillStyle = "black"
+                            ctx.fill()
+                            bx += stepX*2; by += stepY*2
+                            remaining -= 50
+                        }
+                        // Full barbs (10 kt)
+                        while (remaining >= 10) {
+                            ctx.beginPath()
+                            ctx.moveTo(bx, by)
+                            ctx.lineTo(bx + perpX*barbLen, by + perpY*barbLen)
+                            ctx.strokeStyle = "black"
+                            ctx.lineWidth = 2
+                            ctx.stroke()
+                            bx += stepX; by += stepY
+                            remaining -= 10
+                        }
+                        // Half barb (5 kt)
+                        if (remaining >= 5) {
+                            ctx.beginPath()
+                            ctx.moveTo(bx, by)
+                            ctx.lineTo(bx + perpX*barbLen*0.5, by + perpY*barbLen*0.5)
+                            ctx.stroke()
+                        }
+                    }
+
+                    Connections {
+                        target: metarItem.obs
+                        function onMetarChanged() { metarCanvas.requestPaint() }
+                    }
+
+                    Component.onCompleted: requestPaint()
+                }
+            }
+        }
     }
 
 } // End of FlightMap

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -682,10 +682,6 @@ Map {
                 "raster-resampling": 'linear'
             }
 
-            paint: ({
-                "raster-opacity":         flightMap.showWindLayer ? 0.35 : 1.0,
-                "raster-brightness-max":  flightMap.showWindLayer ? 0.7  : 1.0
-            })
         }
 
         LayerParameter {
@@ -774,6 +770,15 @@ Map {
         }
     }
 
+
+    // Dim the base map when the wind layer is active so barbs stand out
+    Rectangle {
+        anchors.fill: parent
+        color: "white"
+        opacity: flightMap.showWindLayer ? 0.55 : 0.0
+        z: 0
+        Behavior on opacity { NumberAnimation { duration: 300 } }
+    }
 
     //
     // Additional Map Items

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -701,7 +701,7 @@ Map {
             styleId: "ofmDimmer"
             type: "background"
             layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
-            paint: { "background-color": "white", "background-opacity": 0.55 }
+            paint: { "background-color": "white", "background-opacity": 0.68 }
         }
 
         LayerParameter {

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -49,8 +49,9 @@ Map {
     /*! \brief Show Météo-France cloud base forecast layer */
     property bool showCloudbaseLayer: false
 
-    /*! \brief Show wind forecast layer (client-drawn vector barbs) */
-    property bool showWindLayer: false
+    /*! \brief Show wind forecast layer (client-drawn vector barbs).
+        Bound to the global setting so the map and side view share one toggle. */
+    property bool showWindLayer: GlobalSettings.showWindLayer
 
     /*! \brief Altitude (ft) at which the wind-barb layer samples the wind field */
     property real windAltitudeFt: 3000

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -1131,9 +1131,10 @@ Map {
                 return Math.abs(rl - Math.round(rl)) < 0.05 && Math.abs(ro - Math.round(ro)) < 0.05
             }
 
-            // Only interpolate for points actually shown at this zoom level
+            // Native grid value at the nearest forecast step (no interpolation);
+            // only computed for points actually shown at this zoom level.
             property var wind: showHere
-                ? WindFieldProvider.windAt(modelData.lat, modelData.lon, flightMap.windAltitudeFt, flightMap.windForecastTime)
+                ? WindFieldProvider.windAtStep(modelData.lat, modelData.lon, flightMap.windAltitudeFt, flightMap.windForecastTime)
                 : null
             onWindChanged: windCanvas.requestPaint()
 

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -43,6 +43,15 @@ Map {
     /*! \brief Show METAR weather layer (flight category dots + wind barbs) */
     property bool showWeatherLayer: false
 
+    /*! \brief Show Météo-France rain forecast layer */
+    property bool showRainLayer: false
+
+    /*! \brief Show Météo-France cloud base forecast layer */
+    property bool showCloudbaseLayer: false
+
+    /*! \brief Show Météo-France wind forecast layer */
+    property bool showWindLayer: false
+
     /* Handle changes in zoom level */
     onZoomLevelChanged: {
         var vec1 = flightMap.fromCoordinate(flightMap.center, false)
@@ -108,6 +117,31 @@ Map {
                 // return [ [7, 48], [8, 48], [8, 47], [7, 47] ]
             }
 
+        }
+
+        // Météo-France forecast image sources (fixed bounding box: 10W–15E, 38N–55N)
+        SourceParameter {
+            id: forecastRainSource
+            styleId: "forecastRain"
+            type: "image"
+            property string url: ForecastMapProvider.currentRainMap !== "" ? "file://" + ForecastMapProvider.currentRainMap : "qrc:/icons/appIcon.png"
+            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
+        }
+
+        SourceParameter {
+            id: forecastCloudbaseSource
+            styleId: "forecastCloudbase"
+            type: "image"
+            property string url: ForecastMapProvider.currentCloudbaseMap !== "" ? "file://" + ForecastMapProvider.currentCloudbaseMap : "qrc:/icons/appIcon.png"
+            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
+        }
+
+        SourceParameter {
+            id: forecastWindSource
+            styleId: "forecastWind"
+            type: "image"
+            property string url: ForecastMapProvider.currentWindMap !== "" ? "file://" + ForecastMapProvider.currentWindMap : "qrc:/icons/appIcon.png"
+            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
         }
 
         SourceParameter {
@@ -662,6 +696,30 @@ Map {
         }
 
         LayerParameter {
+            id: forecastRainLayer
+            styleId: "forecastRainLayer"
+            type: "raster"
+            property string source: "forecastRain"
+            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastCloudbaseLayer
+            styleId: "forecastCloudbaseLayer"
+            type: "raster"
+            property string source: "forecastCloudbase"
+            layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastWindLayer
+            styleId: "forecastWindLayer"
+            type: "raster"
+            property string source: "forecastWind"
+            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
             id: waypointLibParam
 
             styleId: "waypoint-layer"
@@ -952,16 +1010,17 @@ Map {
 
                 property var obs: modelData
                 property var met: obs.metar
+                onMetChanged: metarCanvas.requestPaint()
 
-                anchorPoint.x: 14
-                anchorPoint.y: 14
+                anchorPoint.x: 40
+                anchorPoint.y: 40
                 coordinate: met.coordinate
                 visible: met.isValid
 
                 sourceItem: Canvas {
                     id: metarCanvas
-                    width: 70
-                    height: 70
+                    width: 80
+                    height: 80
 
                     onPaint: {
                         var ctx = getContext("2d")
@@ -970,7 +1029,7 @@ Map {
                         // Flight category dot with transparency
                         var dotColor = met.flightCategoryColor === "transparent" ? "gray" : met.flightCategoryColor
                         ctx.beginPath()
-                        ctx.arc(14, 14, 12, 0, 2*Math.PI)
+                        ctx.arc(40, 40, 12, 0, 2*Math.PI)
                         ctx.globalAlpha = 0.55
                         ctx.fillStyle = dotColor
                         ctx.fill()
@@ -984,8 +1043,8 @@ Map {
                         var spd = met.windSpeed.toKN()
                         if (spd < 1) return
 
-                        var dirRad = met.windDirection.toRAD() + Math.PI // barb points into wind
-                        var cx = 14, cy = 14
+                        var dirRad = met.windDirection.toRAD() // staff points toward wind source; barbs drawn at tip
+                        var cx = 40, cy = 40
                         var len = 32
                         var ex = cx + len * Math.sin(dirRad)
                         var ey = cy - len * Math.cos(dirRad)
@@ -1037,11 +1096,6 @@ Map {
                             ctx.lineTo(bx + perpX*barbLen*0.5, by + perpY*barbLen*0.5)
                             ctx.stroke()
                         }
-                    }
-
-                    Connections {
-                        target: metarItem.obs
-                        function onMetarChanged() { metarCanvas.requestPaint() }
                     }
 
                     Component.onCompleted: requestPaint()

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -49,8 +49,11 @@ Map {
     /*! \brief Show Météo-France cloud base forecast layer */
     property bool showCloudbaseLayer: false
 
-    /*! \brief Show Météo-France wind forecast layer */
+    /*! \brief Show wind forecast layer (client-drawn vector barbs) */
     property bool showWindLayer: false
+
+    /*! \brief Altitude (ft) at which the wind-barb layer samples the wind field */
+    property real windAltitudeFt: 3000
 
     /* Handle changes in zoom level */
     onZoomLevelChanged: {
@@ -133,14 +136,6 @@ Map {
             styleId: "forecastCloudbase"
             type: "image"
             property string url: ForecastMapProvider.currentCloudbaseMap !== "" ? "file://" + ForecastMapProvider.currentCloudbaseMap : "qrc:/icons/appIcon.png"
-            property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
-        }
-
-        SourceParameter {
-            id: forecastWindSource
-            styleId: "forecastWind"
-            type: "image"
-            property string url: ForecastMapProvider.currentWindMap !== "" ? "file://" + ForecastMapProvider.currentWindMap : "qrc:/icons/appIcon.png"
             property var coordinates: [[-10, 55], [15, 55], [15, 38], [-10, 38]]
         }
 
@@ -771,13 +766,6 @@ Map {
             layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
         }
 
-        LayerParameter {
-            id: forecastWindLayer
-            styleId: "forecastWindLayer"
-            type: "raster"
-            property string source: "forecastWind"
-            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
-        }
     }
 
 
@@ -1111,6 +1099,112 @@ Map {
 
                     Component.onCompleted: requestPaint()
                 }
+            }
+        }
+    }
+
+    MapItemView { // Wind field barbs (client-drawn vector layer)
+        id: windBarbLayer
+        visible: flightMap.showWindLayer
+        model: flightMap.showWindLayer ? WindFieldProvider.gridPoints : []
+        delegate: MapQuickItem {
+            id: windItem
+
+            required property var modelData
+
+            // Grid is ~0.5°; show a coarser subset as we zoom out to avoid clutter
+            readonly property real thinStep: flightMap.zoomLevel >= 8.5 ? 0.5
+                                           : flightMap.zoomLevel >= 6.5 ? 1.0 : 2.0
+            readonly property bool showHere: {
+                var rl = modelData.lat / thinStep
+                var ro = modelData.lon / thinStep
+                return Math.abs(rl - Math.round(rl)) < 0.05 && Math.abs(ro - Math.round(ro)) < 0.05
+            }
+
+            property var wind: WindFieldProvider.windAt(modelData.lat, modelData.lon, flightMap.windAltitudeFt)
+            onWindChanged: windCanvas.requestPaint()
+
+            coordinate: QtPositioning.coordinate(modelData.lat, modelData.lon)
+            anchorPoint.x: 30
+            anchorPoint.y: 30
+            visible: showHere && wind.speed.isFinite() && wind.directionFrom.isFinite()
+
+            sourceItem: Canvas {
+                id: windCanvas
+                width: 60
+                height: 60
+
+                onPaint: {
+                    var ctx = getContext("2d")
+                    ctx.clearRect(0, 0, width, height)
+
+                    if (!windItem.wind.speed.isFinite() || !windItem.wind.directionFrom.isFinite())
+                        return
+                    var spd = windItem.wind.speed.toKN()
+
+                    var cx = 30, cy = 30
+                    // Calm: small circle
+                    if (spd < 2.5) {
+                        ctx.beginPath()
+                        ctx.arc(cx, cy, 3, 0, 2*Math.PI)
+                        ctx.strokeStyle = "#1a3a8a"
+                        ctx.lineWidth = 1.5
+                        ctx.stroke()
+                        return
+                    }
+
+                    var dirRad = windItem.wind.directionFrom.toRAD() // staff toward wind source
+                    var len = 22
+                    var ex = cx + len * Math.sin(dirRad)
+                    var ey = cy - len * Math.cos(dirRad)
+
+                    ctx.strokeStyle = "#1a3a8a"
+                    ctx.fillStyle = "#1a3a8a"
+                    ctx.lineWidth = 1.5
+
+                    // Staff
+                    ctx.beginPath()
+                    ctx.moveTo(cx, cy)
+                    ctx.lineTo(ex, ey)
+                    ctx.stroke()
+
+                    // Barbs from the tip, back toward the staff origin
+                    var remaining = Math.round(spd / 5) * 5
+                    var perpX = Math.cos(dirRad)
+                    var perpY = Math.sin(dirRad)
+                    var stepX = -Math.sin(dirRad) * 5
+                    var stepY =  Math.cos(dirRad) * 5
+                    var barbLen = 11
+                    var bx = ex, by = ey
+
+                    while (remaining >= 50) {
+                        ctx.beginPath()
+                        ctx.moveTo(bx, by)
+                        ctx.lineTo(bx + stepX*2 + perpX*barbLen, by + stepY*2 + perpY*barbLen)
+                        ctx.lineTo(bx + stepX*2, by + stepY*2)
+                        ctx.closePath()
+                        ctx.fill()
+                        bx += stepX*2; by += stepY*2
+                        remaining -= 50
+                    }
+                    while (remaining >= 10) {
+                        ctx.beginPath()
+                        ctx.moveTo(bx, by)
+                        ctx.lineTo(bx + perpX*barbLen, by + perpY*barbLen)
+                        ctx.stroke()
+                        bx += stepX; by += stepY
+                        remaining -= 10
+                    }
+                    if (remaining >= 5) {
+                        // Half barb sits one notch in from the tip if it's the only feather
+                        if (Math.round(spd) < 10) { bx += stepX; by += stepY }
+                        ctx.beginPath()
+                        ctx.moveTo(bx, by)
+                        ctx.lineTo(bx + perpX*barbLen*0.5, by + perpY*barbLen*0.5)
+                        ctx.stroke()
+                    }
+                }
+                Component.onCompleted: requestPaint()
             }
         }
     }

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -796,7 +796,7 @@ Map {
     MapPolyline {
         id: flightPath
         line.width: 4
-        line.color: "#ff00ff"
+        line.color: Global.flightRouteColor
         path: {
             var array = []
             //Looks weird, but is necessary. geoPath is an 'object' not an array

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -705,6 +705,7 @@ Map {
             property string source: "waypointlib"
 
             layout: {
+                "visibility": flightMap.showWindLayer ? 'none' : 'visible',
                 "icon-image": '["get", "CAT"]',
                 "text-field": '["get", "NAM"]',
                 "text-size": 0.85*GlobalSettings.fontSize,
@@ -729,6 +730,7 @@ Map {
             property string source: "notams"
 
             layout: {
+                "visibility": flightMap.showWindLayer ? 'none' : 'visible',
                 "icon-ignore-placement": true,
                 "icon-image": ["get", "CAT"],
                 "text-field": ["get", "NAM"],
@@ -745,7 +747,7 @@ Map {
             }
         }
 
-        // White veil between OFM/NOTAMs and forecast layers — dims everything below when wind is active
+        // White veil between OFM tiles and forecast layers — dims the chart when wind is active
         LayerParameter {
             styleId: "ofmDimmer"
             type: "background"

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -729,6 +729,13 @@ Map {
         }
 
         LayerParameter {
+            styleId: "notamDimmer"
+            type: "background"
+            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
+            paint: { "background-color": "white", "background-opacity": 0.45 }
+        }
+
+        LayerParameter {
             id: waypointLibParam
 
             styleId: "waypoint-layer"

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -696,6 +696,14 @@ Map {
             }
         }
 
+        // White veil between OFM tiles and forecast layers — dims the chart without touching overlays
+        LayerParameter {
+            styleId: "ofmDimmer"
+            type: "background"
+            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
+            paint: { "background-color": "white", "background-opacity": 0.55 }
+        }
+
         LayerParameter {
             id: forecastRainLayer
             styleId: "forecastRainLayer"
@@ -770,15 +778,6 @@ Map {
         }
     }
 
-
-    // Dim the base map when the wind layer is active so barbs stand out
-    Rectangle {
-        anchors.fill: parent
-        color: "white"
-        opacity: flightMap.showWindLayer ? 0.55 : 0.0
-        z: 0
-        Behavior on opacity { NumberAnimation { duration: 300 } }
-    }
 
     //
     // Additional Map Items

--- a/src/qml/items/FlightMap.qml
+++ b/src/qml/items/FlightMap.qml
@@ -696,45 +696,6 @@ Map {
             }
         }
 
-        // White veil between OFM tiles and forecast layers — dims the chart without touching overlays
-        LayerParameter {
-            styleId: "ofmDimmer"
-            type: "background"
-            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
-            paint: { "background-color": "white", "background-opacity": 0.68 }
-        }
-
-        LayerParameter {
-            id: forecastRainLayer
-            styleId: "forecastRainLayer"
-            type: "raster"
-            property string source: "forecastRain"
-            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
-            id: forecastCloudbaseLayer
-            styleId: "forecastCloudbaseLayer"
-            type: "raster"
-            property string source: "forecastCloudbase"
-            layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
-            id: forecastWindLayer
-            styleId: "forecastWindLayer"
-            type: "raster"
-            property string source: "forecastWind"
-            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
-        }
-
-        LayerParameter {
-            styleId: "notamDimmer"
-            type: "background"
-            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
-            paint: { "background-color": "white", "background-opacity": 0.45 }
-        }
-
         LayerParameter {
             id: waypointLibParam
 
@@ -782,6 +743,38 @@ Map {
                 "text-halo-width": 2,
                 "text-halo-color": "white"
             }
+        }
+
+        // White veil between OFM/NOTAMs and forecast layers — dims everything below when wind is active
+        LayerParameter {
+            styleId: "ofmDimmer"
+            type: "background"
+            layout: { "visibility": flightMap.showWindLayer ? 'visible' : 'none' }
+            paint: { "background-color": "white", "background-opacity": 0.68 }
+        }
+
+        LayerParameter {
+            id: forecastRainLayer
+            styleId: "forecastRainLayer"
+            type: "raster"
+            property string source: "forecastRain"
+            layout: { "visibility": flightMap.showRainLayer && ForecastMapProvider.currentRainMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastCloudbaseLayer
+            styleId: "forecastCloudbaseLayer"
+            type: "raster"
+            property string source: "forecastCloudbase"
+            layout: { "visibility": flightMap.showCloudbaseLayer && ForecastMapProvider.currentCloudbaseMap !== "" ? 'visible' : 'none' }
+        }
+
+        LayerParameter {
+            id: forecastWindLayer
+            styleId: "forecastWindLayer"
+            type: "raster"
+            property string source: "forecastWind"
+            layout: { "visibility": flightMap.showWindLayer && ForecastMapProvider.currentWindMap !== "" ? 'visible' : 'none' }
         }
     }
 

--- a/src/qml/items/Global.qml
+++ b/src/qml/items/Global.qml
@@ -35,6 +35,10 @@ Item {
     property vac currentVAC
     property vac defaultVAC
 
+    // Color used to draw the planned flight route, both on the moving map and
+    // in the sideview planned-altitude profile.
+    readonly property color flightRouteColor: "#ff00ff"
+
     //
     // GUI Warnings
     //

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -683,8 +683,8 @@ Item {
                                 CheckDelegate {
                                     text: qsTr("Wind") + "  [kt]"
                                     enabled: WindFieldProvider.hasData
-                                    checked: flightMap.showWindLayer
-                                    onClicked: flightMap.showWindLayer = checked
+                                    checked: GlobalSettings.showWindLayer
+                                    onClicked: GlobalSettings.showWindLayer = checked
                                 }
 
                                 ItemDelegate {

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -689,13 +689,14 @@ Item {
                                 }
 
                                 CheckDelegate {
-                                    text: qsTr("Wind forecast") + (ForecastMapProvider.windUnits ? "  [" + ForecastMapProvider.windUnits + "]" : "")
+                                    text: qsTr("Wind") + "  [kt]"
+                                    enabled: WindFieldProvider.hasData
                                     checked: flightMap.showWindLayer
                                     onClicked: flightMap.showWindLayer = checked
                                 }
 
                                 ItemDelegate {
-                                    visible: flightMap.showWindLayer && ForecastMapProvider.windPressureLevels.length > 1
+                                    visible: flightMap.showWindLayer && WindFieldProvider.levelsFt.length > 1
                                     implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: Column {
@@ -703,8 +704,8 @@ Item {
                                         spacing: 2
                                         Label {
                                             width: parent.width
-                                            text: weatherLayerButton.hpaToFL(ForecastMapProvider.currentWindPressureLevel)
-                                                  + "  (" + ForecastMapProvider.currentWindPressureLevel + " hPa)"
+                                            text: "FL" + ("00" + Math.round(flightMap.windAltitudeFt/100)).slice(-3)
+                                                  + "  (" + Math.round(flightMap.windAltitudeFt) + " ft)"
                                             font.pixelSize: 9
                                             horizontalAlignment: Text.AlignHCenter
                                             opacity: 0.7
@@ -712,24 +713,24 @@ Item {
                                         Slider {
                                             width: parent.width
                                             from: 0
-                                            to: Math.max(0, ForecastMapProvider.windPressureLevels.length - 1)
+                                            to: Math.max(0, WindFieldProvider.levelsFt.length - 1)
                                             stepSize: 1
-                                            value: ForecastMapProvider.windPressureLevels.indexOf(ForecastMapProvider.currentWindPressureLevel)
-                                            onMoved: ForecastMapProvider.currentWindPressureLevel =
-                                                ForecastMapProvider.windPressureLevels[Math.round(value)]
+                                            value: WindFieldProvider.levelsFt.indexOf(flightMap.windAltitudeFt)
+                                            onMoved: flightMap.windAltitudeFt =
+                                                WindFieldProvider.levelsFt[Math.round(value)]
                                         }
                                         Row {
                                             width: parent.width
                                             Repeater {
-                                                model: ForecastMapProvider.windPressureLevels
+                                                model: WindFieldProvider.levelsFt
                                                 Label {
-                                                    width: parent.width / ForecastMapProvider.windPressureLevels.length
-                                                    text: weatherLayerButton.hpaToFL(modelData)
+                                                    width: parent.width / WindFieldProvider.levelsFt.length
+                                                    text: "FL" + ("00" + Math.round(modelData/100)).slice(-3)
                                                     font.pixelSize: 9
                                                     horizontalAlignment: index === 0 ? Text.AlignLeft
-                                                        : index === ForecastMapProvider.windPressureLevels.length - 1 ? Text.AlignRight
+                                                        : index === WindFieldProvider.levelsFt.length - 1 ? Text.AlignRight
                                                         : Text.AlignHCenter
-                                                    opacity: ForecastMapProvider.currentWindPressureLevel === modelData ? 1.0 : 0.5
+                                                    opacity: flightMap.windAltitudeFt === modelData ? 1.0 : 0.5
                                                 }
                                             }
                                         }

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -783,7 +783,7 @@ Item {
                                         ToolButton {
                                             icon.source: "/icons/material/ic_refresh.svg"
                                             enabled: ForecastMapProvider.status !== 1  // not Refreshing
-                                            onClicked: ForecastMapProvider.refresh()
+                                            onClicked: { ForecastMapProvider.refresh(); WindFieldProvider.refresh() }
                                         }
                                         Label {
                                             anchors.verticalCenter: parent.verticalCenter

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -612,6 +612,22 @@ Item {
                         }
 
                         MapButton {
+                            id: weatherLayerButton
+
+                            checkable: true
+                            checked: flightMap.showWeatherLayer
+                            icon.source: "/icons/material/ic_cloud_queue.svg"
+
+                            onClicked: {
+                                PlatformAdaptor.vibrateBrief()
+                                flightMap.showWeatherLayer = !flightMap.showWeatherLayer
+                                if (flightMap.showWeatherLayer) {
+                                    WeatherDataProvider.requestUpdate()
+                                }
+                            }
+                        }
+
+                        MapButton {
                             id: rasterMapButton
 
                             icon.source: "/icons/material/ic_layers.svg"

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -623,14 +623,6 @@ Item {
                                 weatherMenu.popup()
                             }
 
-                            // Cheated but pilot-friendly FL labels for the 4 AROME pressure levels
-                            function hpaToFL(hpa) {
-                                var lookup = { "1000": "FL000", "900": "FL033", "800": "FL065", "700": "FL100" }
-                                return lookup[String(Math.round(parseFloat(hpa)))] ?? ("FL" + Math.round(
-                                    (1 - Math.pow(parseFloat(hpa)/1013.25, 0.190284)) * 145366.45 / 100
-                                ).toString().padStart(3,"0"))
-                            }
-
                             // Convert cloudbase metres to the aircraft's configured altitude unit
                             function cbLabel(metres) {
                                 if (Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters)

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -760,10 +760,16 @@ Item {
                                         }
                                         Label {
                                             visible: ForecastMapProvider.referenceTimeLabel !== ""
-                                            text: qsTr("Model run: ") + ForecastMapProvider.referenceTimeLabel
+                                            text: "AROME " + ForecastMapProvider.referenceTimeLabel
                                             anchors.horizontalCenter: parent.horizontalCenter
                                             font.pixelSize: parent.font ? parent.font.pixelSize * 0.85 : 11
                                             opacity: 0.7
+                                        }
+                                        Label {
+                                            text: "© Météo-France"
+                                            anchors.horizontalCenter: parent.horizontalCenter
+                                            font.pixelSize: parent.font ? parent.font.pixelSize * 0.8 : 10
+                                            opacity: 0.5
                                         }
                                     }
                                 }

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -623,9 +623,19 @@ Item {
                                 weatherMenu.popup()
                             }
 
+                            // Cheated but pilot-friendly FL labels for the 4 AROME pressure levels
                             function hpaToFL(hpa) {
-                                var ft = (1 - Math.pow(parseFloat(hpa) / 1013.25, 0.190284)) * 145366.45
-                                return "FL" + Math.round(ft / 100).toString().padStart(3, "0")
+                                var lookup = { "1000": "FL000", "900": "FL033", "800": "FL065", "700": "FL100" }
+                                return lookup[String(Math.round(parseFloat(hpa)))] ?? ("FL" + Math.round(
+                                    (1 - Math.pow(parseFloat(hpa)/1013.25, 0.190284)) * 145366.45 / 100
+                                ).toString().padStart(3,"0"))
+                            }
+
+                            // Convert cloudbase metres to the aircraft's configured altitude unit
+                            function cbLabel(metres) {
+                                if (Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters)
+                                    return metres.toFixed(0) + " m"
+                                return Math.round(metres * 3.28084) + " ft"
                             }
 
                             AutoSizingMenu {
@@ -674,7 +684,7 @@ Item {
                                         colors: ForecastMapProvider.cloudbaseColors
                                         vmin: ForecastMapProvider.cloudbaseVmin
                                         vmax: ForecastMapProvider.cloudbaseVmax
-                                        units: ForecastMapProvider.cloudbaseUnits
+                                        labelFunc: function(v) { return weatherLayerButton.cbLabel(v) }
                                     }
                                 }
 

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -623,6 +623,11 @@ Item {
                                 weatherMenu.popup()
                             }
 
+                            function hpaToFL(hpa) {
+                                var ft = (1 - Math.pow(parseFloat(hpa) / 1013.25, 0.190284)) * 145366.45
+                                return "FL" + Math.round(ft / 100).toString().padStart(3, "0")
+                            }
+
                             AutoSizingMenu {
                                 id: weatherMenu
 
@@ -642,7 +647,7 @@ Item {
                                 }
 
                                 ItemDelegate {
-                                    visible: flightMap.showRainLayer && ForecastMapProvider.rainColors.length >= 4
+                                    visible: flightMap.showRainLayer
                                     implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
@@ -661,7 +666,7 @@ Item {
                                 }
 
                                 ItemDelegate {
-                                    visible: flightMap.showCloudbaseLayer && ForecastMapProvider.cloudbaseColors.length >= 4
+                                    visible: flightMap.showCloudbaseLayer
                                     implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
@@ -688,7 +693,8 @@ Item {
                                         spacing: 2
                                         Label {
                                             width: parent.width
-                                            text: ForecastMapProvider.currentWindPressureLevel + " hPa"
+                                            text: weatherLayerButton.hpaToFL(ForecastMapProvider.currentWindPressureLevel)
+                                                  + "  (" + ForecastMapProvider.currentWindPressureLevel + " hPa)"
                                             font.pixelSize: 9
                                             horizontalAlignment: Text.AlignHCenter
                                             opacity: 0.7
@@ -708,7 +714,7 @@ Item {
                                                 model: ForecastMapProvider.windPressureLevels
                                                 Label {
                                                     width: parent.width / ForecastMapProvider.windPressureLevels.length
-                                                    text: modelData + " hPa"
+                                                    text: weatherLayerButton.hpaToFL(modelData)
                                                     font.pixelSize: 9
                                                     horizontalAlignment: index === 0 ? Text.AlignLeft
                                                         : index === ForecastMapProvider.windPressureLevels.length - 1 ? Text.AlignRight

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -643,9 +643,10 @@ Item {
 
                                 ItemDelegate {
                                     visible: flightMap.showRainLayer && ForecastMapProvider.rainColors.length >= 4
-                                    width: parent ? parent.width : 300
+                                    implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
+                                        width: parent.width
                                         colors: ForecastMapProvider.rainColors
                                         vmin: ForecastMapProvider.rainVmin
                                         vmax: ForecastMapProvider.rainVmax
@@ -661,9 +662,10 @@ Item {
 
                                 ItemDelegate {
                                     visible: flightMap.showCloudbaseLayer && ForecastMapProvider.cloudbaseColors.length >= 4
-                                    width: parent ? parent.width : 300
+                                    implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: ColorScaleLegend {
+                                        width: parent.width
                                         colors: ForecastMapProvider.cloudbaseColors
                                         vmin: ForecastMapProvider.cloudbaseVmin
                                         vmax: ForecastMapProvider.cloudbaseVmax
@@ -679,9 +681,10 @@ Item {
 
                                 ItemDelegate {
                                     visible: flightMap.showWindLayer && ForecastMapProvider.windPressureLevels.length > 1
-                                    width: parent ? parent.width : 300
+                                    implicitWidth: 280
                                     topPadding: 0; bottomPadding: 6
                                     contentItem: Column {
+                                        width: parent.width
                                         spacing: 2
                                         Label {
                                             width: parent.width

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -636,54 +636,38 @@ Item {
                                 }
 
                                 CheckDelegate {
-                                    text: qsTr("Rain forecast") + (ForecastMapProvider.rainUnits ? "  [" + ForecastMapProvider.rainUnits + "]" : "")
+                                    text: qsTr("Rain forecast")
                                     checked: flightMap.showRainLayer
                                     onClicked: flightMap.showRainLayer = checked
-                                    contentItem: Row {
-                                        spacing: 8
-                                        Label {
-                                            text: parent.parent.text
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            elide: Text.ElideRight
-                                        }
-                                        Rectangle {
-                                            visible: ForecastMapProvider.rainColors.length > 1
-                                            width: 60; height: 8
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            gradient: Gradient {
-                                                orientation: Gradient.Horizontal
-                                                GradientStop { position: 0.0; color: ForecastMapProvider.rainColors[0] || "transparent" }
-                                                GradientStop { position: 0.33; color: ForecastMapProvider.rainColors[1] || "transparent" }
-                                                GradientStop { position: 0.66; color: ForecastMapProvider.rainColors[2] || "transparent" }
-                                                GradientStop { position: 1.0; color: ForecastMapProvider.rainColors[3] || "transparent" }
-                                            }
-                                        }
+                                }
+
+                                ItemDelegate {
+                                    visible: flightMap.showRainLayer && ForecastMapProvider.rainColors.length >= 4
+                                    width: parent ? parent.width : 300
+                                    topPadding: 0; bottomPadding: 6
+                                    contentItem: ColorScaleLegend {
+                                        colors: ForecastMapProvider.rainColors
+                                        vmin: ForecastMapProvider.rainVmin
+                                        vmax: ForecastMapProvider.rainVmax
+                                        units: ForecastMapProvider.rainUnits
                                     }
                                 }
 
                                 CheckDelegate {
-                                    text: qsTr("Cloud base forecast") + (ForecastMapProvider.cloudbaseUnits ? "  [" + ForecastMapProvider.cloudbaseUnits + "]" : "")
+                                    text: qsTr("Cloud base forecast")
                                     checked: flightMap.showCloudbaseLayer
                                     onClicked: flightMap.showCloudbaseLayer = checked
-                                    contentItem: Row {
-                                        spacing: 8
-                                        Label {
-                                            text: parent.parent.text
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            elide: Text.ElideRight
-                                        }
-                                        Rectangle {
-                                            visible: ForecastMapProvider.cloudbaseColors.length > 1
-                                            width: 60; height: 8
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            gradient: Gradient {
-                                                orientation: Gradient.Horizontal
-                                                GradientStop { position: 0.0; color: ForecastMapProvider.cloudbaseColors[0] || "transparent" }
-                                                GradientStop { position: 0.33; color: ForecastMapProvider.cloudbaseColors[1] || "transparent" }
-                                                GradientStop { position: 0.66; color: ForecastMapProvider.cloudbaseColors[2] || "transparent" }
-                                                GradientStop { position: 1.0; color: ForecastMapProvider.cloudbaseColors[3] || "transparent" }
-                                            }
-                                        }
+                                }
+
+                                ItemDelegate {
+                                    visible: flightMap.showCloudbaseLayer && ForecastMapProvider.cloudbaseColors.length >= 4
+                                    width: parent ? parent.width : 300
+                                    topPadding: 0; bottomPadding: 6
+                                    contentItem: ColorScaleLegend {
+                                        colors: ForecastMapProvider.cloudbaseColors
+                                        vmin: ForecastMapProvider.cloudbaseVmin
+                                        vmax: ForecastMapProvider.cloudbaseVmax
+                                        units: ForecastMapProvider.cloudbaseUnits
                                     }
                                 }
 

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -677,18 +677,44 @@ Item {
                                     onClicked: flightMap.showWindLayer = checked
                                 }
 
-                                MenuSeparator { visible: flightMap.showWindLayer }
-
-                                Instantiator {
-                                    model: ForecastMapProvider.windPressureLevels
-                                    delegate: RadioDelegate {
-                                        visible: flightMap.showWindLayer
-                                        text: modelData + " hPa"
-                                        checked: ForecastMapProvider.currentWindPressureLevel === modelData
-                                        onClicked: ForecastMapProvider.currentWindPressureLevel = modelData
+                                ItemDelegate {
+                                    visible: flightMap.showWindLayer && ForecastMapProvider.windPressureLevels.length > 1
+                                    width: parent ? parent.width : 300
+                                    topPadding: 0; bottomPadding: 6
+                                    contentItem: Column {
+                                        spacing: 2
+                                        Label {
+                                            width: parent.width
+                                            text: ForecastMapProvider.currentWindPressureLevel + " hPa"
+                                            font.pixelSize: 9
+                                            horizontalAlignment: Text.AlignHCenter
+                                            opacity: 0.7
+                                        }
+                                        Slider {
+                                            width: parent.width
+                                            from: 0
+                                            to: Math.max(0, ForecastMapProvider.windPressureLevels.length - 1)
+                                            stepSize: 1
+                                            value: ForecastMapProvider.windPressureLevels.indexOf(ForecastMapProvider.currentWindPressureLevel)
+                                            onMoved: ForecastMapProvider.currentWindPressureLevel =
+                                                ForecastMapProvider.windPressureLevels[Math.round(value)]
+                                        }
+                                        Row {
+                                            width: parent.width
+                                            Repeater {
+                                                model: ForecastMapProvider.windPressureLevels
+                                                Label {
+                                                    width: parent.width / ForecastMapProvider.windPressureLevels.length
+                                                    text: modelData + " hPa"
+                                                    font.pixelSize: 9
+                                                    horizontalAlignment: index === 0 ? Text.AlignLeft
+                                                        : index === ForecastMapProvider.windPressureLevels.length - 1 ? Text.AlignRight
+                                                        : Text.AlignHCenter
+                                                    opacity: ForecastMapProvider.currentWindPressureLevel === modelData ? 1.0 : 0.5
+                                                }
+                                            }
+                                        }
                                     }
-                                    onObjectAdded: (index, object) => weatherMenu.insertItem(index + 5, object)
-                                    onObjectRemoved: (index, object) => weatherMenu.removeItem(object)
                                 }
 
                                 MenuSeparator {

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -38,6 +38,20 @@ Item {
 
     enum MapBearingPolicies { NUp=0, TTUp=1, UserDefinedBearingUp=2 }
 
+    // The weather time slider doubles as the trip-start time: the selected
+    // forecast step drives Navigator.departureTime, which the route tab and the
+    // side view integrate forward from.
+    function syncDepartureTime() {
+        var ts = ForecastMapProvider.timestamps
+        var i = ForecastMapProvider.currentIndex
+        if (ts && ts.length > 0 && i >= 0 && i < ts.length)
+            Navigator.departureTime = new Date(ts[i])
+    }
+    Connections {
+        target: ForecastMapProvider
+        function onCurrentIndexChanged() { page.syncDepartureTime() }
+        function onTimestampsChanged() { page.syncDepartureTime() }
+    }
 
     Connections {
         target: DemoRunner

--- a/src/qml/items/MFM.qml
+++ b/src/qml/items/MFM.qml
@@ -615,14 +615,147 @@ Item {
                             id: weatherLayerButton
 
                             checkable: true
-                            checked: flightMap.showWeatherLayer
+                            checked: flightMap.showWeatherLayer || flightMap.showRainLayer || flightMap.showCloudbaseLayer || flightMap.showWindLayer
                             icon.source: "/icons/material/ic_cloud_queue.svg"
 
                             onClicked: {
                                 PlatformAdaptor.vibrateBrief()
-                                flightMap.showWeatherLayer = !flightMap.showWeatherLayer
-                                if (flightMap.showWeatherLayer) {
-                                    WeatherDataProvider.requestUpdate()
+                                weatherMenu.popup()
+                            }
+
+                            AutoSizingMenu {
+                                id: weatherMenu
+
+                                CheckDelegate {
+                                    text: qsTr("METAR (flight category + wind)")
+                                    checked: flightMap.showWeatherLayer
+                                    onClicked: {
+                                        flightMap.showWeatherLayer = checked
+                                        if (checked) { WeatherDataProvider.requestUpdate() }
+                                    }
+                                }
+
+                                CheckDelegate {
+                                    text: qsTr("Rain forecast") + (ForecastMapProvider.rainUnits ? "  [" + ForecastMapProvider.rainUnits + "]" : "")
+                                    checked: flightMap.showRainLayer
+                                    onClicked: flightMap.showRainLayer = checked
+                                    contentItem: Row {
+                                        spacing: 8
+                                        Label {
+                                            text: parent.parent.text
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            elide: Text.ElideRight
+                                        }
+                                        Rectangle {
+                                            visible: ForecastMapProvider.rainColors.length > 1
+                                            width: 60; height: 8
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            gradient: Gradient {
+                                                orientation: Gradient.Horizontal
+                                                GradientStop { position: 0.0; color: ForecastMapProvider.rainColors[0] || "transparent" }
+                                                GradientStop { position: 0.33; color: ForecastMapProvider.rainColors[1] || "transparent" }
+                                                GradientStop { position: 0.66; color: ForecastMapProvider.rainColors[2] || "transparent" }
+                                                GradientStop { position: 1.0; color: ForecastMapProvider.rainColors[3] || "transparent" }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                CheckDelegate {
+                                    text: qsTr("Cloud base forecast") + (ForecastMapProvider.cloudbaseUnits ? "  [" + ForecastMapProvider.cloudbaseUnits + "]" : "")
+                                    checked: flightMap.showCloudbaseLayer
+                                    onClicked: flightMap.showCloudbaseLayer = checked
+                                    contentItem: Row {
+                                        spacing: 8
+                                        Label {
+                                            text: parent.parent.text
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            elide: Text.ElideRight
+                                        }
+                                        Rectangle {
+                                            visible: ForecastMapProvider.cloudbaseColors.length > 1
+                                            width: 60; height: 8
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            gradient: Gradient {
+                                                orientation: Gradient.Horizontal
+                                                GradientStop { position: 0.0; color: ForecastMapProvider.cloudbaseColors[0] || "transparent" }
+                                                GradientStop { position: 0.33; color: ForecastMapProvider.cloudbaseColors[1] || "transparent" }
+                                                GradientStop { position: 0.66; color: ForecastMapProvider.cloudbaseColors[2] || "transparent" }
+                                                GradientStop { position: 1.0; color: ForecastMapProvider.cloudbaseColors[3] || "transparent" }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                CheckDelegate {
+                                    text: qsTr("Wind forecast") + (ForecastMapProvider.windUnits ? "  [" + ForecastMapProvider.windUnits + "]" : "")
+                                    checked: flightMap.showWindLayer
+                                    onClicked: flightMap.showWindLayer = checked
+                                }
+
+                                MenuSeparator { visible: flightMap.showWindLayer }
+
+                                Instantiator {
+                                    model: ForecastMapProvider.windPressureLevels
+                                    delegate: RadioDelegate {
+                                        visible: flightMap.showWindLayer
+                                        text: modelData + " hPa"
+                                        checked: ForecastMapProvider.currentWindPressureLevel === modelData
+                                        onClicked: ForecastMapProvider.currentWindPressureLevel = modelData
+                                    }
+                                    onObjectAdded: (index, object) => weatherMenu.insertItem(index + 5, object)
+                                    onObjectRemoved: (index, object) => weatherMenu.removeItem(object)
+                                }
+
+                                MenuSeparator {
+                                    visible: flightMap.showRainLayer || flightMap.showCloudbaseLayer || flightMap.showWindLayer
+                                }
+
+                                ItemDelegate {
+                                    visible: flightMap.showRainLayer || flightMap.showCloudbaseLayer || flightMap.showWindLayer
+                                    width: parent ? parent.width : 300
+                                    contentItem: Column {
+                                        spacing: 4
+                                        Label {
+                                            text: ForecastMapProvider.currentTimestampLabel
+                                            anchors.horizontalCenter: parent.horizontalCenter
+                                            font.bold: true
+                                        }
+                                        Slider {
+                                            width: parent.width
+                                            from: 0
+                                            to: Math.max(0, ForecastMapProvider.timestamps.length - 1)
+                                            stepSize: 1
+                                            value: ForecastMapProvider.currentIndex
+                                            onMoved: ForecastMapProvider.currentIndex = Math.round(value)
+                                        }
+                                        Label {
+                                            visible: ForecastMapProvider.referenceTimeLabel !== ""
+                                            text: qsTr("Model run: ") + ForecastMapProvider.referenceTimeLabel
+                                            anchors.horizontalCenter: parent.horizontalCenter
+                                            font.pixelSize: parent.font ? parent.font.pixelSize * 0.85 : 11
+                                            opacity: 0.7
+                                        }
+                                    }
+                                }
+
+                                MenuSeparator {}
+
+                                ItemDelegate {
+                                    width: parent ? parent.width : 300
+                                    contentItem: Row {
+                                        spacing: 8
+                                        ToolButton {
+                                            icon.source: "/icons/material/ic_refresh.svg"
+                                            enabled: ForecastMapProvider.status !== 1  // not Refreshing
+                                            onClicked: ForecastMapProvider.refresh()
+                                        }
+                                        Label {
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            text: ForecastMapProvider.lastRefreshLabel
+                                            color: ForecastMapProvider.status === 2 ? "red" : palette.text  // Error
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -477,6 +477,85 @@ SideviewQuickItem {
             }
         }
 
+        // Wind projected onto the route profile: a horizontal barb per sample
+        // point at the planned altitude. Red = headwind, green = tailwind;
+        // feathers encode the along-track component magnitude.
+        Repeater {
+            model: rawSideView.mode === SideviewQuickItem.Route ? rawSideView.windProfile : 0
+
+            delegate: Canvas {
+                id: windBarb
+                required property var modelData
+
+                width: 60
+                height: 44
+                x: modelData.x - width/2
+                y: modelData.y - height - 6   // sit just above the profile point
+
+                onModelDataChanged: requestPaint()
+                Component.onCompleted: requestPaint()
+
+                onPaint: {
+                    var ctx = getContext("2d")
+                    ctx.clearRect(0, 0, width, height)
+
+                    var along = modelData.alongKn          // + headwind, − tailwind
+                    var mag = Math.abs(along)
+                    var cx = width/2, cy = height - 6
+                    var color = along >= 0 ? "#b00020" : "#2e7d32"
+                    ctx.strokeStyle = color
+                    ctx.fillStyle = color
+                    ctx.lineWidth = 1.5
+
+                    if (mag < 2.5) {
+                        ctx.beginPath()
+                        ctx.arc(cx, cy, 3, 0, 2*Math.PI)
+                        ctx.stroke()
+                        return
+                    }
+
+                    var dir = along >= 0 ? 1 : -1          // headwind staff points toward source (ahead = right)
+                    var L = 22, barbLen = 10, spacing = 5
+                    var ex = cx + dir*L, ey = cy
+
+                    // Staff
+                    ctx.beginPath()
+                    ctx.moveTo(cx, cy)
+                    ctx.lineTo(ex, ey)
+                    ctx.stroke()
+
+                    var remaining = Math.round(mag/5)*5
+                    var bx = ex, by = ey
+                    var stepX = -dir*spacing
+
+                    while (remaining >= 50) {
+                        ctx.beginPath()
+                        ctx.moveTo(bx, by)
+                        ctx.lineTo(bx + 2*stepX, by - barbLen)
+                        ctx.lineTo(bx + 2*stepX, by)
+                        ctx.closePath()
+                        ctx.fill()
+                        bx += 2*stepX
+                        remaining -= 50
+                    }
+                    while (remaining >= 10) {
+                        ctx.beginPath()
+                        ctx.moveTo(bx, by)
+                        ctx.lineTo(bx + stepX, by - barbLen)
+                        ctx.stroke()
+                        bx += stepX
+                        remaining -= 10
+                    }
+                    if (remaining >= 5) {
+                        ctx.beginPath()
+                        ctx.moveTo(bx, by)
+                        ctx.lineTo(bx + stepX*0.5, by - barbLen*0.5)
+                        ctx.stroke()
+                    }
+                }
+            }
+        }
+
         Image {
             id: ownShip
 

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -20,9 +20,11 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Shapes
 
 import akaflieg_freiburg.enroute
+import "../dialogs"
 
 SideviewQuickItem {
     id: rawSideView
@@ -427,6 +429,52 @@ SideviewQuickItem {
                     relativeY: 0.2*shp.animatedFiveMinuteBarY
                 }
             }
+
+            // Planned cruise-altitude profile (route mode only). Sloped segments
+            // connecting the planned altitude at each waypoint.
+            ShapePath {
+                strokeWidth: 3
+                strokeColor: Global.flightRouteColor
+                fillColor: "transparent"
+                PathPolyline { path: rawSideView.plannedProfile }
+            }
+        }
+
+        // Clickable altitude points, one per waypoint (route mode only). Tapping
+        // a point opens a popup to specify the planned altitude. Placed in
+        // Flickable content space, aligned with the profile polyline.
+        Repeater {
+            model: rawSideView.mode === SideviewQuickItem.Route ? rawSideView.plannedProfilePoints : 0
+
+            delegate: Item {
+                id: handle
+                required property int index
+                required property var modelData
+
+                width: 28
+                height: 28
+                x: modelData.x - width/2
+                y: modelData.y - height/2
+
+                // Same marker as the route turnpoints on the moving map.
+                Image {
+                    anchors.centerIn: parent
+                    source: "/icons/waypoints/WP-map.svg"
+                    sourceSize.width: 14
+                    sourceSize.height: 14
+                    scale: tapArea.pressed ? 1.25 : 1.0
+                }
+
+                MouseArea {
+                    id: tapArea
+                    anchors.fill: parent
+                    onDoubleClicked: {
+                        PlatformAdaptor.vibrateBrief()
+                        sideviewAltEditor.index = handle.index
+                        sideviewAltEditor.open()
+                    }
+                }
+            }
         }
 
         Image {
@@ -569,6 +617,46 @@ SideviewQuickItem {
             } else {
                 rawSideView.mode = SideviewQuickItem.Route
             }
+        }
+    }
+
+    // Popup to specify the planned altitude of a waypoint, opened by tapping a
+    // blue altitude point.
+    CenteringDialog {
+        id: sideviewAltEditor
+
+        property int index: -1 // Index of waypoint in flight route
+
+        title: qsTr("Planned Altitude")
+        modal: true
+        standardButtons: Dialog.Ok | Dialog.Cancel
+
+        onAboutToShow: {
+            var m = Navigator.flightRoute.plannedAltitude(sideviewAltEditor.index)
+            sideviewAltField.valueMeter = isNaN(m) ? Navigator.aircraft.cruiseAltitudeM : m
+        }
+
+        ColumnLayout {
+            width: parent.width
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: qsTr("Planned cruise altitude at this waypoint. Leave empty to use the aircraft's default cruise altitude.")
+            }
+
+            ElevationInput {
+                id: sideviewAltField
+                Layout.fillWidth: true
+                currentIndex: Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters ? 1 : 0
+                onAccepted: sideviewAltEditor.accept()
+            }
+        }
+
+        onAccepted: {
+            PlatformAdaptor.vibrateBrief()
+            sideviewAltField.commit()
+            Navigator.flightRoute.setPlannedAltitude(sideviewAltEditor.index, sideviewAltField.valueMeter)
         }
     }
 }

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -481,7 +481,7 @@ SideviewQuickItem {
         // point at the planned altitude. Red = headwind, green = tailwind;
         // feathers encode the along-track component magnitude.
         Repeater {
-            model: rawSideView.mode === SideviewQuickItem.Route ? rawSideView.windProfile : 0
+            model: (rawSideView.mode === SideviewQuickItem.Route && rawSideView.showWind) ? rawSideView.windProfile : 0
 
             delegate: Canvas {
                 id: windBarb
@@ -697,6 +697,32 @@ SideviewQuickItem {
                 rawSideView.mode = SideviewQuickItem.Route
             }
         }
+    }
+
+    // Wind toggle button — only in Route mode; shows the projected wind barbs
+    RoundButton {
+        id: windToggle
+
+        anchors.right:   modeToggle.left
+        anchors.top:     parent.top
+        anchors.margins: 4
+        z: 10
+
+        width:  32
+        height: 32
+        padding: 0
+
+        visible: rawSideView.mode === SideviewQuickItem.Route
+        checkable: true
+        checked: rawSideView.showWind
+        onToggled: rawSideView.showWind = checked
+
+        text: "🌫"
+        font.pixelSize: 16
+        opacity: checked ? 1.0 : 0.55
+
+        ToolTip.text: qsTr("Show wind")
+        ToolTip.visible: hovered
     }
 
     // Popup to specify the planned altitude of a waypoint, opened by tapping a

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -36,6 +36,9 @@ SideviewQuickItem {
     // coordinates in the Flickable's content space.
     renderWidth: flickable.contentWidth
 
+    // Wind barbs follow the global wind-layer toggle (shared with the map)
+    showWind: GlobalSettings.showWindLayer
+
     // Full-area sky background (scale panels sit on top of it)
     Rectangle {
         anchors.fill: parent
@@ -698,32 +701,6 @@ SideviewQuickItem {
                 rawSideView.mode = SideviewQuickItem.Route
             }
         }
-    }
-
-    // Wind toggle button — only in Route mode; shows the projected wind barbs
-    RoundButton {
-        id: windToggle
-
-        anchors.right:   modeToggle.left
-        anchors.top:     parent.top
-        anchors.margins: 4
-        z: 10
-
-        width:  32
-        height: 32
-        padding: 0
-
-        visible: rawSideView.mode === SideviewQuickItem.Route
-        checkable: true
-        checked: rawSideView.showWind
-        onToggled: rawSideView.showWind = checked
-
-        text: "🌫"
-        font.pixelSize: 16
-        opacity: checked ? 1.0 : 0.55
-
-        ToolTip.text: qsTr("Show wind")
-        ToolTip.visible: hovered
     }
 
     // Popup to specify the planned altitude of a waypoint, opened by tapping a

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -477,82 +477,83 @@ SideviewQuickItem {
             }
         }
 
-        // Wind projected onto the route profile: a horizontal barb per sample
-        // point at the planned altitude. Red = headwind, green = tailwind;
-        // feathers encode the along-track component magnitude.
-        Repeater {
-            model: (rawSideView.mode === SideviewQuickItem.Route && rawSideView.showWind) ? rawSideView.windProfile : 0
+        // Wind projected onto the route profile, drawn as a single overlay over
+        // the whole content. Each sample is a horizontal barb: red = headwind,
+        // green = tailwind, feathers encode the along-track component.
+        Canvas {
+            id: windOverlay
 
-            delegate: Canvas {
-                id: windBarb
-                required property var modelData
+            width: flickable.contentWidth
+            height: flickable.contentHeight
+            visible: rawSideView.mode === SideviewQuickItem.Route && rawSideView.showWind
 
-                width: 60
-                height: 44
-                x: modelData.x - width/2
-                y: modelData.y - height - 6   // sit just above the profile point
+            property var pts: rawSideView.windProfile
+            onPtsChanged: requestPaint()
+            onWidthChanged: requestPaint()
+            onVisibleChanged: if (visible) requestPaint()
+            Component.onCompleted: requestPaint()
 
-                onModelDataChanged: requestPaint()
-                Component.onCompleted: requestPaint()
+            function drawBarb(ctx, x, y, alongKn) {
+                var mag = Math.abs(alongKn)
+                var color = alongKn >= 0 ? "#b00020" : "#2e7d32"
+                ctx.strokeStyle = color
+                ctx.fillStyle = color
+                ctx.lineWidth = 1.5
 
-                onPaint: {
-                    var ctx = getContext("2d")
-                    ctx.clearRect(0, 0, width, height)
-
-                    var along = modelData.alongKn          // + headwind, − tailwind
-                    var mag = Math.abs(along)
-                    var cx = width/2, cy = height - 6
-                    var color = along >= 0 ? "#b00020" : "#2e7d32"
-                    ctx.strokeStyle = color
-                    ctx.fillStyle = color
-                    ctx.lineWidth = 1.5
-
-                    if (mag < 2.5) {
-                        ctx.beginPath()
-                        ctx.arc(cx, cy, 3, 0, 2*Math.PI)
-                        ctx.stroke()
-                        return
-                    }
-
-                    var dir = along >= 0 ? 1 : -1          // headwind staff points toward source (ahead = right)
-                    var L = 22, barbLen = 10, spacing = 5
-                    var ex = cx + dir*L, ey = cy
-
-                    // Staff
+                if (mag < 2.5) {
                     ctx.beginPath()
-                    ctx.moveTo(cx, cy)
-                    ctx.lineTo(ex, ey)
+                    ctx.arc(x, y, 3, 0, 2*Math.PI)
                     ctx.stroke()
-
-                    var remaining = Math.round(mag/5)*5
-                    var bx = ex, by = ey
-                    var stepX = -dir*spacing
-
-                    while (remaining >= 50) {
-                        ctx.beginPath()
-                        ctx.moveTo(bx, by)
-                        ctx.lineTo(bx + 2*stepX, by - barbLen)
-                        ctx.lineTo(bx + 2*stepX, by)
-                        ctx.closePath()
-                        ctx.fill()
-                        bx += 2*stepX
-                        remaining -= 50
-                    }
-                    while (remaining >= 10) {
-                        ctx.beginPath()
-                        ctx.moveTo(bx, by)
-                        ctx.lineTo(bx + stepX, by - barbLen)
-                        ctx.stroke()
-                        bx += stepX
-                        remaining -= 10
-                    }
-                    if (remaining >= 5) {
-                        ctx.beginPath()
-                        ctx.moveTo(bx, by)
-                        ctx.lineTo(bx + stepX*0.5, by - barbLen*0.5)
-                        ctx.stroke()
-                    }
+                    return
                 }
+
+                var dir = alongKn >= 0 ? 1 : -1   // headwind staff points toward source (ahead = right)
+                var L = 22, barbLen = 11, spacing = 5
+                var ex = x + dir*L, ey = y
+
+                ctx.beginPath()
+                ctx.moveTo(x, y)
+                ctx.lineTo(ex, ey)
+                ctx.stroke()
+
+                var remaining = Math.round(mag/5)*5
+                var bx = ex, by = ey
+                var stepX = -dir*spacing
+
+                while (remaining >= 50) {
+                    ctx.beginPath()
+                    ctx.moveTo(bx, by)
+                    ctx.lineTo(bx + 2*stepX, by - barbLen)
+                    ctx.lineTo(bx + 2*stepX, by)
+                    ctx.closePath()
+                    ctx.fill()
+                    bx += 2*stepX
+                    remaining -= 50
+                }
+                while (remaining >= 10) {
+                    ctx.beginPath()
+                    ctx.moveTo(bx, by)
+                    ctx.lineTo(bx + stepX, by - barbLen)
+                    ctx.stroke()
+                    bx += stepX
+                    remaining -= 10
+                }
+                if (remaining >= 5) {
+                    ctx.beginPath()
+                    ctx.moveTo(bx, by)
+                    ctx.lineTo(bx + stepX*0.5, by - barbLen*0.5)
+                    ctx.stroke()
+                }
+            }
+
+            onPaint: {
+                var ctx = getContext("2d")
+                ctx.clearRect(0, 0, width, height)
+                if (!visible)
+                    return
+                var p = pts
+                for (var i = 0; i < p.length; i++)
+                    drawBarb(ctx, p[i].x, p[i].y, p[i].alongKn)
             }
         }
 

--- a/src/qml/items/Sideview.qml
+++ b/src/qml/items/Sideview.qml
@@ -30,206 +30,441 @@ SideviewQuickItem {
     clip: true
     pixelPer10km: flightMap.pixelPer10km
 
+    // Feed the C++ backend the actual content width so it computes
+    // coordinates in the Flickable's content space.
+    renderWidth: flickable.contentWidth
+
+    // Full-area sky background (scale panels sit on top of it)
     Rectangle {
-        id: sky
         anchors.fill: parent
         color: "lightblue"
+        z: -1
     }
 
-    Shape {
-        id: shp
+    // -------------------------------------------------------------------------
+    // Unit helpers
+    // -------------------------------------------------------------------------
+    readonly property bool useFeet: Navigator.aircraft.verticalDistanceUnit === Aircraft.Feet
+    readonly property bool useNM:   Navigator.aircraft.horizontalDistanceUnit === Aircraft.NauticalMile
+    readonly property bool useSM:   Navigator.aircraft.horizontalDistanceUnit === Aircraft.StatuteMile
+    // km → display unit conversions
+    readonly property double kmToHDist: useNM ? 0.539957 : (useSM ? 0.621371 : 1.0)
+    readonly property string hDistUnit: useNM ? qsTr("NM") : (useSM ? qsTr("mi") : qsTr("km"))
+    // ft → display unit for altitude
+    readonly property double ftToVDist: useFeet ? 1.0 : 0.3048
+    readonly property string vDistUnit: useFeet ? qsTr("ft") : qsTr("m")
 
-        preferredRendererType: Shape.CurveRenderer
-        asynchronous: true
+    // -------------------------------------------------------------------------
+    // Y-axis scale (altitude) — fixed strip on the left, not scrolled
+    // -------------------------------------------------------------------------
+    readonly property int yScaleWidth: 54
+    readonly property int xScaleHeight: 20
 
-        ShapePath {
-            id: terrain
-            strokeWidth: -1
-            strokeColor: "saddlebrown"
-            fillColor: "brown"
+    Item {
+        id: yScalePanel
 
-            PathPolyline { path: rawSideView.terrain }
+        x: 0
+        y: 0
+        width: rawSideView.yScaleWidth
+        height: rawSideView.height - rawSideView.xScaleHeight
+        z: 20
+        clip: true
+
+        // Semi-transparent background
+        Rectangle {
+            anchors.fill: parent
+            color: "#99F0F0F0"
         }
 
-        ShapePath {
-            id: airspacesABorder
-            strokeWidth: 10
-            strokeColor: "#330000FF"
-            fillColor: "transparent"
+        // Tick marks and labels
+        Repeater {
+            id: yTicks
 
-            PathMultiline { paths: rawSideView.airspaces["A"] }
-        }
+            // Work in display units (ft or m)
+            readonly property double minDisp: rawSideView.scaleMinAltFt * rawSideView.ftToVDist
+            readonly property double maxDisp: rawSideView.scaleMaxAltFt * rawSideView.ftToVDist
+            readonly property double rangeH:  maxDisp - minDisp
 
-        ShapePath {
-            id: airspacesA
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["A"] }
-        }
-
-        ShapePath {
-            id: airspacesRBorder
-            strokeWidth: 10
-            strokeColor: "#33FF0000"
-            fillColor: "transparent"
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["R"] }
-        }
-
-        ShapePath {
-            id: airspacesR
-            strokeWidth: 2
-            strokeColor: "red"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["R"] }
-        }
-
-        ShapePath {
-            id: airspacesPJE
-            strokeWidth: 2
-            strokeColor: "red"
-            fillColor: "transparent"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-
-            PathMultiline { paths: rawSideView.airspaces["PJE"] }
-        }
-
-        ShapePath {
-            id: airspacesTMZ
-            strokeWidth: 2
-            strokeColor: "black"
-            fillColor: "transparent"
-            dashPattern: [4.0, 3.0, 0.5, 3.0]
-            strokeStyle: ShapePath.DashLine
-
-            PathMultiline { paths: rawSideView.airspaces["TMZ"] }
-        }
-
-        ShapePath {
-            id: airspacesNRABorder
-            strokeWidth: 10
-            strokeColor: "#3300FF00"
-            fillColor: "transparent"
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["NRA"] }
-        }
-
-        ShapePath {
-            id: airspacesNRA
-            strokeWidth: 2
-            strokeColor: "green"
-            fillColor: "transparent"
-
-            PathMultiline { paths: rawSideView.airspaces["NRA"] }
-        }
-
-        ShapePath {
-            id: airspacesRMZ
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "#330000FF"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["RMZ"] }
-        }
-
-        ShapePath {
-            id: airspacesCTR
-            strokeWidth: 2
-            strokeColor: "blue"
-            fillColor: "#33FF0000"
-            dashPattern: [4,3]
-            strokeStyle: ShapePath.DashLine
-            fillRule: ShapePath.WindingFill
-
-            PathMultiline { paths: rawSideView.airspaces["CTR"] }
-        }
-
-        property double animatedFiveMinuteBarX: rawSideView.fiveMinuteBar.x
-        Behavior on animatedFiveMinuteBarX { NumberAnimation {duration: 1000} }
-        property double animatedFiveMinuteBarY: rawSideView.fiveMinuteBar.y
-        Behavior on animatedFiveMinuteBarY { NumberAnimation {duration: 1000} }
-
-        ShapePath {
-            id: fiveMinuteBar
-            strokeWidth: 3
-            strokeColor: "black"
-
-            startX: rawSideView.ownshipPosition.x
-            startY: rawSideView.ownshipPosition.y
-            PathLine {
-                relativeX: shp.animatedFiveMinuteBarX
-                relativeY: shp.animatedFiveMinuteBarY
+            // Pick a tick interval (in display units) giving roughly 4-8 ticks
+            readonly property double tickStep: {
+                var range = rangeH > 0 ? rangeH : 1000
+                var candidates = rawSideView.useFeet
+                    ? [100, 200, 500, 1000, 2000, 5000]
+                    : [50, 100, 200, 500, 1000, 2000]
+                for (var i = 0; i < candidates.length; i++) {
+                    if (range / candidates[i] <= 8) { return candidates[i] }
+                }
+                return candidates[candidates.length - 1]
             }
-        }
+            readonly property double firstTick: Math.ceil(minDisp / tickStep) * tickStep
+            readonly property int tickCount: rangeH > 0
+                ? Math.floor((maxDisp - firstTick) / tickStep) + 1
+                : 0
 
-        ShapePath {
-            id: fiveMinuteBar_1_2
-            strokeWidth: 2
-            strokeColor: "white"
+            model: (rangeH > 0 && tickCount > 0) ? tickCount : 0
 
-            startX: rawSideView.ownshipPosition.x + 0.2*shp.animatedFiveMinuteBarX
-            startY: rawSideView.ownshipPosition.y + 0.2*shp.animatedFiveMinuteBarY
-            PathLine {
-                relativeX: 0.2*shp.animatedFiveMinuteBarX
-                relativeY: 0.2*shp.animatedFiveMinuteBarY
-            }
-        }
+            delegate: Item {
+                required property int index
+                readonly property double altDisp: yTicks.firstTick + index * yTicks.tickStep
+                readonly property double frac: (altDisp - yTicks.minDisp) / yTicks.rangeH
+                readonly property double yPos: (1.0 - frac) * yScalePanel.height
 
-        ShapePath {
-            id: fiveMinuteBar_3_4
-            strokeWidth: 2
-            strokeColor: "white"
+                y: yPos - 7
+                x: 0
+                width: yScalePanel.width
+                height: 14
+                visible: yPos >= 0 && yPos <= yScalePanel.height
 
-            startX: rawSideView.ownshipPosition.x + 0.6*shp.animatedFiveMinuteBarX
-            startY: rawSideView.ownshipPosition.y + 0.6*shp.animatedFiveMinuteBarY
-            PathLine {
-                relativeX: 0.2*shp.animatedFiveMinuteBarX
-                relativeY: 0.2*shp.animatedFiveMinuteBarY
+                Rectangle {
+                    x: yScalePanel.width - 4
+                    y: 6
+                    width: 4
+                    height: 1
+                    color: "#80000000"
+                }
+
+                Label {
+                    x: 2; y: 0
+                    width: yScalePanel.width - 6
+                    height: 14
+                    text: qsTr("%1 %2").arg(Math.round(altDisp)).arg(rawSideView.vDistUnit)
+                    font.pixelSize: 9
+                    color: "#CC000000"
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideNone
+                }
             }
         }
     }
 
-    Image {
-        id: ownShip
+    // -------------------------------------------------------------------------
+    // X-axis scale (distance) — fixed strip at the bottom
+    // -------------------------------------------------------------------------
+    Item {
+        id: xScalePanel
 
-        x: rawSideView.ownshipPosition.x-width/2.0
-        y: rawSideView.ownshipPosition.y-height/2.0
-        rotation: {
-            if (shp.animatedFiveMinuteBarX > 2)
-            {
-                return 90 + 360*Math.atan( shp.animatedFiveMinuteBarY/shp.animatedFiveMinuteBarX )/(2*Math.PI)
-            }
-            return 90
+        x: rawSideView.yScaleWidth
+        y: rawSideView.height - rawSideView.xScaleHeight
+        width: rawSideView.width - rawSideView.yScaleWidth
+        height: rawSideView.xScaleHeight
+        z: 20
+        clip: true
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#99F0F0F0"
         }
 
-        source: {
-            var pInfo = PositionProvider.positionInfo
-            if (!pInfo.isValid()) {
-                return "/icons/self-noPosition.svg"
-            }
-            if (!pInfo.trueTrack().isFinite()) {
-                return "/icons/self-noDirection.svg"
-            }
-            return "/icons/self-withDirection.svg"
-        }
+        // Scrolling tick marks — shift opposite to Flickable.contentX
+        Item {
+            x: -flickable.contentX
+            width: flickable.contentWidth
+            height: xScalePanel.height
 
-        sourceSize.width: 25
-        sourceSize.height: 25
+            Repeater {
+                id: xTicks
+
+                readonly property double totalKm: rawSideView.scaleTotalDistKm
+                readonly property double contentW: flickable.contentWidth
+                readonly property bool isRouteMode: totalKm > 0
+
+                // distance (in display units) per pixel in content space
+                readonly property double dispPerPx: isRouteMode
+                    ? (totalKm * rawSideView.kmToHDist / contentW)
+                    : (10.0 * rawSideView.kmToHDist / rawSideView.pixelPer10km)
+
+                // pixels per display-unit
+                readonly property double pxPerDisp: dispPerPx > 0 ? 1.0 / dispPerPx : 0
+
+                // pick a nice tick interval (display units) giving ≥ 50 px between ticks
+                readonly property double tickDist: {
+                    if (pxPerDisp <= 0) { return 100 }
+                    var candidates = rawSideView.useNM
+                        ? [0.5, 1, 2, 5, 10, 20, 50, 100, 200]
+                        : [1, 2, 5, 10, 20, 50, 100, 200, 500]
+                    for (var i = 0; i < candidates.length; i++) {
+                        if (pxPerDisp * candidates[i] >= 50) { return candidates[i] }
+                    }
+                    return candidates[candidates.length - 1]
+                }
+
+                readonly property double totalDispShown: dispPerPx > 0 ? contentW * dispPerPx : 0
+                readonly property int tickCount: totalDispShown > 0
+                    ? Math.ceil(totalDispShown / tickDist) + 2
+                    : 0
+
+                model: tickCount
+
+                delegate: Item {
+                    required property int index
+                    // distance value this tick represents (in display units)
+                    readonly property double dist: {
+                        if (xTicks.isRouteMode) {
+                            return index * xTicks.tickDist
+                        }
+                        // track mode: pixel x=0 is 0.2*contentW*dispPerPx behind ownship
+                        var startDisp = -0.2 * xTicks.contentW * xTicks.dispPerPx
+                        return Math.ceil(startDisp / xTicks.tickDist) * xTicks.tickDist
+                               + index * xTicks.tickDist
+                    }
+                    readonly property double xPos: xTicks.isRouteMode
+                        ? (xTicks.pxPerDisp > 0 ? dist * xTicks.pxPerDisp : 0)
+                        : (xTicks.pxPerDisp > 0
+                           ? (dist + 0.2 * xTicks.contentW * xTicks.dispPerPx) * xTicks.pxPerDisp
+                           : 0)
+
+                    x: xPos - 1
+                    y: 0
+                    width: 2
+                    height: xScalePanel.height
+                    visible: xPos >= 0 && xPos <= xTicks.contentW
+
+                    Rectangle {
+                        x: 0; y: 0; width: 1; height: 4
+                        color: "#80000000"
+                    }
+
+                    Label {
+                        x: 2; y: 2
+                        font.pixelSize: 9
+                        color: "#CC000000"
+                        text: {
+                            var v = rawSideView.useNM
+                                    ? dist.toFixed(1)
+                                    : Math.round(dist)
+                            return xTicks.isRouteMode
+                                ? qsTr("%1 %2").arg(v).arg(rawSideView.hDistUnit)
+                                : (dist >= 0
+                                   ? qsTr("+%1 %2").arg(v).arg(rawSideView.hDistUnit)
+                                   : qsTr("%1 %2").arg(v).arg(rawSideView.hDistUnit))
+                        }
+                    }
+                }
+            }
+        }
     }
 
+    // -------------------------------------------------------------------------
+    // Flickable — horizontal scrolling for the content area
+    // -------------------------------------------------------------------------
+    Flickable {
+        id: flickable
+
+        x: rawSideView.yScaleWidth
+        y: 0
+        width: rawSideView.width - rawSideView.yScaleWidth
+        height: rawSideView.height - rawSideView.xScaleHeight
+
+        contentWidth: width * zoomFactor
+        contentHeight: height
+
+        flickableDirection: Flickable.HorizontalFlick
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+
+        property real zoomFactor: 1.0
+
+        Shape {
+            id: shp
+
+            width: flickable.contentWidth
+            height: flickable.contentHeight
+
+            preferredRendererType: Shape.CurveRenderer
+            asynchronous: true
+
+            ShapePath {
+                id: terrain
+                strokeWidth: -1
+                strokeColor: "saddlebrown"
+                fillColor: "brown"
+
+                PathPolyline { path: rawSideView.terrain }
+            }
+
+            ShapePath {
+                id: airspacesABorder
+                strokeWidth: 10
+                strokeColor: "#330000FF"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["A"] }
+            }
+
+            ShapePath {
+                id: airspacesA
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["A"] }
+            }
+
+            ShapePath {
+                id: airspacesRBorder
+                strokeWidth: 10
+                strokeColor: "#33FF0000"
+                fillColor: "transparent"
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["R"] }
+            }
+
+            ShapePath {
+                id: airspacesR
+                strokeWidth: 2
+                strokeColor: "red"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["R"] }
+            }
+
+            ShapePath {
+                id: airspacesPJE
+                strokeWidth: 2
+                strokeColor: "red"
+                fillColor: "transparent"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+
+                PathMultiline { paths: rawSideView.airspaces["PJE"] }
+            }
+
+            ShapePath {
+                id: airspacesTMZ
+                strokeWidth: 2
+                strokeColor: "black"
+                fillColor: "transparent"
+                dashPattern: [4.0, 3.0, 0.5, 3.0]
+                strokeStyle: ShapePath.DashLine
+
+                PathMultiline { paths: rawSideView.airspaces["TMZ"] }
+            }
+
+            ShapePath {
+                id: airspacesNRABorder
+                strokeWidth: 10
+                strokeColor: "#3300FF00"
+                fillColor: "transparent"
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["NRA"] }
+            }
+
+            ShapePath {
+                id: airspacesNRA
+                strokeWidth: 2
+                strokeColor: "green"
+                fillColor: "transparent"
+
+                PathMultiline { paths: rawSideView.airspaces["NRA"] }
+            }
+
+            ShapePath {
+                id: airspacesRMZ
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "#330000FF"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["RMZ"] }
+            }
+
+            ShapePath {
+                id: airspacesCTR
+                strokeWidth: 2
+                strokeColor: "blue"
+                fillColor: "#33FF0000"
+                dashPattern: [4,3]
+                strokeStyle: ShapePath.DashLine
+                fillRule: ShapePath.WindingFill
+
+                PathMultiline { paths: rawSideView.airspaces["CTR"] }
+            }
+
+            property double animatedFiveMinuteBarX: rawSideView.fiveMinuteBar.x
+            Behavior on animatedFiveMinuteBarX { NumberAnimation {duration: 1000} }
+            property double animatedFiveMinuteBarY: rawSideView.fiveMinuteBar.y
+            Behavior on animatedFiveMinuteBarY { NumberAnimation {duration: 1000} }
+
+            ShapePath {
+                id: fiveMinuteBar
+                strokeWidth: 3
+                strokeColor: "black"
+
+                startX: rawSideView.ownshipPosition.x
+                startY: rawSideView.ownshipPosition.y
+                PathLine {
+                    relativeX: shp.animatedFiveMinuteBarX
+                    relativeY: shp.animatedFiveMinuteBarY
+                }
+            }
+
+            ShapePath {
+                id: fiveMinuteBar_1_2
+                strokeWidth: 2
+                strokeColor: "white"
+
+                startX: rawSideView.ownshipPosition.x + 0.2*shp.animatedFiveMinuteBarX
+                startY: rawSideView.ownshipPosition.y + 0.2*shp.animatedFiveMinuteBarY
+                PathLine {
+                    relativeX: 0.2*shp.animatedFiveMinuteBarX
+                    relativeY: 0.2*shp.animatedFiveMinuteBarY
+                }
+            }
+
+            ShapePath {
+                id: fiveMinuteBar_3_4
+                strokeWidth: 2
+                strokeColor: "white"
+
+                startX: rawSideView.ownshipPosition.x + 0.6*shp.animatedFiveMinuteBarX
+                startY: rawSideView.ownshipPosition.y + 0.6*shp.animatedFiveMinuteBarY
+                PathLine {
+                    relativeX: 0.2*shp.animatedFiveMinuteBarX
+                    relativeY: 0.2*shp.animatedFiveMinuteBarY
+                }
+            }
+        }
+
+        Image {
+            id: ownShip
+
+            x: rawSideView.ownshipPosition.x-width/2.0
+            y: rawSideView.ownshipPosition.y-height/2.0
+            rotation: {
+                if (shp.animatedFiveMinuteBarX > 2)
+                {
+                    return 90 + 360*Math.atan( shp.animatedFiveMinuteBarY/shp.animatedFiveMinuteBarX )/(2*Math.PI)
+                }
+                return 90
+            }
+
+            source: {
+                var pInfo = PositionProvider.positionInfo
+                if (!pInfo.isValid()) {
+                    return "/icons/self-noPosition.svg"
+                }
+                if (!pInfo.trueTrack().isFinite()) {
+                    return "/icons/self-noDirection.svg"
+                }
+                return "/icons/self-withDirection.svg"
+            }
+
+            sourceSize.width: 25
+            sourceSize.height: 25
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Labels (outside Flickable — anchored to the visible area)
+    // -------------------------------------------------------------------------
     Label {
         id: trackLabel
 
-        x: rawSideView.width*0.1
+        x: rawSideView.yScaleWidth + flickable.width*0.1
         text: rawSideView.track
         visible: rawSideView.track !== ""
     }
@@ -238,6 +473,7 @@ SideviewQuickItem {
         id: errorLabel
 
         anchors.centerIn: parent
+        anchors.horizontalCenterOffset: rawSideView.yScaleWidth / 2.0
 
         text: rawSideView.error
         visible: rawSideView.error !== ""
@@ -262,6 +498,77 @@ SideviewQuickItem {
                                    }
                                    )
             dialogLoader.active = true
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Zoom buttons — Route mode only
+    // -------------------------------------------------------------------------
+    Column {
+        id: zoomButtons
+
+        anchors.right: modeToggle.left
+        anchors.top:   parent.top
+        anchors.margins: 4
+        spacing: 2
+        z: 10
+
+        visible: rawSideView.mode === SideviewQuickItem.Route
+
+        RoundButton {
+            width:  28; height: 28; padding: 0
+            text: "+"
+            font.pixelSize: 16
+            opacity: 0.85
+            enabled: flickable.zoomFactor < 8.0
+            onClicked: flickable.zoomFactor = Math.min(8.0, flickable.zoomFactor * 2.0)
+        }
+
+        RoundButton {
+            width:  28; height: 28; padding: 0
+            text: "−"
+            font.pixelSize: 16
+            opacity: 0.85
+            enabled: flickable.zoomFactor > 1.0
+            onClicked: {
+                flickable.zoomFactor = Math.max(1.0, flickable.zoomFactor / 2.0)
+                if (flickable.contentWidth <= flickable.width) {
+                    flickable.contentX = 0
+                }
+            }
+        }
+    }
+
+    // Mode toggle button — rendered last so it sits above all other children
+    RoundButton {
+        id: modeToggle
+
+        anchors.right:   parent.right
+        anchors.top:     parent.top
+        anchors.margins: 4
+        z: 10
+
+        width:  32
+        height: 32
+        padding: 0
+
+        text: rawSideView.mode === SideviewQuickItem.Route ? "✈" : "⇢"
+        font.pixelSize: 16
+        opacity: 0.85
+
+        ToolTip.text: rawSideView.mode === SideviewQuickItem.Route
+                      ? qsTr("Showing planned route – tap for current track")
+                      : qsTr("Showing current track – tap for planned route")
+        ToolTip.visible: hovered
+
+        onClicked: {
+            if (rawSideView.mode === SideviewQuickItem.Route) {
+                rawSideView.mode = SideviewQuickItem.Track
+                flickable.zoomFactor = 1.0
+                flickable.contentX = 0
+            } else {
+                rawSideView.mode = SideviewQuickItem.Route
+            }
         }
     }
 }

--- a/src/qml/pages/AircraftPage.qml
+++ b/src/qml/pages/AircraftPage.qml
@@ -413,6 +413,20 @@ Page {
             Item { }
 
             Label {
+                text: qsTr("Cruise altitude")
+                Layout.alignment: Qt.AlignBaseline
+            }
+            ElevationInput {
+                id: cruiseAltField
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                currentIndex: Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters ? 1 : 0
+                valueMeter: Navigator.aircraft.cruiseAltitudeM
+                onValueMeterChanged: Navigator.aircraft.cruiseAltitudeM = valueMeter
+            }
+            Item { }
+
+            Label {
                 text: qsTr("Descent")
                 Layout.alignment: Qt.AlignBaseline
             }

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -196,6 +196,7 @@ Page {
             id: grid
 
             property leg leg: ({});
+            property int legIndex: -1
 
             Layout.fillWidth: true
 
@@ -207,15 +208,19 @@ Page {
                     // Mention units
                     Navigator.aircraft.horizontalDistanceUnit
                     Navigator.aircraft.fuelConsumptionUnit
+                    // Re-evaluate when the wind field reloads or inputs change
+                    Navigator.windSource
+                    Navigator.cruiseAltitudeFt
+                    Navigator.departureTime
 
                     if (leg == null)
                         return ""
 
-                    // Use the spatially-resolved wind field when available, else
-                    // fall back to the manually-entered uniform wind.
-                    var wind = Navigator.windSource === "field"
-                        ? leg.averageWind(Navigator.windField(), Navigator.cruiseAltitudeFt)
-                        : Navigator.wind
+                    // ETA-aware wind from the field (falls back to manual wind
+                    // internally when the field has no usable data).
+                    var wind = Navigator.flightRoute.legWind(
+                        grid.legIndex, Navigator.windField(), Navigator.wind,
+                        Navigator.aircraft, Navigator.departureTime, Navigator.cruiseAltitudeFt)
 
                     var txt = leg.description(wind, Navigator.aircraft)
 
@@ -630,7 +635,7 @@ Page {
                             var legs = Navigator.flightRoute.legs
                             var j
                             for (j=0; j<legs.length; j++) {
-                                legComponent.createObject(co, {leg: legs[j]});
+                                legComponent.createObject(co, {leg: legs[j], legIndex: j});
                                 waypointComponent.createObject(co, {waypoint: legs[j].endPoint, index: j+1});
                             }
                         }

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -39,6 +39,14 @@ Page {
     property angle staticAngle
     property speed staticSpeed
 
+    // Bumped whenever a planned altitude changes, so the per-row altitude
+    // labels (bound to the Q_INVOKABLE plannedAltitude) re-evaluate.
+    property int plannedAltRevision: 0
+    Connections {
+        target: Navigator.flightRoute
+        function onPlannedAltitudesChanged() { flightRoutePage.plannedAltRevision++ }
+    }
+
     Component {
         id: waypointComponent
 
@@ -53,6 +61,42 @@ Page {
             WaypointDelegate {
                 Layout.fillWidth: true
                 waypoint: waypointLayout.waypoint
+            }
+
+            ToolButton {
+                id: altButton
+
+                // Resolved planned altitude in meters: stored value, else the
+                // aircraft default. NaN if neither is set.
+                readonly property double resolvedM: {
+                    flightRoutePage.plannedAltRevision // dependency
+                    var m = Navigator.flightRoute.plannedAltitude(waypointLayout.index)
+                    if (!isNaN(m)) return m
+                    return Navigator.aircraft.cruiseAltitudeM
+                }
+                readonly property bool isDefault: {
+                    flightRoutePage.plannedAltRevision // dependency
+                    return isNaN(Navigator.flightRoute.plannedAltitude(waypointLayout.index))
+                }
+
+                contentItem: Label {
+                    text: {
+                        if (isNaN(altButton.resolvedM)) return "––"
+                        if (Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters)
+                            return Math.round(altButton.resolvedM) + " m"
+                        return Math.round(altButton.resolvedM * 3.281) + " ft"
+                    }
+                    color: altButton.isDefault ? "#808080" : Global.flightRouteColor
+                    font.pixelSize: flightRoutePage.font.pixelSize*0.9
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                onClicked: {
+                    PlatformAdaptor.vibrateBrief()
+                    altEditor.index = waypointLayout.index
+                    altEditor.open()
+                }
             }
 
             ToolButton {
@@ -957,6 +1001,44 @@ Page {
             newWP.coordinate = QtPositioning.coordinate(newLatitude, newLongitude, newAltitudeMeter)
             Navigator.flightRoute.replaceWaypoint(index, newWP)
             wpEditor.close()
+        }
+    }
+
+    CenteringDialog {
+        id: altEditor
+
+        property int index: -1 // Index of waypoint in flight route
+
+        title: qsTr("Planned Altitude")
+        modal: true
+        standardButtons: Dialog.Ok | Dialog.Cancel
+
+        onAboutToShow: {
+            var m = Navigator.flightRoute.plannedAltitude(altEditor.index)
+            altField.valueMeter = isNaN(m) ? Navigator.aircraft.cruiseAltitudeM : m
+        }
+
+        ColumnLayout {
+            width: parent.width
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: qsTr("Planned cruise altitude at this waypoint. Leave empty to use the aircraft's default cruise altitude.")
+            }
+
+            ElevationInput {
+                id: altField
+                Layout.fillWidth: true
+                currentIndex: Navigator.aircraft.verticalDistanceUnit === Aircraft.Meters ? 1 : 0
+                onAccepted: altEditor.accept()
+            }
+        }
+
+        onAccepted: {
+            PlatformAdaptor.vibrateBrief()
+            altField.commit()
+            Navigator.flightRoute.setPlannedAltitude(altEditor.index, altField.valueMeter)
         }
     }
 } // Page

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -210,7 +210,25 @@ Page {
 
                     if (leg == null)
                         return ""
-                    return leg.description(Navigator.wind, Navigator.aircraft)
+
+                    // Use the spatially-resolved wind field when available, else
+                    // fall back to the manually-entered uniform wind.
+                    var wind = Navigator.windSource === "field"
+                        ? leg.averageWind(Navigator.windField(), Navigator.cruiseAltitudeFt)
+                        : Navigator.wind
+
+                    var txt = leg.description(wind, Navigator.aircraft)
+
+                    var gs = leg.GS(wind, Navigator.aircraft)
+                    if (gs.isFinite())
+                        txt += " • GS " + Navigator.aircraft.horizontalSpeedToString(gs)
+
+                    if (wind.speed.isFinite() && wind.directionFrom.isFinite() && wind.speed.toKN() > 0.5) {
+                        var dir = Math.round(wind.directionFrom.toDEG())
+                        txt += " • W/V " + dir + "°/" + Navigator.aircraft.horizontalSpeedToString(wind.speed)
+                    }
+
+                    return txt
                 }
             }
 
@@ -541,8 +559,39 @@ Page {
                 text: qsTr("<h3>Empty Route</h3><p>Use the button <strong>Add Waypoint</strong> below or double click on any point in the moving map.</p>")
             }
 
+            // Wind-source banner: shows when a server wind field is loaded, and
+            // warns when it is stale (computation falls back to manual wind).
+            Rectangle {
+                id: windBanner
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+
+                visible: WindFieldProvider.hasData
+                height: visible ? windBannerLabel.implicitHeight + 12 : 0
+
+                color: WindFieldProvider.isStale ? "#fff3cd" : "#d1e7dd"
+
+                Label {
+                    id: windBannerLabel
+                    anchors.centerIn: parent
+                    width: parent.width - 24
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.Wrap
+                    color: "black"
+                    text: WindFieldProvider.isStale
+                        ? qsTr("Wind field stale (%1) — using manual wind").arg(WindFieldProvider.validTimeLabel)
+                        : qsTr("Using wind field — valid %1, FL%2")
+                            .arg(WindFieldProvider.validTimeLabel)
+                            .arg(Math.round(Navigator.cruiseAltitudeFt/100))
+                }
+            }
+
             DecoratedScrollView {
-                anchors.fill: parent
+                anchors.top: windBanner.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
 
                 contentWidth: availableWidth
 

--- a/src/qml/pages/FlightRouteEditor.qml
+++ b/src/qml/pages/FlightRouteEditor.qml
@@ -208,27 +208,39 @@ Page {
                     // Mention units
                     Navigator.aircraft.horizontalDistanceUnit
                     Navigator.aircraft.fuelConsumptionUnit
-                    // Re-evaluate when the wind field reloads or inputs change
+                    // Re-evaluate when the wind field, altitudes or departure change
                     Navigator.windSource
-                    Navigator.cruiseAltitudeFt
                     Navigator.departureTime
+                    flightRoutePage.plannedAltRevision
 
                     if (leg == null)
                         return ""
 
-                    // ETA-aware wind from the field (falls back to manual wind
-                    // internally when the field has no usable data).
-                    var wind = Navigator.flightRoute.legWind(
+                    // ETA-aware, wind-integrated nav for this leg (4-D field
+                    // sampling along the leg, altitude ramp between waypoints,
+                    // advancing clock; falls back to manual wind internally).
+                    var nav = Navigator.flightRoute.legNav(
                         grid.legIndex, Navigator.windField(), Navigator.wind,
-                        Navigator.aircraft, Navigator.departureTime, Navigator.cruiseAltitudeFt)
+                        Navigator.aircraft, Navigator.departureTime)
+                    var wind = nav.wind
 
-                    var txt = leg.description(wind, Navigator.aircraft)
+                    var txt = Navigator.aircraft.horizontalDistanceToString(leg.distance)
 
-                    var gs = leg.GS(wind, Navigator.aircraft)
-                    if (gs.isFinite())
-                        txt += " • GS " + Navigator.aircraft.horizontalSpeedToString(gs)
+                    if (nav.ete !== undefined && nav.ete.isFinite())
+                        txt += " • ETE " + nav.ete.toHoursAndMinutes() + " h"
 
-                    if (wind.speed.isFinite() && wind.directionFrom.isFinite() && wind.speed.toKN() > 0.5) {
+                    var tcDeg = leg.TC.toDEG()
+                    if (!isNaN(tcDeg))
+                        txt += " • TC " + Math.round(tcDeg) + "°"
+
+                    var thDeg = leg.TH(wind, Navigator.aircraft).toDEG()
+                    if (!isNaN(thDeg))
+                        txt += " • TH " + Math.round(thDeg) + "°"
+
+                    if (nav.gs !== undefined && nav.gs.isFinite())
+                        txt += " • GS " + Navigator.aircraft.horizontalSpeedToString(nav.gs)
+
+                    if (wind !== undefined && wind.speed.isFinite() && wind.directionFrom.isFinite() && wind.speed.toKN() > 0.5) {
                         var dir = Math.round(wind.directionFrom.toDEG())
                         txt += " • W/V " + dir + "°/" + Navigator.aircraft.horizontalSpeedToString(wind.speed)
                     }

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -390,12 +390,12 @@ Page {
                 font.bold: true
             }
 
-            Icon {
-                source: "/icons/material/ic_cloud.svg"
-            }
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 0
+                Layout.columnSpan: 2
+                Layout.leftMargin: settingsPage.font.pixelSize
+                Layout.rightMargin: settingsPage.font.pixelSize
+                spacing: 4
 
                 Label {
                     text: qsTr("Server URL")
@@ -421,17 +421,13 @@ Page {
                     color: "#606060"
                     font.pixelSize: settingsPage.font.pixelSize * 0.85
                 }
-            }
-
-            Item { Layout.preferredHeight: 4 }  // spacer
-
-            Item { /* empty icon column */ }
-            Button {
-                text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
-                      ? qsTr("Refreshing…") : qsTr("Refresh now")
-                enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
-                         && ForecastMapProvider.serverUrl !== ""
-                onClicked: ForecastMapProvider.refresh()
+                Button {
+                    text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
+                          ? qsTr("Refreshing…") : qsTr("Refresh now")
+                    enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
+                             && ForecastMapProvider.serverUrl !== ""
+                    onClicked: ForecastMapProvider.refresh()
+                }
             }
 
             Item { // Spacer

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -385,6 +385,63 @@ Page {
             Label {
                 Layout.leftMargin: settingsPage.font.pixelSize
                 Layout.columnSpan: 2
+                text: qsTr("Forecast Maps")
+                font.pixelSize: settingsPage.font.pixelSize*1.2
+                font.bold: true
+            }
+
+            Icon {
+                source: "/icons/material/ic_cloud.svg"
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                Label {
+                    text: qsTr("Server URL")
+                    font.pixelSize: settingsPage.font.pixelSize
+                }
+                TextField {
+                    id: serverUrlField
+                    Layout.fillWidth: true
+                    placeholderText: "http://192.168.1.x:8765/meteo"
+                    text: ForecastMapProvider.serverUrl
+                    inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoPredictiveText
+                    onEditingFinished: ForecastMapProvider.serverUrl = text.trim()
+                }
+                Label {
+                    visible: ForecastMapProvider.status === ForecastMapProvider.Error
+                    text: qsTr("Last refresh failed — showing cached data")
+                    color: "red"
+                    font.pixelSize: settingsPage.font.pixelSize * 0.85
+                }
+                Label {
+                    visible: ForecastMapProvider.status !== ForecastMapProvider.Error
+                    text: qsTr("Last updated: ") + ForecastMapProvider.lastRefreshLabel
+                    color: "#606060"
+                    font.pixelSize: settingsPage.font.pixelSize * 0.85
+                }
+            }
+
+            Item { Layout.preferredHeight: 4 }  // spacer
+
+            Item { /* empty icon column */ }
+            Button {
+                text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
+                      ? qsTr("Refreshing…") : qsTr("Refresh now")
+                enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
+                         && ForecastMapProvider.serverUrl !== ""
+                onClicked: ForecastMapProvider.refresh()
+            }
+
+            Item { // Spacer
+                Layout.columnSpan: 2
+                Layout.preferredHeight: 3
+            }
+
+            Label {
+                Layout.leftMargin: settingsPage.font.pixelSize
+                Layout.columnSpan: 2
                 text: qsTr("Help")
                 font.pixelSize: settingsPage.font.pixelSize*1.2
                 font.bold: true

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -392,9 +392,7 @@ Page {
 
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.columnSpan: 2
                 Layout.leftMargin: settingsPage.font.pixelSize
-                Layout.rightMargin: settingsPage.font.pixelSize
                 spacing: 4
 
                 Label {
@@ -421,12 +419,14 @@ Page {
                     color: "#606060"
                     font.pixelSize: settingsPage.font.pixelSize * 0.85
                 }
-                Button {
-                    text: ForecastMapProvider.status === ForecastMapProvider.Refreshing
-                          ? qsTr("Refreshing…") : qsTr("Refresh now")
-                    enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
-                             && ForecastMapProvider.serverUrl !== ""
-                    onClicked: ForecastMapProvider.refresh()
+            }
+            ToolButton {
+                icon.source: "/icons/material/ic_refresh.svg"
+                enabled: ForecastMapProvider.status !== ForecastMapProvider.Refreshing
+                         && ForecastMapProvider.serverUrl !== ""
+                onClicked: {
+                    PlatformAdaptor.vibrateBrief()
+                    ForecastMapProvider.refresh()
                 }
             }
 

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -402,6 +402,7 @@ Page {
                 TextField {
                     id: serverUrlField
                     Layout.fillWidth: true
+                    Layout.preferredWidth: 0
                     placeholderText: "http://192.168.1.x:8765/meteo"
                     text: ForecastMapProvider.serverUrl
                     inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoPredictiveText

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -50,6 +50,9 @@ Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
     notifiers.push_back(GlobalObject::navigator()->flightRoute()->bindableGeoPath().addNotifier([this]() {
         if (m_mode == Mode::Route) { updateProperties(); }
     }));
+    connect(GlobalObject::navigator()->flightRoute(), &Navigation::FlightRoute::plannedAltitudesChanged, this, [this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    });
 
     updateProperties();
 }
@@ -190,6 +193,8 @@ void Ui::SideviewQuickItem::updatePropertiesTrack()
     m_track = QString();
     m_error = QString();
     m_terrain = QPolygonF();
+    m_plannedProfile = QPolygonF();
+    m_plannedProfilePoints = QVariantList();
 
     QVariantMap newAirspaces;
     const QVector<QPolygonF> empty;
@@ -413,6 +418,8 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     m_track           = QString();
     m_error           = QString();
     m_terrain         = QPolygonF();
+    m_plannedProfile  = QPolygonF();
+    m_plannedProfilePoints = QVariantList();
 
     const QVector<QPolygonF> empty;
     QVariantMap newAirspaces;
@@ -526,6 +533,29 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     Units::Distance sideview_minAlt = minElevation - Units::Distance::fromFT(200);
     Units::Distance sideview_maxAlt = maxElevation + Units::Distance::fromFT(4000);
 
+    // -----------------------------------------------------------------------
+    // 6b. Resolve the planned altitude at each waypoint (stored value, else
+    //     aircraft cruise altitude, else terrain + 1000ft) and expand the
+    //     vertical extent so the whole profile is visible.
+    // -----------------------------------------------------------------------
+    auto* flightRoute = GlobalObject::navigator()->flightRoute();
+    const auto routeWaypoints = flightRoute->waypoints();
+    const Units::Distance defaultCruiseAlt = GlobalObject::navigator()->aircraft().cruiseAltitude();
+    const Units::Distance fallbackAlt = maxElevation + Units::Distance::fromFT(1000);
+
+    QList<Units::Distance> plannedAlts;
+    plannedAlts.reserve(routeWaypoints.size());
+    for (int i = 0; i < routeWaypoints.size(); i++)
+    {
+        double storedM = flightRoute->plannedAltitude(i);
+        Units::Distance alt = !qIsNaN(storedM) ? Units::Distance::fromM(storedM)
+                            : defaultCruiseAlt.isFinite() ? defaultCruiseAlt
+                            : fallbackAlt;
+        plannedAlts << alt;
+        sideview_maxAlt = qMax(sideview_maxAlt, alt + Units::Distance::fromFT(200));
+        sideview_minAlt = qMin(sideview_minAlt, alt - Units::Distance::fromFT(200));
+    }
+
     auto altToY = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt) {
         return ((double)height()) * (sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
     };
@@ -533,6 +563,22 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     m_scaleMinAltFt    = sideview_minAlt.toFeet();
     m_scaleMaxAltFt    = sideview_maxAlt.toFeet();
     m_scaleTotalDistKm = totalRouteLen / 1000.0;
+
+    // Build the planned-altitude polyline: one point per waypoint, at the
+    // waypoint's x position along the route.
+    QPolygonF profile;
+    QVariantList profilePoints;
+    profile.reserve(plannedAlts.size());
+    profilePoints.reserve(plannedAlts.size());
+    for (qsizetype i = 0; (i < plannedAlts.size()) && (i < cumulativeDist.size()); i++)
+    {
+        double x = (cumulativeDist[i] / totalRouteLen) * renderW;
+        QPointF pt(x, altToY(plannedAlts[i]));
+        profile << pt;
+        profilePoints << pt;
+    }
+    m_plannedProfile = profile;
+    m_plannedProfilePoints = profilePoints;
 
     // -----------------------------------------------------------------------
     // 7. Terrain polygon

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -59,6 +59,9 @@ Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
     connect(Weather::WindFieldProvider::instance(), &Weather::WindFieldProvider::dataChanged, this, [this]() {
         if (m_mode == Mode::Route) { updateProperties(); }
     });
+    connect(GlobalObject::navigator(), &Navigation::Navigator::departureTimeChanged, this, [this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    });
 
     updateProperties();
 }
@@ -612,7 +615,13 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
         {
             const int nCols = qBound(3, int(renderW / 90.0), 14);
             const int nRows = 5; // altitude rows across the visible range
-            const QDateTime now = QDateTime::currentDateTimeUtc();
+
+            // ETA-aware sampling: the trip starts at departureTime (driven by the
+            // weather time slider) and the clock advances along the route.
+            auto* nav = GlobalObject::navigator();
+            QDateTime departure = nav->departureTime();
+            if (!departure.isValid()) { departure = QDateTime::currentDateTimeUtc(); }
+            const auto etas = flightRoute->waypointETAs(wfp, manualWind, nav->aircraft(), departure);
 
             for (int c = 0; c < nCols; c++)
             {
@@ -629,13 +638,23 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
                 }
                 const double trackDeg = geoPath[seg].azimuthTo(geoPath[qMin(seg+1, geoPath.size()-1)]);
 
+                // Time of arrival at this distance: interpolate between the
+                // bracketing waypoints' ETAs by distance fraction within the leg.
+                QDateTime eta = departure;
+                if ((seg + 1) < etas.size() && etas[seg].isValid() && etas[seg + 1].isValid())
+                {
+                    const double segLen = cumulativeDist[seg + 1] - cumulativeDist[seg];
+                    const double segFrac = (segLen > 0.01) ? qBound(0.0, (distM - cumulativeDist[seg]) / segLen, 1.0) : 0.0;
+                    eta = etas[seg].addSecs(qRound64(etas[seg].secsTo(etas[seg + 1]) * segFrac));
+                }
+
                 for (int rrow = 0; rrow < nRows; rrow++)
                 {
                     const Units::Distance alt = sideview_minAlt
                         + (sideview_maxAlt - sideview_minAlt) * ((rrow + 0.5) / nRows);
 
                     Weather::Wind w = haveField
-                        ? wfp->windAt(coord.latitude(), coord.longitude(), alt.toFeet(), now)
+                        ? wfp->windAt(coord.latitude(), coord.longitude(), alt.toFeet(), eta)
                         : Weather::Wind();
                     if (!w.speed().isFinite() || !w.directionFrom().isFinite())
                     {

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -21,6 +21,7 @@
 #include "GeoMapProvider.h"
 #include "PositionProvider.h"
 #include "SideviewQuickItem.h"
+#include "navigation/Navigator.h"
 #include "weather/WeatherDataProvider.h"
 
 using namespace Qt::Literals::StringLiterals;
@@ -40,7 +41,25 @@ Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
     notifiers.push_back(GlobalObject::positionProvider()->bindablePositionInfo().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(GlobalObject::positionProvider()->bindablePressureAltitude().addNotifier([this]() {updateProperties();}));
     notifiers.push_back(m_pixelPer10km.addNotifier([this]() {updateProperties();}));
-    updateProperties();   
+    notifiers.push_back(m_renderWidth.addNotifier([this]() { emit renderWidthChanged(); updateProperties(); }));
+    notifiers.push_back(m_scaleMaxAltFt.addNotifier([this]() { emit scaleRangeChanged(); }));
+    notifiers.push_back(m_scaleMinAltFt.addNotifier([this]() { emit scaleRangeChanged(); }));
+    notifiers.push_back(m_scaleTotalDistKm.addNotifier([this]() { emit scaleRangeChanged(); }));
+
+    // React to route changes when in Route mode
+    notifiers.push_back(GlobalObject::navigator()->flightRoute()->bindableGeoPath().addNotifier([this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    }));
+
+    updateProperties();
+}
+
+void Ui::SideviewQuickItem::setMode(Mode newMode)
+{
+    if (m_mode == newMode) { return; }
+    m_mode = newMode;
+    emit modeChanged();
+    updateProperties();
 }
 
 void Ui::SideviewQuickItem::updateProperties()
@@ -61,10 +80,111 @@ void Ui::SideviewQuickItem::updateProperties()
     }
     m_elapsedTimer.start();
 
+    if (m_mode == Mode::Route)
+    {
+        updatePropertiesRoute();
+    }
+    else
+    {
+        updatePropertiesTrack();
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Shared helper: build airspace polygons along a sampled geo-path
+// ---------------------------------------------------------------------------
+QVariantMap Ui::SideviewQuickItem::buildAirspacePolygons(
+    const QList<int>& xCoordinates,
+    const QList<QGeoCoordinate>& geoCoordinates,
+    const QList<Units::Distance>& elevations,
+    Units::Distance ownshipGeometricAltitude,
+    Units::Distance ownshipPressureAltitude,
+    std::function<double(Units::Distance)> altToY)
+{
+    const QVector<QPolygonF> empty;
+    QVariantMap result;
+    result[u"A"_s]   = QVariant::fromValue(empty);
+    result[u"CTR"_s] = QVariant::fromValue(empty);
+    result[u"R"_s]   = QVariant::fromValue(empty);
+    result[u"RMZ"_s] = QVariant::fromValue(empty);
+    result[u"NRA"_s] = QVariant::fromValue(empty);
+    result[u"PJE"_s] = QVariant::fromValue(empty);
+    result[u"TMZ"_s] = QVariant::fromValue(empty);
+
+    auto QNH = GlobalObject::weatherDataProvider()->QNH();
+    if (!QNH.isFinite()) { return result; }
+
+    QVector<QPolygonF> polyA, polyCTR, polyR, polyRMZ, polyNRA, polyPJE, polyTMZ;
+
+    auto airspaces = GlobalObject::geoMapProvider()->airspaces();
+    QGeoRectangle const viewBBox(QList({geoCoordinates.constFirst(), geoCoordinates.constLast()}));
+
+    for (const auto& airspace : std::as_const(airspaces))
+    {
+        if (!airspaceCategories.contains(airspace.CAT())) { continue; }
+        if (!airspace.polygon().boundingGeoRectangle().intersects(viewBBox)) { continue; }
+
+        QList<QPointF> upper, lower;
+        auto airspacePolygon = airspace.polygon();
+
+        for (int i = 0; i < xCoordinates.size(); i++)
+        {
+            auto x = xCoordinates[i];
+            const auto& gc = geoCoordinates[i];
+            if ((i != xCoordinates.size()-1) && airspacePolygon.contains(gc))
+            {
+                auto u = airspace.estimatedUpperBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
+                auto l = airspace.estimatedLowerBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
+                if (l < u)
+                {
+                    upper << QPointF(x, altToY(u));
+                    lower << QPointF(x, altToY(l));
+                    continue;
+                }
+            }
+
+            if (!upper.isEmpty())
+            {
+                std::reverse(lower.begin(), lower.end());
+                QPolygonF poly(upper + lower);
+                poly << upper[0];
+
+                auto cat = airspace.CAT();
+                if (cat == u"A"_s || cat == u"B"_s || cat == u"C"_s || cat == u"D"_s) { polyA   << poly; }
+                if (cat == u"CTR"_s)                                                   { polyCTR << poly; }
+                if (cat == u"R"_s  || cat == u"P"_s  || cat == u"DNG"_s)              { polyR   << poly; }
+                if (cat == u"ATZ"_s|| cat == u"RMZ"_s|| cat == u"TIA"_s|| cat == u"TIZ"_s) { polyRMZ << poly; }
+                if (cat == u"NRA"_s)                                                   { polyNRA << poly; }
+                if (cat == u"PJE"_s|| cat == u"SUA"_s)                                { polyPJE << poly; }
+                if (cat == u"TMZ"_s)                                                   { polyTMZ << poly; }
+
+                upper.clear();
+                lower.clear();
+            }
+        }
+    }
+
+    result[u"A"_s]   = QVariant::fromValue(polyA);
+    result[u"CTR"_s] = QVariant::fromValue(polyCTR);
+    result[u"R"_s]   = QVariant::fromValue(polyR);
+    result[u"RMZ"_s] = QVariant::fromValue(polyRMZ);
+    result[u"NRA"_s] = QVariant::fromValue(polyNRA);
+    result[u"PJE"_s] = QVariant::fromValue(polyPJE);
+    result[u"TMZ"_s] = QVariant::fromValue(polyTMZ);
+    return result;
+}
+
+
+// ---------------------------------------------------------------------------
+// Mode::Track  — original logic, unchanged except extracted to own method
+// ---------------------------------------------------------------------------
+void Ui::SideviewQuickItem::updatePropertiesTrack()
+{
+    const QScopedPropertyUpdateGroup updateLock;
     //
     // Set all properties to default values. We update those depending on the data we have available.
     //
-    const QScopedPropertyUpdateGroup updateLock;
     m_fiveMinuteBar = {0, 0};
     m_ownshipPosition = {-100, -100};
     m_track = QString();
@@ -178,13 +298,14 @@ void Ui::SideviewQuickItem::updateProperties()
         }
     }
 
+    const double renderW = rw();
     //
     // Compute array of x-coordinates in pixels.
     //
     const int step = 4.0;
     QList<int> xCoordinates;
-    xCoordinates.reserve( qRound((width()+20)/step) );
-    for(int x = -10; x <= width()+10; x += step)
+    xCoordinates.reserve( qRound((renderW+20)/step) );
+    for(int x = -10; x <= renderW+10; x += step)
     {
         xCoordinates << x;
     }
@@ -196,7 +317,7 @@ void Ui::SideviewQuickItem::updateProperties()
     geoCoordinates.reserve(xCoordinates.size());
     for(auto x : std::as_const(xCoordinates))
     {
-        auto dist = 10000.0*(x-0.2*width())/(m_pixelPer10km.value());
+        auto dist = 10000.0*(x-0.2*renderW)/(m_pixelPer10km.value());
         auto geoCoordinate = ownshipCoordinate.atDistanceAndAzimuth(dist, ownshipTrack.toDEG());
         geoCoordinates << geoCoordinate;
     }
@@ -249,12 +370,16 @@ void Ui::SideviewQuickItem::updateProperties()
         return ((double)height())*(sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
     };
 
+    m_scaleMinAltFt  = sideview_minAlt.toFeet();
+    m_scaleMaxAltFt  = sideview_maxAlt.toFeet();
+    m_scaleTotalDistKm = 0.0;
+
     //
     // Compute graphics data
     //
 
     // Ownship position
-    m_ownshipPosition = {width()*0.2, altToYCoordinate(ownshipGeometricAltitude)};
+    m_ownshipPosition = {renderW*0.2, altToYCoordinate(ownshipGeometricAltitude)};
 
     // 5-Minute-Bar
     if (ownshipVSpeed.isFinite() && ownshipHSpeed.isFinite())
@@ -269,98 +394,247 @@ void Ui::SideviewQuickItem::updateProperties()
     {
         polygon << QPointF(xCoordinates[i], altToYCoordinate(elevations[i]));
     }
-    polygon  << QPointF(width(), height()+2000) << QPointF(-20, height()+2000);
+    polygon << QPointF(renderW, height()+2000) << QPointF(-20, height()+2000);
     m_terrain = polygon;
-    //qWarning() << "SideviewQuickItem terrain" << m_elapsedTimer.elapsed();
 
-    // Airspaces
-    auto airspaces = GlobalObject::geoMapProvider()->airspaces();
-    QVector<QPolygonF> airspacePolygonsA;
-    QVector<QPolygonF> airspacePolygonsCTR;
-    QVector<QPolygonF> airspacePolygonsR;
-    QVector<QPolygonF> airspacePolygonsRMZ;
-    QVector<QPolygonF> airspacePolygonsNRA;
-    QVector<QPolygonF> airspacePolygonsPJE;
-    QVector<QPolygonF> airspacePolygonsTMZ;
-    QList<QPointF> upper;
-    QList<QPointF> lower;
-    QGeoRectangle const viewBBox(QList({geoCoordinates.constFirst(), geoCoordinates.constLast()}));
-    for(const auto& airspace : std::as_const(airspaces))
+    m_airspaces = buildAirspacePolygons(xCoordinates, geoCoordinates, elevations,
+                                         ownshipGeometricAltitude, ownshipPressureAltitude, altToYCoordinate);
+}
+
+
+// ---------------------------------------------------------------------------
+// Mode::Route  — terrain/airspaces along the planned flight route
+// ---------------------------------------------------------------------------
+void Ui::SideviewQuickItem::updatePropertiesRoute()
+{
+    const QScopedPropertyUpdateGroup updateLock;
+    m_fiveMinuteBar   = {0, 0};
+    m_ownshipPosition = {-100, -100};
+    m_track           = QString();
+    m_error           = QString();
+    m_terrain         = QPolygonF();
+
+    const QVector<QPolygonF> empty;
+    QVariantMap newAirspaces;
+    newAirspaces[u"A"_s]   = QVariant::fromValue(empty);
+    newAirspaces[u"CTR"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"R"_s]   = QVariant::fromValue(empty);
+    newAirspaces[u"RMZ"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"NRA"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"PJE"_s] = QVariant::fromValue(empty);
+    newAirspaces[u"TMZ"_s] = QVariant::fromValue(empty);
+    m_airspaces = newAirspaces;
+
+    if (height() < 5.0) { return; }
+
+    // -----------------------------------------------------------------------
+    // 1. Get the planned route
+    // -----------------------------------------------------------------------
+    auto geoPath = GlobalObject::navigator()->flightRoute()->geoPath();
+    if (geoPath.size() < 2)
     {
-        if (!airspaceCategories.contains(airspace.CAT()))
-        {
-            continue;
-        }
-        auto bbox = airspace.polygon().boundingGeoRectangle();
-        if (!bbox.intersects(viewBBox))
-        {
-            continue;
-        }
+        m_error = tr("Unable to show side view: No flight route. Please plan a route first.");
+        return;
+    }
 
-        auto airspacePolygon = airspace.polygon();
-        for(int i=0; i < xCoordinates.size(); i++)
+    // -----------------------------------------------------------------------
+    // 2. Build cumulative distance table along the route polyline
+    //    cumulativeDist[i] = distance from geoPath[0] to geoPath[i], in metres
+    // -----------------------------------------------------------------------
+    QList<double> cumulativeDist;
+    cumulativeDist.reserve(geoPath.size());
+    cumulativeDist << 0.0;
+    for (qsizetype i = 1; i < geoPath.size(); i++)
+    {
+        cumulativeDist << cumulativeDist.last() + geoPath[i-1].distanceTo(geoPath[i]);
+    }
+    const double totalRouteLen = cumulativeDist.last();
+    if (totalRouteLen < 1.0)
+    {
+        m_error = tr("Unable to show side view: Flight route is too short.");
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Helper: given a distance along the route, return the QGeoCoordinate
+    //    by linear interpolation between the nearest waypoints.
+    // -----------------------------------------------------------------------
+    auto coordAtDist = [&](double distM) -> QGeoCoordinate
+    {
+        distM = qBound(0.0, distM, totalRouteLen);
+        // Find the leg that contains distM
+        qsizetype seg = 0;
+        for (qsizetype i = 1; i < cumulativeDist.size(); i++)
         {
-            auto x = xCoordinates[i];
-            const auto& geoCoordinate = geoCoordinates[i];
-            if ((i != xCoordinates.size()-1) && airspacePolygon.contains(geoCoordinate))
+            if (cumulativeDist[i] >= distM)
             {
-                auto u = airspace.estimatedUpperBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
-                auto l = airspace.estimatedLowerBoundMSL(elevations[i], QNH, ownshipGeometricAltitude, ownshipPressureAltitude);
-                if (l < u)
-                {
-                    upper << QPointF(x, altToYCoordinate(u));
-                    lower << QPointF(x, altToYCoordinate(l));
-                    continue;
-                }
+                seg = i - 1;
+                break;
             }
+            seg = i - 1; // last segment
+        }
+        double segLen = cumulativeDist[seg+1] - cumulativeDist[seg];
+        if (segLen < 0.01) { return geoPath[seg]; }
+        double t = (distM - cumulativeDist[seg]) / segLen;
+        double az = geoPath[seg].azimuthTo(geoPath[seg+1]);
+        return geoPath[seg].atDistanceAndAzimuth(t * segLen, az);
+    };
 
-            if (!upper.isEmpty())
+    // -----------------------------------------------------------------------
+    // 4. Sample the route at pixel resolution
+    //    Each pixel column x maps to a distance proportional along the route.
+    // -----------------------------------------------------------------------
+    const double renderW = rw();
+    const int step = 4;
+    QList<int> xCoordinates;
+    xCoordinates.reserve(qRound((renderW+20)/step));
+    for (int x = -10; x <= renderW+10; x += step) { xCoordinates << x; }
+
+    QList<QGeoCoordinate> geoCoordinates;
+    geoCoordinates.reserve(xCoordinates.size());
+    for (auto x : std::as_const(xCoordinates))
+    {
+        double fraction = (double)x / renderW;
+        geoCoordinates << coordAtDist(fraction * totalRouteLen);
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Sample terrain elevations
+    // -----------------------------------------------------------------------
+    QList<Units::Distance> elevations;
+    elevations.reserve(geoCoordinates.size());
+    Units::Distance minElevation = Units::Distance::fromM(0.0);
+    Units::Distance maxElevation = Units::Distance::fromM(0.0);
+    bool firstElev = true;
+    for (const auto& gc : std::as_const(geoCoordinates))
+    {
+        auto elev = GlobalObject::geoMapProvider()->terrainElevationAMSL(gc);
+        if (!elev.isFinite())
+        {
+            elev = Units::Distance::fromM(0.0);
+            m_error = tr("Incomplete terrain data. Please install the relevant terrain maps.");
+        }
+        elevations << elev;
+        if (firstElev) { minElevation = maxElevation = elev; firstElev = false; }
+        else { minElevation = qMin(minElevation, elev); maxElevation = qMax(maxElevation, elev); }
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Determine vertical extent of the view
+    //    Centre vertically around the terrain + a comfortable margin above.
+    // -----------------------------------------------------------------------
+    Units::Distance sideview_minAlt = minElevation - Units::Distance::fromFT(200);
+    Units::Distance sideview_maxAlt = maxElevation + Units::Distance::fromFT(4000);
+
+    auto altToY = [this, sideview_minAlt, sideview_maxAlt](Units::Distance alt) {
+        return ((double)height()) * (sideview_maxAlt - alt) / (sideview_maxAlt - sideview_minAlt);
+    };
+
+    m_scaleMinAltFt    = sideview_minAlt.toFeet();
+    m_scaleMaxAltFt    = sideview_maxAlt.toFeet();
+    m_scaleTotalDistKm = totalRouteLen / 1000.0;
+
+    // -----------------------------------------------------------------------
+    // 7. Terrain polygon
+    // -----------------------------------------------------------------------
+    QPolygonF polygon;
+    polygon.reserve(elevations.size() + 4);
+    for (qsizetype i = 0; i < elevations.size(); i++)
+    {
+        polygon << QPointF(xCoordinates[i], altToY(elevations[i]));
+    }
+    polygon << QPointF(renderW, height()+2000) << QPointF(-10, height()+2000);
+    m_terrain = polygon;
+
+    // -----------------------------------------------------------------------
+    // 8. Ownship position — project current GPS fix onto the route polyline
+    //    by finding the closest point along all legs.
+    // -----------------------------------------------------------------------
+    auto ownshipCoordinate = Positioning::PositionProvider::lastValidCoordinate();
+    auto ownshipGeometricAltitude = Units::Distance::fromM(0.0);
+    auto ownshipPressureAltitude  = Units::Distance::fromM(0.0);
+
+    if (ownshipCoordinate.isValid())
+    {
+        // Find the leg with minimum perpendicular distance to ownship
+        double bestDistM = std::numeric_limits<double>::max();
+        double bestAlongRouteM = 0.0;
+
+        for (qsizetype i = 0; i+1 < geoPath.size(); i++)
+        {
+            // Project ownship onto this leg segment
+            double legLen = geoPath[i].distanceTo(geoPath[i+1]);
+            if (legLen < 1.0) { continue; }
+
+            double az      = geoPath[i].azimuthTo(geoPath[i+1]);
+            double azOwn   = geoPath[i].azimuthTo(ownshipCoordinate);
+            double distFromStart = geoPath[i].distanceTo(ownshipCoordinate);
+            double angleDiff = (azOwn - az) * M_PI / 180.0;
+            double along = distFromStart * std::cos(angleDiff);
+            along = qBound(0.0, along, legLen);
+
+            QGeoCoordinate projected = geoPath[i].atDistanceAndAzimuth(along, az);
+            double perp = projected.distanceTo(ownshipCoordinate);
+
+            if (perp < bestDistM)
             {
-                std::reverse(lower.begin(), lower.end());
-                QPolygonF polygon(upper + lower);
-                polygon << upper[0];
-                if ((airspace.CAT() == u"A"_s) || (airspace.CAT() == u"B"_s) || (airspace.CAT() == u"C"_s) || (airspace.CAT() == u"D"_s))
-                {
-                    airspacePolygonsA << polygon;
-                }
-                if (airspace.CAT() == u"CTR"_s)
-                {
-                    airspacePolygonsCTR << polygon;
-                }
-                if ((airspace.CAT() == u"R"_s) || (airspace.CAT() == u"P"_s) || (airspace.CAT() == u"DNG"_s))
-                {
-                    airspacePolygonsR << polygon;
-                }
-                if ((airspace.CAT() == u"ATZ"_s) || (airspace.CAT() == u"RMZ"_s) || (airspace.CAT() == u"TIA"_s) || (airspace.CAT() == u"TIZ"_s))
-                {
-                    airspacePolygonsRMZ << polygon;
-                }
-                if (airspace.CAT() == u"NRA"_s)
-                {
-                    airspacePolygonsNRA << polygon;
-                }
-                if ((airspace.CAT() == u"PJE"_s) || (airspace.CAT() == u"SUA"_s))
-                {
-                    airspacePolygonsPJE << polygon;
-                }
-                if (airspace.CAT() == u"TMZ"_s)
-                {
-                    airspacePolygonsTMZ << polygon;
-                }
-                upper.clear();
-                lower.clear();
+                bestDistM = perp;
+                bestAlongRouteM = cumulativeDist[i] + along;
+            }
+        }
+
+        double ownX = (bestAlongRouteM / totalRouteLen) * renderW;
+
+        ownshipGeometricAltitude = Units::Distance::fromM(ownshipCoordinate.altitude());
+        if (!ownshipGeometricAltitude.isFinite()) { ownshipGeometricAltitude = minElevation; }
+
+        ownshipPressureAltitude = GlobalObject::positionProvider()->pressureAltitude();
+        if (!ownshipPressureAltitude.isFinite())
+        {
+            ownshipPressureAltitude = m_baroCache->estimatedPressureAltitude(ownshipGeometricAltitude);
+        }
+        if (!ownshipPressureAltitude.isFinite())
+        {
+            ownshipPressureAltitude = ownshipGeometricAltitude;
+            m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because barometric altitude information is not available. <a href='xx'>Click here</a> for more information.");
+        }
+
+        // Clamp to terrain
+        auto ownTerrainElev = GlobalObject::geoMapProvider()->terrainElevationAMSL(ownshipCoordinate);
+        if (ownTerrainElev.isFinite() && ownshipGeometricAltitude < ownTerrainElev)
+        {
+            ownshipGeometricAltitude = ownTerrainElev;
+        }
+
+        double ownY = altToY(ownshipGeometricAltitude);
+        m_ownshipPosition = {ownX, ownY};
+
+        // 5-minute bar: use current speed/vspeed projected along the route
+        auto posInfo = GlobalObject::positionProvider()->positionInfo();
+        if (posInfo.isValid())
+        {
+            auto hSpeed = posInfo.groundSpeed();
+            auto vSpeed = posInfo.verticalSpeed();
+            if (hSpeed.isFinite() && hSpeed >= Units::Speed::fromKN(10) && vSpeed.isFinite())
+            {
+                double dxPixels = (hSpeed.toMPS() * 5.0 * 60.0 / totalRouteLen) * renderW;
+                double dyPixels = -height() * vSpeed.toFPM() * 5.0 / (sideview_maxAlt - sideview_minAlt).toFeet();
+                m_fiveMinuteBar = {dxPixels, dyPixels};
             }
         }
     }
 
-    newAirspaces[u"A"_s] = QVariant::fromValue(airspacePolygonsA);
-    newAirspaces[u"CTR"_s] = QVariant::fromValue(airspacePolygonsCTR);
-    newAirspaces[u"R"_s] = QVariant::fromValue(airspacePolygonsR);
-    newAirspaces[u"RMZ"_s] = QVariant::fromValue(airspacePolygonsRMZ);
-    newAirspaces[u"NRA"_s] = QVariant::fromValue(airspacePolygonsNRA);
-    newAirspaces[u"PJE"_s] = QVariant::fromValue(airspacePolygonsPJE);
-    newAirspaces[u"TMZ"_s] = QVariant::fromValue(airspacePolygonsTMZ);
-
-    m_airspaces = newAirspaces;
-    //qWarning() << "SideviewQuickItem full" << m_elapsedTimer.elapsed();
+    // -----------------------------------------------------------------------
+    // 9. Airspace polygons
+    // -----------------------------------------------------------------------
+    if (!GlobalObject::weatherDataProvider()->QNH().isFinite())
+    {
+        m_error = tr("Unable to compute sufficiently precise vertical airspace boundaries because the QNH is not available. Please wait while QNH information is downloaded from the internet.");
+        // Still show terrain — don't return early
+    }
+    else
+    {
+        m_airspaces = buildAirspacePolygons(xCoordinates, geoCoordinates, elevations,
+                                             ownshipGeometricAltitude, ownshipPressureAltitude, altToY);
+    }
 }

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -23,6 +23,9 @@
 #include "SideviewQuickItem.h"
 #include "navigation/Navigator.h"
 #include "weather/WeatherDataProvider.h"
+#include "weather/WindFieldProvider.h"
+
+#include <QtMath>
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -51,6 +54,9 @@ Ui::SideviewQuickItem::SideviewQuickItem(QQuickItem *parent)
         if (m_mode == Mode::Route) { updateProperties(); }
     }));
     connect(GlobalObject::navigator()->flightRoute(), &Navigation::FlightRoute::plannedAltitudesChanged, this, [this]() {
+        if (m_mode == Mode::Route) { updateProperties(); }
+    });
+    connect(Weather::WindFieldProvider::instance(), &Weather::WindFieldProvider::dataChanged, this, [this]() {
         if (m_mode == Mode::Route) { updateProperties(); }
     });
 
@@ -195,6 +201,7 @@ void Ui::SideviewQuickItem::updatePropertiesTrack()
     m_terrain = QPolygonF();
     m_plannedProfile = QPolygonF();
     m_plannedProfilePoints = QVariantList();
+    m_windProfile = QVariantList();
 
     QVariantMap newAirspaces;
     const QVector<QPolygonF> empty;
@@ -420,6 +427,7 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     m_terrain         = QPolygonF();
     m_plannedProfile  = QPolygonF();
     m_plannedProfilePoints = QVariantList();
+    m_windProfile     = QVariantList();
 
     const QVector<QPolygonF> empty;
     QVariantMap newAirspaces;
@@ -579,6 +587,81 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     }
     m_plannedProfile = profile;
     m_plannedProfilePoints = profilePoints;
+
+    // -----------------------------------------------------------------------
+    // 6c. Wind barbs projected onto the route profile: sample the wind field
+    //     along the route at the planned altitude and project onto the track.
+    // -----------------------------------------------------------------------
+    {
+        const auto* wfp = Weather::WindFieldProvider::instance();
+        const bool haveField = wfp->isUsable();
+        const Weather::Wind manualWind = GlobalObject::navigator()->wind();
+        const bool haveManual = manualWind.speed().isFinite() && manualWind.directionFrom().isFinite();
+
+        // Planned altitude (metres) at a distance along the route
+        auto plannedAltAtDist = [&](double distM) -> Units::Distance {
+            qsizetype seg = 0;
+            for (qsizetype i = 1; i < cumulativeDist.size(); i++)
+            {
+                if (cumulativeDist[i] >= distM) { seg = i - 1; break; }
+                seg = i - 1;
+            }
+            if (seg + 1 >= plannedAlts.size()) { return plannedAlts.isEmpty() ? Units::Distance() : plannedAlts.last(); }
+            const double segLen = cumulativeDist[seg+1] - cumulativeDist[seg];
+            const double t = (segLen > 0.01) ? (distM - cumulativeDist[seg]) / segLen : 0.0;
+            return plannedAlts[seg] + (plannedAlts[seg+1] - plannedAlts[seg]) * qBound(0.0, t, 1.0);
+        };
+
+        QVariantList windPts;
+        if ((haveField || haveManual) && (totalRouteLen > 1.0))
+        {
+            // One sample roughly every 80 px, clamped to a sane count
+            const int nSamples = qBound(3, int(renderW / 80.0), 16);
+            const QDateTime now = QDateTime::currentDateTimeUtc();
+            for (int s = 0; s < nSamples; s++)
+            {
+                const double frac = (s + 0.5) / nSamples;
+                const double distM = frac * totalRouteLen;
+                const auto coord = coordAtDist(distM);
+                const auto alt = plannedAltAtDist(distM);
+
+                Weather::Wind w = haveField
+                    ? wfp->windAt(coord.latitude(), coord.longitude(), alt.toFeet(), now)
+                    : Weather::Wind();
+                if (!w.speed().isFinite() || !w.directionFrom().isFinite())
+                {
+                    w = manualWind;
+                }
+                if (!w.speed().isFinite() || !w.directionFrom().isFinite())
+                {
+                    continue;
+                }
+
+                // Track azimuth at this distance
+                qsizetype seg = 0;
+                for (qsizetype i = 1; i < cumulativeDist.size(); i++)
+                {
+                    if (cumulativeDist[i] >= distM) { seg = i - 1; break; }
+                    seg = i - 1;
+                }
+                const double trackDeg = geoPath[seg].azimuthTo(geoPath[qMin(seg+1, geoPath.size()-1)]);
+
+                const double spdKn = w.speed().toKN();
+                const double dirDeg = w.directionFrom().toDEG();
+                // Headwind component (+) = wind blowing from ahead along the track
+                const double alongKn = spdKn * qCos(qDegreesToRadians(dirDeg - trackDeg));
+
+                QVariantMap m;
+                m[QStringLiteral("x")]          = frac * renderW;
+                m[QStringLiteral("y")]          = altToY(alt);
+                m[QStringLiteral("speedKn")]    = spdKn;
+                m[QStringLiteral("dirFromDeg")] = dirDeg;
+                m[QStringLiteral("alongKn")]    = alongKn;
+                windPts << m;
+            }
+        }
+        m_windProfile = windPts;
+    }
 
     // -----------------------------------------------------------------------
     // 7. Terrain polygon

--- a/src/ui/SideviewQuickItem.cpp
+++ b/src/ui/SideviewQuickItem.cpp
@@ -71,6 +71,14 @@ void Ui::SideviewQuickItem::setMode(Mode newMode)
     updateProperties();
 }
 
+void Ui::SideviewQuickItem::setShowWind(bool newShowWind)
+{
+    if (m_showWind == newShowWind) { return; }
+    m_showWind = newShowWind;
+    emit showWindChanged();
+    updateProperties();
+}
+
 void Ui::SideviewQuickItem::updateProperties()
 {
     // Rate-limiting code. Ensure that this expensive method runs at most every minimumUpdateInterval_ms and not more often.
@@ -589,8 +597,9 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
     m_plannedProfilePoints = profilePoints;
 
     // -----------------------------------------------------------------------
-    // 6c. Wind barbs projected onto the route profile: sample the wind field
-    //     along the route at the planned altitude and project onto the track.
+    // 6c. Wind barbs projected onto the route profile (when enabled): sample
+    //     the field on a grid of distance × altitude and project onto the
+    //     track. Altitude rows span the visible Y range.
     // -----------------------------------------------------------------------
     {
         const auto* wfp = Weather::WindFieldProvider::instance();
@@ -598,44 +607,18 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
         const Weather::Wind manualWind = GlobalObject::navigator()->wind();
         const bool haveManual = manualWind.speed().isFinite() && manualWind.directionFrom().isFinite();
 
-        // Planned altitude (metres) at a distance along the route
-        auto plannedAltAtDist = [&](double distM) -> Units::Distance {
-            qsizetype seg = 0;
-            for (qsizetype i = 1; i < cumulativeDist.size(); i++)
-            {
-                if (cumulativeDist[i] >= distM) { seg = i - 1; break; }
-                seg = i - 1;
-            }
-            if (seg + 1 >= plannedAlts.size()) { return plannedAlts.isEmpty() ? Units::Distance() : plannedAlts.last(); }
-            const double segLen = cumulativeDist[seg+1] - cumulativeDist[seg];
-            const double t = (segLen > 0.01) ? (distM - cumulativeDist[seg]) / segLen : 0.0;
-            return plannedAlts[seg] + (plannedAlts[seg+1] - plannedAlts[seg]) * qBound(0.0, t, 1.0);
-        };
-
         QVariantList windPts;
-        if ((haveField || haveManual) && (totalRouteLen > 1.0))
+        if (m_showWind && (haveField || haveManual) && (totalRouteLen > 1.0))
         {
-            // One sample roughly every 80 px, clamped to a sane count
-            const int nSamples = qBound(3, int(renderW / 80.0), 16);
+            const int nCols = qBound(3, int(renderW / 90.0), 14);
+            const int nRows = 5; // altitude rows across the visible range
             const QDateTime now = QDateTime::currentDateTimeUtc();
-            for (int s = 0; s < nSamples; s++)
+
+            for (int c = 0; c < nCols; c++)
             {
-                const double frac = (s + 0.5) / nSamples;
+                const double frac = (c + 0.5) / nCols;
                 const double distM = frac * totalRouteLen;
                 const auto coord = coordAtDist(distM);
-                const auto alt = plannedAltAtDist(distM);
-
-                Weather::Wind w = haveField
-                    ? wfp->windAt(coord.latitude(), coord.longitude(), alt.toFeet(), now)
-                    : Weather::Wind();
-                if (!w.speed().isFinite() || !w.directionFrom().isFinite())
-                {
-                    w = manualWind;
-                }
-                if (!w.speed().isFinite() || !w.directionFrom().isFinite())
-                {
-                    continue;
-                }
 
                 // Track azimuth at this distance
                 qsizetype seg = 0;
@@ -646,18 +629,36 @@ void Ui::SideviewQuickItem::updatePropertiesRoute()
                 }
                 const double trackDeg = geoPath[seg].azimuthTo(geoPath[qMin(seg+1, geoPath.size()-1)]);
 
-                const double spdKn = w.speed().toKN();
-                const double dirDeg = w.directionFrom().toDEG();
-                // Headwind component (+) = wind blowing from ahead along the track
-                const double alongKn = spdKn * qCos(qDegreesToRadians(dirDeg - trackDeg));
+                for (int rrow = 0; rrow < nRows; rrow++)
+                {
+                    const Units::Distance alt = sideview_minAlt
+                        + (sideview_maxAlt - sideview_minAlt) * ((rrow + 0.5) / nRows);
 
-                QVariantMap m;
-                m[QStringLiteral("x")]          = frac * renderW;
-                m[QStringLiteral("y")]          = altToY(alt);
-                m[QStringLiteral("speedKn")]    = spdKn;
-                m[QStringLiteral("dirFromDeg")] = dirDeg;
-                m[QStringLiteral("alongKn")]    = alongKn;
-                windPts << m;
+                    Weather::Wind w = haveField
+                        ? wfp->windAt(coord.latitude(), coord.longitude(), alt.toFeet(), now)
+                        : Weather::Wind();
+                    if (!w.speed().isFinite() || !w.directionFrom().isFinite())
+                    {
+                        w = manualWind;
+                    }
+                    if (!w.speed().isFinite() || !w.directionFrom().isFinite())
+                    {
+                        continue;
+                    }
+
+                    const double spdKn = w.speed().toKN();
+                    const double dirDeg = w.directionFrom().toDEG();
+                    // Headwind component (+) = wind blowing from ahead along the track
+                    const double alongKn = spdKn * qCos(qDegreesToRadians(dirDeg - trackDeg));
+
+                    QVariantMap m;
+                    m[QStringLiteral("x")]          = frac * renderW;
+                    m[QStringLiteral("y")]          = altToY(alt);
+                    m[QStringLiteral("speedKn")]    = spdKn;
+                    m[QStringLiteral("dirFromDeg")] = dirDeg;
+                    m[QStringLiteral("alongKn")]    = alongKn;
+                    windPts << m;
+                }
             }
         }
         m_windProfile = windPts;

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -42,6 +42,14 @@ class SideviewQuickItem : public QQuickItem
     QML_NAMED_ELEMENT(SideviewQuickItem)
 
 public:
+
+    /*! \brief Display mode for the side view */
+    enum class Mode {
+        Track, /*!< Show terrain/airspaces along current position and track (default) */
+        Route  /*!< Show terrain/airspaces along the planned flight route */
+    };
+    Q_ENUM(Mode)
+
     explicit SideviewQuickItem(QQuickItem *parent = nullptr);
 
     ~SideviewQuickItem() override = default;
@@ -83,6 +91,16 @@ public:
      */
     Q_PROPERTY(QPointF fiveMinuteBar READ fiveMinuteBar BINDABLE bindableFiveMinuteBar)
 
+    /*! \brief Display mode
+     *
+     * Controls whether the side view is computed along the current track
+     * (Mode::Track, default) or along the planned flight route (Mode::Route).
+     * In Route mode the ownship marker is placed at the aircraft's projected
+     * position along the route; the horizontal extent of the view covers the
+     * full route from first to last waypoint.
+     */
+    Q_PROPERTY(Mode mode READ mode WRITE setMode NOTIFY modeChanged)
+
     /*! \brief Position of the own aircraft
      *
      * This property holds the position of the own aircraft, in pixel
@@ -96,6 +114,22 @@ public:
      * flightmap in order to synchronize the scales.
      */
     Q_PROPERTY(double pixelPer10km READ pixelPer10km WRITE setPixelPer10km BINDABLE bindablePixelPer10km REQUIRED)
+
+    /*! \brief Width (in pixels) used for horizontal coordinate computation.
+     *
+     * Set this to the Flickable contentWidth to enable horizontal scrolling.
+     * When ≤ 0 the item's own width() is used instead.
+     */
+    Q_PROPERTY(double renderWidth READ renderWidth WRITE setRenderWidth NOTIFY renderWidthChanged)
+
+    /*! \brief Maximum altitude shown on the Y axis, in feet */
+    Q_PROPERTY(double scaleMaxAltFt READ scaleMaxAltFt NOTIFY scaleRangeChanged)
+
+    /*! \brief Minimum altitude shown on the Y axis, in feet */
+    Q_PROPERTY(double scaleMinAltFt READ scaleMinAltFt NOTIFY scaleRangeChanged)
+
+    /*! \brief Total route length shown on the X axis, in kilometres (0 in Track mode) */
+    Q_PROPERTY(double scaleTotalDistKm READ scaleTotalDistKm NOTIFY scaleRangeChanged)
 
     /*! \brief Terrain polygons
      *
@@ -153,6 +187,9 @@ public:
      */
     QBindable<QPointF> bindableFiveMinuteBar() const {return &m_fiveMinuteBar;}
 
+    Mode mode() const { return m_mode; }
+    void setMode(Mode newMode);
+
     /*! \brief Getter method for property with the same name
      *
      *  @returns Property ownshipPosition
@@ -183,6 +220,13 @@ public:
      */
     void setPixelPer10km(double newVal) {m_pixelPer10km = newVal;}
 
+    double renderWidth() const { auto v = m_renderWidth.value(); return v > 0 ? v : width(); }
+    void setRenderWidth(double v) { m_renderWidth = v; }
+
+    double scaleMaxAltFt() const { return m_scaleMaxAltFt.value(); }
+    double scaleMinAltFt() const { return m_scaleMinAltFt.value(); }
+    double scaleTotalDistKm() const { return m_scaleTotalDistKm.value(); }
+
     /*! \brief Getter method for property with the same name
      *
      *  @returns Property track
@@ -207,6 +251,10 @@ public:
      */
     QBindable<QPolygonF> bindableTerrain() const {return &m_terrain;}
 
+signals:
+    void modeChanged();
+    void renderWidthChanged();
+    void scaleRangeChanged();
 
 private:
     Q_DISABLE_COPY_MOVE(SideviewQuickItem)
@@ -219,7 +267,25 @@ private:
 
     // Compute
     void updateProperties();
+    void updatePropertiesTrack();
+    void updatePropertiesRoute();
 
+    // Returns renderWidth if set, else actual item width.
+    double rw() const { auto v = m_renderWidth.value(); return v > 0 ? v : width(); }
+
+    // Shared helper: build airspace polygons along a sampled geo-path.
+    // xCoordinates and geoCoordinates must be the same length.
+    // elevations must be the same length.
+    // Returns a QVariantMap with the same keys as m_airspaces.
+    QVariantMap buildAirspacePolygons(
+        const QList<int>& xCoordinates,
+        const QList<QGeoCoordinate>& geoCoordinates,
+        const QList<Units::Distance>& elevations,
+        Units::Distance ownshipGeometricAltitude,
+        Units::Distance ownshipPressureAltitude,
+        std::function<double(Units::Distance)> altToY);
+
+    Mode m_mode {Mode::Track};
 
     QProperty<QString> m_error;
 
@@ -235,10 +301,15 @@ private:
 
     QProperty<QVariantMap> m_airspaces;
 
+    QProperty<double> m_renderWidth   {0.0};
+    QProperty<double> m_scaleMaxAltFt {0.0};
+    QProperty<double> m_scaleMinAltFt {0.0};
+    QProperty<double> m_scaleTotalDistKm {0.0};
+
     Navigation::BaroCache* m_baroCache;
 
     std::vector<QPropertyNotifier> notifiers;
-
+    
 };
 
 } // namespace Ui

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -165,6 +165,9 @@ public:
      */
     Q_PROPERTY(QVariantList windProfile READ windProfile BINDABLE bindableWindProfile)
 
+    /*! \brief Whether to compute and show the projected wind barbs (route mode) */
+    Q_PROPERTY(bool showWind READ showWind WRITE setShowWind NOTIFY showWindChanged)
+
     /*! \brief Track string
      *
      * If the own aircraft is not moving sufficiently fast, this property holds
@@ -314,10 +317,17 @@ public:
      */
     QBindable<QVariantList> bindableWindProfile() const {return &m_windProfile;}
 
+    /*! \brief Getter for property showWind */
+    bool showWind() const {return m_showWind;}
+
+    /*! \brief Setter for property showWind */
+    void setShowWind(bool newShowWind);
+
 signals:
     void modeChanged();
     void renderWidthChanged();
     void scaleRangeChanged();
+    void showWindChanged();
 
 private:
     Q_DISABLE_COPY_MOVE(SideviewQuickItem)
@@ -366,6 +376,7 @@ private:
 
     QProperty<QVariantList> m_plannedProfilePoints;
     QProperty<QVariantList> m_windProfile;
+    bool m_showWind {false};
 
     QProperty<QVariantMap> m_airspaces;
 

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -154,6 +154,17 @@ public:
      */
     Q_PROPERTY(QVariantList plannedProfilePoints READ plannedProfilePoints BINDABLE bindablePlannedProfilePoints)
 
+    /*! \brief Wind barbs projected onto the route profile (route mode only)
+     *
+     * A QVariantList of maps, sampled along the route at the planned altitude:
+     *   "x", "y"          pixel position on the profile
+     *   "speedKn"         total wind speed (kt)
+     *   "dirFromDeg"      wind direction (° from)
+     *   "alongKn"         along-track component (kt, + = headwind, − = tailwind)
+     * Empty in Track mode or when no wind data is available.
+     */
+    Q_PROPERTY(QVariantList windProfile READ windProfile BINDABLE bindableWindProfile)
+
     /*! \brief Track string
      *
      * If the own aircraft is not moving sufficiently fast, this property holds
@@ -291,6 +302,18 @@ public:
      */
     QBindable<QVariantList> bindablePlannedProfilePoints() const {return &m_plannedProfilePoints;}
 
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property windProfile
+     */
+    QVariantList windProfile() const {return m_windProfile.value();}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property windProfile
+     */
+    QBindable<QVariantList> bindableWindProfile() const {return &m_windProfile;}
+
 signals:
     void modeChanged();
     void renderWidthChanged();
@@ -342,6 +365,7 @@ private:
     QProperty<QPolygonF> m_plannedProfile;
 
     QProperty<QVariantList> m_plannedProfilePoints;
+    QProperty<QVariantList> m_windProfile;
 
     QProperty<QVariantMap> m_airspaces;
 

--- a/src/ui/SideviewQuickItem.h
+++ b/src/ui/SideviewQuickItem.h
@@ -138,6 +138,22 @@ public:
      */
     Q_PROPERTY(QPolygonF terrain READ terrain BINDABLE bindableTerrain)
 
+    /*! \brief Planned altitude profile (route mode only)
+     *
+     * A polyline of (x, y) points in content-pixel coordinates, one point per
+     * route waypoint, representing the planned cruise altitude. Used to draw the
+     * profile line. Empty in Track mode.
+     */
+    Q_PROPERTY(QPolygonF plannedProfile READ plannedProfile BINDABLE bindablePlannedProfile)
+
+    /*! \brief Planned altitude profile points, as a list (route mode only)
+     *
+     * The same points as plannedProfile, but as a QVariantList of QPointF so
+     * that a QML Repeater can iterate them to place the clickable altitude
+     * markers. Empty in Track mode.
+     */
+    Q_PROPERTY(QVariantList plannedProfilePoints READ plannedProfilePoints BINDABLE bindablePlannedProfilePoints)
+
     /*! \brief Track string
      *
      * If the own aircraft is not moving sufficiently fast, this property holds
@@ -251,6 +267,30 @@ public:
      */
     QBindable<QPolygonF> bindableTerrain() const {return &m_terrain;}
 
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfile
+     */
+    QPolygonF plannedProfile() const {return m_plannedProfile.value();}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfile
+     */
+    QBindable<QPolygonF> bindablePlannedProfile() const {return &m_plannedProfile;}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfilePoints
+     */
+    QVariantList plannedProfilePoints() const {return m_plannedProfilePoints.value();}
+
+    /*! \brief Getter method for property with the same name
+     *
+     *  @returns Property plannedProfilePoints
+     */
+    QBindable<QVariantList> bindablePlannedProfilePoints() const {return &m_plannedProfilePoints;}
+
 signals:
     void modeChanged();
     void renderWidthChanged();
@@ -298,6 +338,10 @@ private:
     QProperty<QPointF> m_fiveMinuteBar;
 
     QProperty<QPolygonF> m_terrain;
+
+    QProperty<QPolygonF> m_plannedProfile;
+
+    QProperty<QVariantList> m_plannedProfilePoints;
 
     QProperty<QVariantMap> m_airspaces;
 

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -48,6 +48,10 @@ static const QRegularExpression re_wind(
 Weather::ForecastMapProvider::ForecastMapProvider(QObject* parent)
     : QObject(parent)
 {
+    // Default colors match config.py LAYER_META (Qt #AARRGGBB format)
+    m_rainColors      = {u"#9900B2E6"_s, u"#990000CC"_s, u"#9900CC00"_s, u"#9900CCCC"_s};
+    m_cloudbaseColors = {u"#40404040"_s, u"#40808080"_s, u"#40BFBFBF"_s, u"#00FFFFFF"_s};
+
     QSettings s;
     m_serverUrl       = s.value(u"ForecastMapProvider/serverUrl"_s).toString();
     m_lastRefreshTime = s.value(u"ForecastMapProvider/lastRefreshTime"_s).toDateTime();

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -81,6 +81,29 @@ void Weather::ForecastMapProvider::refresh()
         setStatus(Status::Error);
         return;
     }
+
+    // Local directory mode: file:///path/to/generated_maps
+    const QUrl url(m_serverUrl);
+    if (url.isLocalFile()) {
+        setStatus(Status::Refreshing);
+        m_localScanDir = url.toLocalFile();
+
+        // Parse index.json from the local directory if present
+        QFile idxFile(m_localScanDir + u"/index.json"_s);
+        if (idxFile.open(QIODevice::ReadOnly)) {
+            const auto doc = QJsonDocument::fromJson(idxFile.readAll());
+            if (doc.isObject())
+                parseMetadata(doc.object());
+        }
+
+        m_lastRefreshTime = QDateTime::currentDateTimeUtc();
+        QSettings().setValue(u"ForecastMapProvider/lastRefreshTime"_s, m_lastRefreshTime);
+        setStatus(Status::Idle);
+        emit lastRefreshLabelChanged();
+        scan();
+        return;
+    }
+
     setStatus(Status::Refreshing);
     fetchIndex();
 }
@@ -108,9 +131,13 @@ void Weather::ForecastMapProvider::fetchIndex()
             return;
         }
 
+        const auto root = doc.object();
+
         QStringList serverFiles;
-        for (const auto& v : doc.object()[u"files"_s].toArray())
+        for (const auto& v : root[u"files"_s].toArray())
             serverFiles << v.toString();
+
+        parseMetadata(root);
 
         // Only download files not already in cache
         const QDir dir(cacheDir());
@@ -202,6 +229,47 @@ void Weather::ForecastMapProvider::abortRefresh()
 
 
 // ---------------------------------------------------------------------------
+// Metadata parsing
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::parseMetadata(const QJsonObject& root)
+{
+    m_referenceTime = root[u"reference_time"_s].toString();
+
+    const auto layers = root[u"layers"_s].toObject();
+
+    auto readColors = [](const QJsonObject& layer) {
+        QStringList out;
+        for (const auto& v : layer[u"colors"_s].toArray())
+            out << v.toString();
+        return out;
+    };
+
+    const auto rain = layers[u"rain"_s].toObject();
+    if (!rain.isEmpty()) {
+        m_rainUnits  = rain[u"units"_s].toString(m_rainUnits);
+        m_rainVmin   = rain[u"vmin"_s].toDouble(m_rainVmin);
+        m_rainVmax   = rain[u"vmax"_s].toDouble(m_rainVmax);
+        m_rainColors = readColors(rain);
+    }
+
+    const auto cb = layers[u"cloudbase"_s].toObject();
+    if (!cb.isEmpty()) {
+        m_cloudbaseUnits  = cb[u"units"_s].toString(m_cloudbaseUnits);
+        m_cloudbaseVmin   = cb[u"vmin"_s].toDouble(m_cloudbaseVmin);
+        m_cloudbaseVmax   = cb[u"vmax"_s].toDouble(m_cloudbaseVmax);
+        m_cloudbaseColors = readColors(cb);
+    }
+
+    const auto wind = layers[u"wind"_s].toObject();
+    if (!wind.isEmpty())
+        m_windUnits = wind[u"units"_s].toString(m_windUnits);
+
+    emit metadataChanged();
+}
+
+
+// ---------------------------------------------------------------------------
 // Directory scan
 // ---------------------------------------------------------------------------
 
@@ -211,7 +279,7 @@ void Weather::ForecastMapProvider::scan()
     m_cloudbaseMaps.clear();
     m_windMaps.clear();
 
-    const QDir dir(cacheDir());
+    const QDir dir(m_localScanDir.isEmpty() ? cacheDir() : m_localScanDir);
     for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files)) {
         auto m = re_rain.match(name);
         if (m.hasMatch()) {
@@ -270,6 +338,8 @@ void Weather::ForecastMapProvider::setServerUrl(const QString& url)
 {
     if (m_serverUrl == url) return;
     m_serverUrl = url;
+    if (!QUrl(url).isLocalFile())
+        m_localScanDir.clear();
     QSettings().setValue(u"ForecastMapProvider/serverUrl"_s, url);
     emit serverUrlChanged();
 }
@@ -294,6 +364,16 @@ void Weather::ForecastMapProvider::setCurrentWindPressureLevel(const QString& le
 // ---------------------------------------------------------------------------
 // Getters
 // ---------------------------------------------------------------------------
+
+QString Weather::ForecastMapProvider::referenceTimeLabel() const
+{
+    if (m_referenceTime.isEmpty())
+        return {};
+    const auto dt = QDateTime::fromString(m_referenceTime, Qt::ISODate);
+    if (!dt.isValid())
+        return m_referenceTime;
+    return dt.toUTC().toString(u"ddd dd MMM HH:mm"_s) + u" UTC"_s;
+}
 
 QString Weather::ForecastMapProvider::lastRefreshLabel() const
 {

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -376,7 +376,7 @@ QString Weather::ForecastMapProvider::referenceTimeLabel() const
     const auto dt = QDateTime::fromString(m_referenceTime, Qt::ISODate);
     if (!dt.isValid())
         return m_referenceTime;
-    return dt.toUTC().toString(u"ddd dd MMM HH:mm"_s) + u" UTC"_s;
+    return dt.toUTC().toString(u"dd MMM HH:mm'Z'"_s);
 }
 
 QString Weather::ForecastMapProvider::lastRefreshLabel() const

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -310,10 +310,10 @@ void Weather::ForecastMapProvider::scan()
     m_timestamps = tsSet.values();
     m_timestamps.sort();
 
-    // Wind pressure levels sorted ascending (700 first = highest altitude)
+    // Wind pressure levels sorted descending (1000 first = FL000 on left of slider)
     QStringList levels = m_windMaps.keys();
     std::sort(levels.begin(), levels.end(),
-              [](const QString& a, const QString& b) { return a.toDouble() < b.toDouble(); });
+              [](const QString& a, const QString& b) { return a.toDouble() > b.toDouble(); });
     m_windPressureLevels = levels;
 
     if (m_currentWindPressureLevel.isEmpty() && !levels.isEmpty())

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -37,8 +37,6 @@ static const QRegularExpression re_rain(
     u"^rain_map_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
 static const QRegularExpression re_cloudbase(
     u"^cloudbase_map_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
-static const QRegularExpression re_wind(
-    u"^wind_map_(\\d+(?:\\.\\d+)?)hPa_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
 
 
 // ---------------------------------------------------------------------------
@@ -273,10 +271,6 @@ void Weather::ForecastMapProvider::parseMetadata(const QJsonObject& root)
         m_cloudbaseColors = readColors(cb);
     }
 
-    const auto wind = layers[u"wind"_s].toObject();
-    if (!wind.isEmpty())
-        m_windUnits = wind[u"units"_s].toString(m_windUnits);
-
     emit metadataChanged();
 }
 
@@ -289,7 +283,6 @@ void Weather::ForecastMapProvider::scan()
 {
     m_rainMaps.clear();
     m_cloudbaseMaps.clear();
-    m_windMaps.clear();
 
     const QDir dir(m_localScanDir.isEmpty() ? cacheDir() : m_localScanDir);
     for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files)) {
@@ -301,37 +294,21 @@ void Weather::ForecastMapProvider::scan()
         m = re_cloudbase.match(name);
         if (m.hasMatch()) {
             m_cloudbaseMaps[m.captured(1)] = dir.absoluteFilePath(name);
-            continue;
         }
-        m = re_wind.match(name);
-        if (m.hasMatch())
-            m_windMaps[m.captured(1)][m.captured(2)] = dir.absoluteFilePath(name);
     }
 
     // Union of all timestamps across all map types
     QSet<QString> tsSet;
     for (const auto& k : m_rainMaps.keys())      tsSet << k;
     for (const auto& k : m_cloudbaseMaps.keys()) tsSet << k;
-    for (const auto& level : std::as_const(m_windMaps))
-        for (const auto& k : level.keys())       tsSet << k;
 
     m_timestamps = tsSet.values();
     m_timestamps.sort();
-
-    // Wind pressure levels sorted descending (1000 first = FL000 on left of slider)
-    QStringList levels = m_windMaps.keys();
-    std::sort(levels.begin(), levels.end(),
-              [](const QString& a, const QString& b) { return a.toDouble() > b.toDouble(); });
-    m_windPressureLevels = levels;
-
-    if (m_currentWindPressureLevel.isEmpty() && !levels.isEmpty())
-        m_currentWindPressureLevel = levels.first();
 
     m_currentIndex = qBound(0, m_currentIndex, qMax(0, int(m_timestamps.size()) - 1));
 
     emit timestampsChanged();
     emit currentIndexChanged();
-    emit currentWindMapChanged();
 }
 
 
@@ -362,14 +339,6 @@ void Weather::ForecastMapProvider::setCurrentIndex(int idx)
     if (m_currentIndex == idx) return;
     m_currentIndex = idx;
     emit currentIndexChanged();
-    emit currentWindMapChanged();
-}
-
-void Weather::ForecastMapProvider::setCurrentWindPressureLevel(const QString& level)
-{
-    if (m_currentWindPressureLevel == level) return;
-    m_currentWindPressureLevel = level;
-    emit currentWindMapChanged();
 }
 
 
@@ -415,11 +384,4 @@ QString Weather::ForecastMapProvider::currentCloudbaseMap() const
 {
     if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
     return m_cloudbaseMaps.value(m_timestamps[m_currentIndex]);
-}
-
-QString Weather::ForecastMapProvider::currentWindMap() const
-{
-    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()
-            || m_currentWindPressureLevel.isEmpty()) return {};
-    return m_windMaps.value(m_currentWindPressureLevel).value(m_timestamps[m_currentIndex]);
 }

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -64,7 +64,7 @@ Weather::ForecastMapProvider* Weather::ForecastMapProvider::create(QQmlEngine*, 
 
 QString Weather::ForecastMapProvider::cacheDir() const
 {
-    return QStandardPaths::writableLocation(QStandardPaths::AppCacheLocation)
+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
            + u"/meteo_france"_s;
 }
 

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -1,0 +1,333 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Quentin Bossard                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "weather/ForecastMapProvider.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QRegularExpression>
+#include <QSet>
+#include <QSettings>
+#include <QStandardPaths>
+
+using namespace Qt::Literals::StringLiterals;
+
+static const QRegularExpression re_rain(
+    u"^rain_map_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
+static const QRegularExpression re_cloudbase(
+    u"^cloudbase_map_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
+static const QRegularExpression re_wind(
+    u"^wind_map_(\\d+(?:\\.\\d+)?)hPa_(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?)\\.png$"_s);
+
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+Weather::ForecastMapProvider::ForecastMapProvider(QObject* parent)
+    : QObject(parent)
+{
+    QSettings s;
+    m_serverUrl       = s.value(u"ForecastMapProvider/serverUrl"_s).toString();
+    m_lastRefreshTime = s.value(u"ForecastMapProvider/lastRefreshTime"_s).toDateTime();
+
+    QDir().mkpath(cacheDir());
+    scan();
+}
+
+Weather::ForecastMapProvider* Weather::ForecastMapProvider::create(QQmlEngine*, QJSEngine*)
+{
+    static ForecastMapProvider instance;
+    return &instance;
+}
+
+QString Weather::ForecastMapProvider::cacheDir() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::AppCacheLocation)
+           + u"/meteo_france"_s;
+}
+
+
+// ---------------------------------------------------------------------------
+// Public slots
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::refresh()
+{
+    if (m_status == Status::Refreshing)
+        return;
+    if (m_serverUrl.isEmpty()) {
+        setStatus(Status::Error);
+        return;
+    }
+    setStatus(Status::Refreshing);
+    fetchIndex();
+}
+
+
+// ---------------------------------------------------------------------------
+// Network: fetch index
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::fetchIndex()
+{
+    auto* reply = m_nam.get(QNetworkRequest(QUrl(m_serverUrl + u"/index.json"_s)));
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+
+        if (reply->error() != QNetworkReply::NoError) {
+            abortRefresh();
+            return;
+        }
+
+        const auto doc = QJsonDocument::fromJson(reply->readAll());
+        if (doc.isNull() || !doc.isObject()) {
+            abortRefresh();
+            return;
+        }
+
+        QStringList serverFiles;
+        for (const auto& v : doc.object()[u"files"_s].toArray())
+            serverFiles << v.toString();
+
+        // Only download files not already in cache
+        const QDir dir(cacheDir());
+        QStringList toDownload;
+        for (const auto& fname : std::as_const(serverFiles))
+            if (!dir.exists(fname))
+                toDownload << fname;
+
+        if (toDownload.isEmpty()) {
+            finalizeRefresh(serverFiles);
+            return;
+        }
+
+        startDownloads(toDownload, serverFiles);
+    });
+}
+
+
+// ---------------------------------------------------------------------------
+// Network: download individual files
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::startDownloads(
+    const QStringList& filenames,
+    const QStringList& serverFiles)
+{
+    m_pendingDownloads = filenames.size();
+    m_serverFileList   = serverFiles;
+
+    for (const auto& fname : filenames) {
+        auto* reply = m_nam.get(QNetworkRequest(QUrl(m_serverUrl + u"/"_s + fname)));
+
+        connect(reply, &QNetworkReply::finished, this, [this, reply, fname]() {
+            reply->deleteLater();
+
+            if (reply->error() == QNetworkReply::NoError) {
+                // Atomic write: tmp → final, so a partial download never appears in scan()
+                const QString tmp   = cacheDir() + u"/"_s + fname + u".tmp"_s;
+                const QString final = cacheDir() + u"/"_s + fname;
+                QFile f(tmp);
+                if (f.open(QIODevice::WriteOnly)) {
+                    f.write(reply->readAll());
+                    f.close();
+                    QFile::rename(tmp, final);
+                }
+            }
+            // Count down regardless — a missing file just won't appear in scan()
+            if (--m_pendingDownloads == 0)
+                finalizeRefresh(m_serverFileList);
+        });
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Post-refresh bookkeeping
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::finalizeRefresh(const QStringList& serverFiles)
+{
+    // Purge cache entries no longer on the server — only on a successful full refresh
+    const QSet<QString> keep(serverFiles.begin(), serverFiles.end());
+    QDir dir(cacheDir());
+    for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files))
+        if (!keep.contains(name))
+            dir.remove(name);
+    // Clean up any leftover .tmp files from crashed downloads
+    for (const auto& name : dir.entryList(QStringList{u"*.tmp"_s}, QDir::Files))
+        dir.remove(name);
+
+    m_lastRefreshTime = QDateTime::currentDateTimeUtc();
+    QSettings().setValue(u"ForecastMapProvider/lastRefreshTime"_s, m_lastRefreshTime);
+
+    setStatus(Status::Idle);
+    emit lastRefreshLabelChanged();
+    scan();
+}
+
+void Weather::ForecastMapProvider::abortRefresh()
+{
+    // Clean up any .tmp files from the aborted attempt
+    QDir dir(cacheDir());
+    for (const auto& name : dir.entryList(QStringList{u"*.tmp"_s}, QDir::Files))
+        dir.remove(name);
+
+    setStatus(Status::Error);
+    scan(); // expose whatever is in cache
+}
+
+
+// ---------------------------------------------------------------------------
+// Directory scan
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::scan()
+{
+    m_rainMaps.clear();
+    m_cloudbaseMaps.clear();
+    m_windMaps.clear();
+
+    const QDir dir(cacheDir());
+    for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files)) {
+        auto m = re_rain.match(name);
+        if (m.hasMatch()) {
+            m_rainMaps[m.captured(1)] = dir.absoluteFilePath(name);
+            continue;
+        }
+        m = re_cloudbase.match(name);
+        if (m.hasMatch()) {
+            m_cloudbaseMaps[m.captured(1)] = dir.absoluteFilePath(name);
+            continue;
+        }
+        m = re_wind.match(name);
+        if (m.hasMatch())
+            m_windMaps[m.captured(1)][m.captured(2)] = dir.absoluteFilePath(name);
+    }
+
+    // Union of all timestamps across all map types
+    QSet<QString> tsSet;
+    for (const auto& k : m_rainMaps.keys())      tsSet << k;
+    for (const auto& k : m_cloudbaseMaps.keys()) tsSet << k;
+    for (const auto& level : std::as_const(m_windMaps))
+        for (const auto& k : level.keys())       tsSet << k;
+
+    m_timestamps = tsSet.values();
+    m_timestamps.sort();
+
+    // Wind pressure levels sorted ascending (700 first = highest altitude)
+    QStringList levels = m_windMaps.keys();
+    std::sort(levels.begin(), levels.end(),
+              [](const QString& a, const QString& b) { return a.toDouble() < b.toDouble(); });
+    m_windPressureLevels = levels;
+
+    if (m_currentWindPressureLevel.isEmpty() && !levels.isEmpty())
+        m_currentWindPressureLevel = levels.first();
+
+    m_currentIndex = qBound(0, m_currentIndex, qMax(0, int(m_timestamps.size()) - 1));
+
+    emit timestampsChanged();
+    emit currentIndexChanged();
+    emit currentWindMapChanged();
+}
+
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+void Weather::ForecastMapProvider::setStatus(Status s)
+{
+    if (m_status == s) return;
+    m_status = s;
+    emit statusChanged();
+}
+
+void Weather::ForecastMapProvider::setServerUrl(const QString& url)
+{
+    if (m_serverUrl == url) return;
+    m_serverUrl = url;
+    QSettings().setValue(u"ForecastMapProvider/serverUrl"_s, url);
+    emit serverUrlChanged();
+}
+
+void Weather::ForecastMapProvider::setCurrentIndex(int idx)
+{
+    idx = qBound(0, idx, qMax(0, int(m_timestamps.size()) - 1));
+    if (m_currentIndex == idx) return;
+    m_currentIndex = idx;
+    emit currentIndexChanged();
+    emit currentWindMapChanged();
+}
+
+void Weather::ForecastMapProvider::setCurrentWindPressureLevel(const QString& level)
+{
+    if (m_currentWindPressureLevel == level) return;
+    m_currentWindPressureLevel = level;
+    emit currentWindMapChanged();
+}
+
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+QString Weather::ForecastMapProvider::lastRefreshLabel() const
+{
+    if (!m_lastRefreshTime.isValid())
+        return u"Never"_s;
+    const auto secs = m_lastRefreshTime.secsTo(QDateTime::currentDateTimeUtc());
+    if (secs < 60)   return u"Just now"_s;
+    if (secs < 3600) return QString::number(secs / 60) + u" min ago"_s;
+    return QString::number(secs / 3600) + u" h ago"_s;
+}
+
+QString Weather::ForecastMapProvider::currentTimestampLabel() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
+    const auto dt = QDateTime::fromString(m_timestamps[m_currentIndex], Qt::ISODate);
+    if (!dt.isValid()) return m_timestamps[m_currentIndex];
+    return dt.toUTC().toString(u"ddd dd MMM HH:mm"_s) + u" UTC"_s;
+}
+
+QString Weather::ForecastMapProvider::currentRainMap() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
+    return m_rainMaps.value(m_timestamps[m_currentIndex]);
+}
+
+QString Weather::ForecastMapProvider::currentCloudbaseMap() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()) return {};
+    return m_cloudbaseMaps.value(m_timestamps[m_currentIndex]);
+}
+
+QString Weather::ForecastMapProvider::currentWindMap() const
+{
+    if (m_timestamps.isEmpty() || m_currentIndex >= m_timestamps.size()
+            || m_currentWindPressureLevel.isEmpty()) return {};
+    return m_windMaps.value(m_currentWindPressureLevel).value(m_timestamps[m_currentIndex]);
+}

--- a/src/weather/ForecastMapProvider.cpp
+++ b/src/weather/ForecastMapProvider.cpp
@@ -141,6 +141,14 @@ void Weather::ForecastMapProvider::fetchIndex()
         for (const auto& v : root[u"files"_s].toArray())
             serverFiles << v.toString();
 
+        // If the model run changed, wipe the cache so stale files are replaced
+        const QString newRefTime = root[u"reference_time"_s].toString();
+        if (!newRefTime.isEmpty() && newRefTime != m_referenceTime) {
+            QDir dir(cacheDir());
+            for (const auto& name : dir.entryList(QStringList{u"*.png"_s}, QDir::Files))
+                dir.remove(name);
+        }
+
         parseMetadata(root);
 
         // Only download files not already in cache

--- a/src/weather/ForecastMapProvider.h
+++ b/src/weather/ForecastMapProvider.h
@@ -63,9 +63,6 @@ public:
     Q_PROPERTY(QString currentTimestampLabel READ currentTimestampLabel NOTIFY currentIndexChanged)
     Q_PROPERTY(QString currentRainMap READ currentRainMap NOTIFY currentIndexChanged)
     Q_PROPERTY(QString currentCloudbaseMap READ currentCloudbaseMap NOTIFY currentIndexChanged)
-    Q_PROPERTY(QString currentWindMap READ currentWindMap NOTIFY currentWindMapChanged)
-    Q_PROPERTY(QStringList windPressureLevels READ windPressureLevels NOTIFY timestampsChanged)
-    Q_PROPERTY(QString currentWindPressureLevel READ currentWindPressureLevel WRITE setCurrentWindPressureLevel NOTIFY currentWindMapChanged)
 
     //
     // Layer metadata (from index.json)
@@ -92,9 +89,6 @@ public:
     /*! \brief vmax for cloudbase color scale */
     Q_PROPERTY(double cloudbaseVmax READ cloudbaseVmax NOTIFY metadataChanged)
 
-    /*! \brief Units string for the wind layer, e.g. "kt" */
-    Q_PROPERTY(QString windUnits READ windUnits NOTIFY metadataChanged)
-
     //
     // Sync / connectivity properties
     //
@@ -118,9 +112,6 @@ public:
     [[nodiscard]] QString currentTimestampLabel() const;
     [[nodiscard]] QString currentRainMap() const;
     [[nodiscard]] QString currentCloudbaseMap() const;
-    [[nodiscard]] QString currentWindMap() const;
-    [[nodiscard]] QStringList windPressureLevels() const { return m_windPressureLevels; }
-    [[nodiscard]] QString currentWindPressureLevel() const { return m_currentWindPressureLevel; }
     [[nodiscard]] QString serverUrl() const { return m_serverUrl; }
     [[nodiscard]] Status status() const { return m_status; }
     [[nodiscard]] QString lastRefreshLabel() const;
@@ -134,7 +125,6 @@ public:
     [[nodiscard]] QStringList cloudbaseColors() const { return m_cloudbaseColors; }
     [[nodiscard]] double cloudbaseVmin() const        { return m_cloudbaseVmin; }
     [[nodiscard]] double cloudbaseVmax() const        { return m_cloudbaseVmax; }
-    [[nodiscard]] QString windUnits() const      { return m_windUnits; }
 
 
     //
@@ -142,7 +132,6 @@ public:
     //
 
     void setCurrentIndex(int idx);
-    void setCurrentWindPressureLevel(const QString& level);
     void setServerUrl(const QString& url);
 
     /*! \brief Fetch index.json from the server and download new maps. No-op if already refreshing. */
@@ -152,7 +141,6 @@ public:
 signals:
     void timestampsChanged();
     void currentIndexChanged();
-    void currentWindMapChanged();
     void serverUrlChanged();
     void statusChanged();
     void lastRefreshLabelChanged();
@@ -186,9 +174,6 @@ private:
     int         m_currentIndex {0};
     QMap<QString, QString>                  m_rainMaps;
     QMap<QString, QString>                  m_cloudbaseMaps;
-    QMap<QString, QMap<QString, QString>>   m_windMaps;      ///< outer key: pressure level string
-    QStringList m_windPressureLevels;
-    QString     m_currentWindPressureLevel;
 
     // Layer metadata from index.json
     QString     m_referenceTime;
@@ -200,7 +185,6 @@ private:
     QStringList m_cloudbaseColors;
     double      m_cloudbaseVmin   {0.0};
     double      m_cloudbaseVmax   {4000.0};
-    QString     m_windUnits       {QStringLiteral("kt")};
 };
 
 } // namespace Weather

--- a/src/weather/ForecastMapProvider.h
+++ b/src/weather/ForecastMapProvider.h
@@ -51,6 +51,9 @@ public:
     explicit ForecastMapProvider(QObject* parent = nullptr);
     static Weather::ForecastMapProvider* create(QQmlEngine*, QJSEngine*);
 
+    /*! \brief Application-wide singleton instance, for C++ callers */
+    static Weather::ForecastMapProvider* instance() { return create(nullptr, nullptr); }
+
     //
     // Map data properties
     //

--- a/src/weather/ForecastMapProvider.h
+++ b/src/weather/ForecastMapProvider.h
@@ -1,0 +1,203 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Quentin Bossard                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QDateTime>
+#include <QJsonObject>
+#include <QMap>
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QQmlEngine>
+#include <QStringList>
+
+namespace Weather {
+
+/*! \brief Downloads and exposes Météo-France forecast PNG maps from a local HTTP server.
+ *
+ * On refresh(), fetches index.json from the configured server, downloads any
+ * new PNGs into the app cache, then scans the cache so QML can display them.
+ * Falls back to whatever is already in cache on connection failure.
+ */
+class ForecastMapProvider : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    enum class Status {
+        Idle,        ///< Ready, showing cached data
+        Refreshing,  ///< Fetching index or downloading files
+        Error        ///< Last refresh failed; showing stale cache
+    };
+    Q_ENUM(Status)
+
+    explicit ForecastMapProvider(QObject* parent = nullptr);
+    static Weather::ForecastMapProvider* create(QQmlEngine*, QJSEngine*);
+
+    //
+    // Map data properties
+    //
+
+    Q_PROPERTY(QStringList timestamps READ timestamps NOTIFY timestampsChanged)
+    Q_PROPERTY(int currentIndex READ currentIndex WRITE setCurrentIndex NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentTimestampLabel READ currentTimestampLabel NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentRainMap READ currentRainMap NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentCloudbaseMap READ currentCloudbaseMap NOTIFY currentIndexChanged)
+    Q_PROPERTY(QString currentWindMap READ currentWindMap NOTIFY currentWindMapChanged)
+    Q_PROPERTY(QStringList windPressureLevels READ windPressureLevels NOTIFY timestampsChanged)
+    Q_PROPERTY(QString currentWindPressureLevel READ currentWindPressureLevel WRITE setCurrentWindPressureLevel NOTIFY currentWindMapChanged)
+
+    //
+    // Layer metadata (from index.json)
+    //
+
+    /*! \brief Model run time that produced the current maps, e.g. "Thu 11 Jun 12:00 UTC" */
+    Q_PROPERTY(QString referenceTimeLabel READ referenceTimeLabel NOTIFY metadataChanged)
+
+    /*! \brief Units string for the rain layer, e.g. "mm/h" */
+    Q_PROPERTY(QString rainUnits READ rainUnits NOTIFY metadataChanged)
+    /*! \brief Color stops for the rain legend, as "#RRGGBBAA" strings, low→high */
+    Q_PROPERTY(QStringList rainColors READ rainColors NOTIFY metadataChanged)
+    /*! \brief vmin for rain color scale */
+    Q_PROPERTY(double rainVmin READ rainVmin NOTIFY metadataChanged)
+    /*! \brief vmax for rain color scale */
+    Q_PROPERTY(double rainVmax READ rainVmax NOTIFY metadataChanged)
+
+    /*! \brief Units string for the cloudbase layer, e.g. "m" */
+    Q_PROPERTY(QString cloudbaseUnits READ cloudbaseUnits NOTIFY metadataChanged)
+    /*! \brief Color stops for the cloudbase legend */
+    Q_PROPERTY(QStringList cloudbaseColors READ cloudbaseColors NOTIFY metadataChanged)
+    /*! \brief vmin for cloudbase color scale */
+    Q_PROPERTY(double cloudbaseVmin READ cloudbaseVmin NOTIFY metadataChanged)
+    /*! \brief vmax for cloudbase color scale */
+    Q_PROPERTY(double cloudbaseVmax READ cloudbaseVmax NOTIFY metadataChanged)
+
+    /*! \brief Units string for the wind layer, e.g. "kt" */
+    Q_PROPERTY(QString windUnits READ windUnits NOTIFY metadataChanged)
+
+    //
+    // Sync / connectivity properties
+    //
+
+    /*! \brief Base URL of the forecast server, e.g. "http://192.168.1.10:8765/meteo" */
+    Q_PROPERTY(QString serverUrl READ serverUrl WRITE setServerUrl NOTIFY serverUrlChanged)
+
+    /*! \brief Current sync state */
+    Q_PROPERTY(Status status READ status NOTIFY statusChanged)
+
+    /*! \brief Human-readable time since last successful refresh, e.g. "42 min ago" */
+    Q_PROPERTY(QString lastRefreshLabel READ lastRefreshLabel NOTIFY lastRefreshLabelChanged)
+
+
+    //
+    // Getters
+    //
+
+    [[nodiscard]] QStringList timestamps() const { return m_timestamps; }
+    [[nodiscard]] int currentIndex() const { return m_currentIndex; }
+    [[nodiscard]] QString currentTimestampLabel() const;
+    [[nodiscard]] QString currentRainMap() const;
+    [[nodiscard]] QString currentCloudbaseMap() const;
+    [[nodiscard]] QString currentWindMap() const;
+    [[nodiscard]] QStringList windPressureLevels() const { return m_windPressureLevels; }
+    [[nodiscard]] QString currentWindPressureLevel() const { return m_currentWindPressureLevel; }
+    [[nodiscard]] QString serverUrl() const { return m_serverUrl; }
+    [[nodiscard]] Status status() const { return m_status; }
+    [[nodiscard]] QString lastRefreshLabel() const;
+
+    [[nodiscard]] QString referenceTimeLabel() const;
+    [[nodiscard]] QString rainUnits() const      { return m_rainUnits; }
+    [[nodiscard]] QStringList rainColors() const { return m_rainColors; }
+    [[nodiscard]] double rainVmin() const        { return m_rainVmin; }
+    [[nodiscard]] double rainVmax() const        { return m_rainVmax; }
+    [[nodiscard]] QString cloudbaseUnits() const      { return m_cloudbaseUnits; }
+    [[nodiscard]] QStringList cloudbaseColors() const { return m_cloudbaseColors; }
+    [[nodiscard]] double cloudbaseVmin() const        { return m_cloudbaseVmin; }
+    [[nodiscard]] double cloudbaseVmax() const        { return m_cloudbaseVmax; }
+    [[nodiscard]] QString windUnits() const      { return m_windUnits; }
+
+
+    //
+    // Setters
+    //
+
+    void setCurrentIndex(int idx);
+    void setCurrentWindPressureLevel(const QString& level);
+    void setServerUrl(const QString& url);
+
+    /*! \brief Fetch index.json from the server and download new maps. No-op if already refreshing. */
+    Q_INVOKABLE void refresh();
+
+
+signals:
+    void timestampsChanged();
+    void currentIndexChanged();
+    void currentWindMapChanged();
+    void serverUrlChanged();
+    void statusChanged();
+    void lastRefreshLabelChanged();
+    void metadataChanged();
+
+
+private:
+    void scan();
+    void fetchIndex();
+    void startDownloads(const QStringList& filenames, const QStringList& serverFiles);
+    void finalizeRefresh(const QStringList& serverFiles);
+    void abortRefresh();
+    void parseMetadata(const QJsonObject& root);
+
+    void setStatus(Status s);
+    [[nodiscard]] QString cacheDir() const;
+
+    QNetworkAccessManager m_nam;
+
+    QString m_serverUrl;
+    QString m_localScanDir;   ///< non-empty when serverUrl is a file:// URL
+    Status  m_status          {Status::Idle};
+    QDateTime m_lastRefreshTime;
+
+    // Tracks in-flight downloads during a refresh cycle
+    int         m_pendingDownloads {0};
+    QStringList m_serverFileList;
+
+    // Map data
+    QStringList m_timestamps;
+    int         m_currentIndex {0};
+    QMap<QString, QString>                  m_rainMaps;
+    QMap<QString, QString>                  m_cloudbaseMaps;
+    QMap<QString, QMap<QString, QString>>   m_windMaps;      ///< outer key: pressure level string
+    QStringList m_windPressureLevels;
+    QString     m_currentWindPressureLevel;
+
+    // Layer metadata from index.json
+    QString     m_referenceTime;
+    QString     m_rainUnits       {QStringLiteral("mm/h")};
+    QStringList m_rainColors;
+    double      m_rainVmin        {0.1};
+    double      m_rainVmax        {10.0};
+    QString     m_cloudbaseUnits  {QStringLiteral("m")};
+    QStringList m_cloudbaseColors;
+    double      m_cloudbaseVmin   {0.0};
+    double      m_cloudbaseVmax   {4000.0};
+    QString     m_windUnits       {QStringLiteral("kt")};
+};
+
+} // namespace Weather

--- a/src/weather/METAR.cpp
+++ b/src/weather/METAR.cpp
@@ -97,6 +97,14 @@ Weather::METAR::METAR(QXmlStreamReader& xml)
             continue;
         }
 
+        // Wind direction
+        if (xml.isStartElement() && name == u"wind_dir_degrees"_s)
+        {
+            auto content = xml.readElementText();
+            m_windDirection = Units::Angle::fromDEG(content.toDouble());
+            continue;
+        }
+
         // Gust
         if (xml.isStartElement() && name == u"wind_gust_kt"_s)
         {
@@ -411,6 +419,7 @@ QDataStream& Weather::operator<<(QDataStream& outstream, const Weather::METAR& m
     outstream << metar.m_qnh;
     outstream << metar.m_rawText;
     outstream << metar.m_wind;
+    outstream << metar.m_windDirection.toDEG();
     outstream << metar.m_gust;
     outstream << metar.m_temperature;
     outstream << metar.m_dewpoint;
@@ -429,6 +438,7 @@ QDataStream& Weather::operator>>(QDataStream& instream, Weather::METAR& metar)
     instream >> metar.m_qnh;
     instream >> metar.m_rawText;
     instream >> metar.m_wind;
+    double windDirDeg; instream >> windDirDeg; metar.m_windDirection = Units::Angle::fromDEG(windDirDeg);
     instream >> metar.m_gust;
     instream >> metar.m_temperature;
     instream >> metar.m_dewpoint;

--- a/src/weather/METAR.h
+++ b/src/weather/METAR.h
@@ -26,6 +26,7 @@
 #include <QXmlStreamReader>
 
 #include "navigation/Aircraft.h"
+#include "units/Angle.h"
 #include "units/Distance.h"
 #include "units/Pressure.h"
 #include "units/Speed.h"
@@ -179,6 +180,18 @@ public:
      */
     Q_PROPERTY(QString rawText READ rawText CONSTANT)
 
+    /*! \brief Wind direction (true north)
+     *
+     * Set to NaN if wind direction is not reported (calm or variable).
+     */
+    Q_PROPERTY(Units::Angle windDirection READ windDirection CONSTANT)
+
+    /*! \brief Wind speed
+     *
+     * Set to NaN if no wind data is available.
+     */
+    Q_PROPERTY(Units::Speed windSpeed READ windSpeed CONSTANT)
+
 
     //
     // Getter Methods
@@ -256,6 +269,24 @@ public:
         return m_rawText;
     }
 
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property windDirection
+     */
+    [[nodiscard]] Units::Angle windDirection() const
+    {
+        return m_windDirection;
+    }
+
+    /*! \brief Getter function for property with the same name
+     *
+     * @returns Property windSpeed
+     */
+    [[nodiscard]] Units::Speed windSpeed() const
+    {
+        return m_wind;
+    }
+
 
     //
     // Methods
@@ -330,6 +361,9 @@ private:
 
     // Raw METAR text, as returned by the Aviation Weather Center
     QString m_rawText;
+
+    // Wind direction (true north), as returned by the Aviation Weather Center
+    Units::Angle m_windDirection;
 
     // Wind speed, as returned by the Aviation Weather Center
     Units::Speed m_wind;

--- a/src/weather/WindFieldProvider.cpp
+++ b/src/weather/WindFieldProvider.cpp
@@ -39,6 +39,14 @@ constexpr double MPS_TO_KN = 1.94384;
 
 // Lower-bound bracket index in a sorted ascending list: returns i such that
 // list[i] <= value <= list[i+1], clamped to [0, n-2]. Returns -1 if list < 2.
+// Quantize lat/lon to 1e-3° and pack into a collision-free key
+qint64 makeCellKey(double lat, double lon)
+{
+    const qint64 la = llround(lat * 1000.0);
+    const qint64 lo = llround(lon * 1000.0) + 500000; // keep positive, < 1e6
+    return la * 1000000LL + lo;
+}
+
 int bracket(const QList<double>& sorted, double value)
 {
     const int n = sorted.size();
@@ -126,6 +134,11 @@ QString Weather::WindFieldProvider::validTimeLabel() const
         return {};
     }
     return m_times.first().toUTC().toString(u"dd MMM HH:mm'Z'"_s);
+}
+
+qint64 Weather::WindFieldProvider::cellKey(double lat, double lon)
+{
+    return makeCellKey(lat, lon);
 }
 
 QVariantList Weather::WindFieldProvider::gridPoints() const
@@ -240,6 +253,13 @@ void Weather::WindFieldProvider::parse(const QByteArray& bytes)
     m_lats          = lats;
     m_lons          = lons;
 
+    // Build the O(1) cell index for corner lookups
+    m_index.clear();
+    m_index.reserve(m_grid.size());
+    for (int i = 0; i < m_grid.size(); ++i) {
+        m_index.insert(makeCellKey(m_grid[i].lat, m_grid[i].lon), i);
+    }
+
     emit dataChanged();
 }
 
@@ -328,12 +348,8 @@ QPointF Weather::WindFieldProvider::uvKnotsAt(double lat, double lon, double alt
     const double lon1 = m_lons[iLon + 1];
 
     auto corner = [this](double la, double lo) -> const GridPoint* {
-        for (const auto& p : m_grid) {
-            if (qFuzzyCompare(p.lat, la) && qFuzzyCompare(p.lon, lo)) {
-                return &p;
-            }
-        }
-        return nullptr;
+        const int idx = m_index.value(makeCellKey(la, lo), -1);
+        return (idx >= 0) ? &m_grid[idx] : nullptr;
     };
     const GridPoint* c00 = corner(lat0, lon0);
     const GridPoint* c01 = corner(lat0, lon1);

--- a/src/weather/WindFieldProvider.cpp
+++ b/src/weather/WindFieldProvider.cpp
@@ -84,18 +84,19 @@ Weather::WindFieldProvider* Weather::WindFieldProvider::instance()
 
 bool Weather::WindFieldProvider::isStale() const
 {
-    if (m_grid.isEmpty() || !m_validTime.isValid()) {
+    if (m_grid.isEmpty() || m_times.isEmpty()) {
         return true;
     }
-    return m_validTime.secsTo(QDateTime::currentDateTimeUtc()) > staleSeconds;
+    // Stale once "now" is past the last forecast step (no more coverage)
+    return QDateTime::currentDateTimeUtc() > m_times.last();
 }
 
 QString Weather::WindFieldProvider::validTimeLabel() const
 {
-    if (!m_validTime.isValid()) {
+    if (m_times.isEmpty()) {
         return {};
     }
-    return m_validTime.toUTC().toString(u"dd MMM HH:mm'Z'"_s);
+    return m_times.first().toUTC().toString(u"dd MMM HH:mm'Z'"_s);
 }
 
 
@@ -141,12 +142,29 @@ void Weather::WindFieldProvider::parse(const QByteArray& bytes)
     }
     const auto root = doc.object();
 
-    QDateTime validTime = QDateTime::fromString(root[u"valid_time"_s].toString(), Qt::ISODate);
+    const QDateTime referenceTime = QDateTime::fromString(root[u"reference_time"_s].toString(), Qt::ISODate);
+
+    QList<QDateTime> times;
+    for (const auto& v : root[u"times"_s].toArray()) {
+        times << QDateTime::fromString(v.toString(), Qt::ISODate).toUTC();
+    }
 
     QList<int> levels;
     for (const auto& v : root[u"levels_ft"_s].toArray()) {
         levels << v.toInt();
     }
+
+    auto readSeries = [](const QJsonArray& outer) {
+        QList<QList<double>> series;
+        for (const auto& step : outer) {
+            QList<double> perLevel;
+            for (const auto& x : step.toArray()) {
+                perLevel << x.toDouble();
+            }
+            series << perLevel;
+        }
+        return series;
+    };
 
     QList<GridPoint> grid;
     QList<double> lats;
@@ -156,12 +174,8 @@ void Weather::WindFieldProvider::parse(const QByteArray& bytes)
         GridPoint p;
         p.lat = o[u"lat"_s].toDouble();
         p.lon = o[u"lon"_s].toDouble();
-        for (const auto& uu : o[u"u"_s].toArray()) {
-            p.u << uu.toDouble();
-        }
-        for (const auto& vv : o[u"v"_s].toArray()) {
-            p.v << vv.toDouble();
-        }
+        p.u = readSeries(o[u"u"_s].toArray());
+        p.v = readSeries(o[u"v"_s].toArray());
         grid << p;
         if (!lats.contains(p.lat)) {
             lats << p.lat;
@@ -171,18 +185,19 @@ void Weather::WindFieldProvider::parse(const QByteArray& bytes)
         }
     }
 
-    if (grid.isEmpty() || levels.isEmpty()) {
+    if (grid.isEmpty() || levels.isEmpty() || times.isEmpty()) {
         return;
     }
 
     std::sort(lats.begin(), lats.end());
     std::sort(lons.begin(), lons.end());
 
-    m_validTime = validTime;
-    m_levelsFt  = levels;
-    m_grid      = grid;
-    m_lats      = lats;
-    m_lons      = lons;
+    m_referenceTime = referenceTime;
+    m_times         = times;
+    m_levelsFt      = levels;
+    m_grid          = grid;
+    m_lats          = lats;
+    m_lons          = lons;
 
     emit dataChanged();
 }
@@ -192,17 +207,29 @@ void Weather::WindFieldProvider::parse(const QByteArray& bytes)
 // Interpolation
 // ---------------------------------------------------------------------------
 
-QPointF Weather::WindFieldProvider::uvAtLevelInterp(const GridPoint& p, double altFt) const
+QPointF Weather::WindFieldProvider::uvAtCorner(const GridPoint& p, int ti, double tFrac, double altFt) const
 {
     const int nLev = m_levelsFt.size();
-    if (nLev == 0 || p.u.isEmpty()) {
+    if (nLev == 0 || ti < 0 || ti >= p.u.size()) {
         return {qQNaN(), qQNaN()};
     }
-    if (nLev == 1) {
-        return {p.u.value(0), p.v.value(0)};
+
+    // Time-interpolate the per-level arrays into a single profile (m/s)
+    const int tj = qMin(ti + 1, int(p.u.size()) - 1);
+    QList<double> uLev;
+    QList<double> vLev;
+    uLev.reserve(nLev);
+    vLev.reserve(nLev);
+    for (int l = 0; l < nLev; ++l) {
+        uLev << p.u[ti].value(l) * (1 - tFrac) + p.u[tj].value(l) * tFrac;
+        vLev << p.v[ti].value(l) * (1 - tFrac) + p.v[tj].value(l) * tFrac;
     }
 
-    // Bracket altitude between two levels (levels are ascending)
+    if (nLev == 1) {
+        return {uLev[0], vLev[0]};
+    }
+
+    // Altitude-interpolate the profile
     QList<double> levelsD;
     levelsD.reserve(nLev);
     for (int lvl : m_levelsFt) {
@@ -210,22 +237,42 @@ QPointF Weather::WindFieldProvider::uvAtLevelInterp(const GridPoint& p, double a
     }
     const int i = bracket(levelsD, altFt);
     if (i < 0) {
-        return {p.u.value(0), p.v.value(0)};
+        return {uLev[0], vLev[0]};
     }
-
     const double a0 = levelsD[i];
     const double a1 = levelsD[i + 1];
     const double t  = (a1 > a0) ? qBound(0.0, (altFt - a0) / (a1 - a0), 1.0) : 0.0;
-
-    const double u = p.u.value(i) * (1 - t) + p.u.value(i + 1) * t;
-    const double v = p.v.value(i) * (1 - t) + p.v.value(i + 1) * t;
-    return {u, v};
+    return {uLev[i] * (1 - t) + uLev[i + 1] * t,
+            vLev[i] * (1 - t) + vLev[i + 1] * t};
 }
 
-QPointF Weather::WindFieldProvider::uvKnotsAt(double lat, double lon, double altFt) const
+QPointF Weather::WindFieldProvider::uvKnotsAt(double lat, double lon, double altFt, const QDateTime& time) const
 {
     if (!isUsable()) {
         return {qQNaN(), qQNaN()};
+    }
+
+    // Bracket time (m_times ascending). Clamp outside the range.
+    int ti = 0;
+    double tFrac = 0.0;
+    const int nT = m_times.size();
+    if (nT >= 2 && time.isValid()) {
+        if (time <= m_times.first()) {
+            ti = 0;
+            tFrac = 0.0;
+        } else if (time >= m_times.last()) {
+            ti = nT - 1;
+            tFrac = 0.0;
+        } else {
+            for (int k = 0; k < nT - 1; ++k) {
+                if (time >= m_times[k] && time <= m_times[k + 1]) {
+                    ti = k;
+                    const qint64 span = m_times[k].secsTo(m_times[k + 1]);
+                    tFrac = (span > 0) ? double(m_times[k].secsTo(time)) / double(span) : 0.0;
+                    break;
+                }
+            }
+        }
     }
 
     const int iLat = bracket(m_lats, lat);
@@ -239,7 +286,6 @@ QPointF Weather::WindFieldProvider::uvKnotsAt(double lat, double lon, double alt
     const double lon0 = m_lons[iLon];
     const double lon1 = m_lons[iLon + 1];
 
-    // Look up the 4 corner grid points
     auto corner = [this](double la, double lo) -> const GridPoint* {
         for (const auto& p : m_grid) {
             if (qFuzzyCompare(p.lat, la) && qFuzzyCompare(p.lon, lo)) {
@@ -259,10 +305,10 @@ QPointF Weather::WindFieldProvider::uvKnotsAt(double lat, double lon, double alt
     const double tx = (lon1 > lon0) ? qBound(0.0, (lon - lon0) / (lon1 - lon0), 1.0) : 0.0;
     const double ty = (lat1 > lat0) ? qBound(0.0, (lat - lat0) / (lat1 - lat0), 1.0) : 0.0;
 
-    const QPointF uv00 = uvAtLevelInterp(*c00, altFt);
-    const QPointF uv01 = uvAtLevelInterp(*c01, altFt);
-    const QPointF uv10 = uvAtLevelInterp(*c10, altFt);
-    const QPointF uv11 = uvAtLevelInterp(*c11, altFt);
+    const QPointF uv00 = uvAtCorner(*c00, ti, tFrac, altFt);
+    const QPointF uv01 = uvAtCorner(*c01, ti, tFrac, altFt);
+    const QPointF uv10 = uvAtCorner(*c10, ti, tFrac, altFt);
+    const QPointF uv11 = uvAtCorner(*c11, ti, tFrac, altFt);
 
     // Bilinear blend (m/s)
     const QPointF top = uv00 * (1 - tx) + uv01 * tx;
@@ -291,8 +337,13 @@ Weather::Wind Weather::WindFieldProvider::windFromUV(double uKnots, double vKnot
     return w;
 }
 
+Weather::Wind Weather::WindFieldProvider::windAt(double lat, double lon, double altFt, const QDateTime& time) const
+{
+    const QPointF uv = uvKnotsAt(lat, lon, altFt, time);
+    return windFromUV(uv.x(), uv.y());
+}
+
 Weather::Wind Weather::WindFieldProvider::windAt(double lat, double lon, double altFt) const
 {
-    const QPointF uv = uvKnotsAt(lat, lon, altFt);
-    return windFromUV(uv.x(), uv.y());
+    return windAt(lat, lon, altFt, QDateTime::currentDateTimeUtc());
 }

--- a/src/weather/WindFieldProvider.cpp
+++ b/src/weather/WindFieldProvider.cpp
@@ -26,6 +26,7 @@
 #include <QJsonObject>
 #include <QNetworkReply>
 #include <QUrl>
+#include <QVariantMap>
 #include <QtMath>
 
 using namespace Qt::Literals::StringLiterals;
@@ -97,6 +98,16 @@ QString Weather::WindFieldProvider::validTimeLabel() const
         return {};
     }
     return m_times.first().toUTC().toString(u"dd MMM HH:mm'Z'"_s);
+}
+
+QVariantList Weather::WindFieldProvider::gridPoints() const
+{
+    QVariantList out;
+    out.reserve(m_grid.size());
+    for (const auto& p : m_grid) {
+        out << QVariantMap{{u"lat"_s, p.lat}, {u"lon"_s, p.lon}};
+    }
+    return out;
 }
 
 

--- a/src/weather/WindFieldProvider.cpp
+++ b/src/weather/WindFieldProvider.cpp
@@ -404,3 +404,29 @@ Weather::Wind Weather::WindFieldProvider::windAt(double lat, double lon, double 
 {
     return windAt(lat, lon, altFt, QDateTime::currentDateTimeUtc());
 }
+
+QDateTime Weather::WindFieldProvider::nearestStep(const QDateTime& time) const
+{
+    if (m_times.isEmpty()) {
+        return {};
+    }
+    if (!time.isValid()) {
+        return m_times.first();
+    }
+    const QDateTime* best = &m_times.first();
+    qint64 bestDiff = qAbs(m_times.first().secsTo(time));
+    for (const auto& t : m_times) {
+        const qint64 d = qAbs(t.secsTo(time));
+        if (d < bestDiff) {
+            bestDiff = d;
+            best = &t;
+        }
+    }
+    return *best;
+}
+
+Weather::Wind Weather::WindFieldProvider::windAtStep(double lat, double lon, double altFt, const QDateTime& time) const
+{
+    // Snap to the nearest forecast step: no time interpolation
+    return windAt(lat, lon, altFt, nearestStep(time));
+}

--- a/src/weather/WindFieldProvider.cpp
+++ b/src/weather/WindFieldProvider.cpp
@@ -20,11 +20,14 @@
 #include "weather/WindFieldProvider.h"
 #include "weather/ForecastMapProvider.h"
 
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkReply>
+#include <QStandardPaths>
 #include <QUrl>
 #include <QVariantMap>
 #include <QtMath>
@@ -65,6 +68,31 @@ int bracket(const QList<double>& sorted, double value)
 Weather::WindFieldProvider::WindFieldProvider(QObject* parent)
     : QObject(parent)
 {
+    // Load the cached wind field so data is available offline at startup
+    QFile f(cacheFilePath());
+    if (f.open(QIODevice::ReadOnly)) {
+        parse(f.readAll());
+    }
+}
+
+QString Weather::WindFieldProvider::cacheFilePath()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+           + u"/meteo_france/wind.json"_s;
+}
+
+void Weather::WindFieldProvider::saveToCache(const QByteArray& bytes) const
+{
+    const QString path = cacheFilePath();
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    // Atomic write: tmp → rename, so a partial write never replaces good data
+    const QString tmp = path + u".tmp"_s;
+    QFile f(tmp);
+    if (f.open(QIODevice::WriteOnly)) {
+        f.write(bytes);
+        f.close();
+        QFile::rename(tmp, path);
+    }
 }
 
 Weather::WindFieldProvider* Weather::WindFieldProvider::create(QQmlEngine*, QJSEngine*)
@@ -135,7 +163,9 @@ void Weather::WindFieldProvider::refresh()
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         reply->deleteLater();
         if (reply->error() == QNetworkReply::NoError) {
-            parse(reply->readAll());
+            const QByteArray bytes = reply->readAll();
+            saveToCache(bytes);
+            parse(bytes);
         }
     });
 }

--- a/src/weather/WindFieldProvider.cpp
+++ b/src/weather/WindFieldProvider.cpp
@@ -1,0 +1,298 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Quentin Bossard                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "weather/WindFieldProvider.h"
+#include "weather/ForecastMapProvider.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QUrl>
+#include <QtMath>
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace {
+constexpr double MPS_TO_KN = 1.94384;
+
+// Lower-bound bracket index in a sorted ascending list: returns i such that
+// list[i] <= value <= list[i+1], clamped to [0, n-2]. Returns -1 if list < 2.
+int bracket(const QList<double>& sorted, double value)
+{
+    const int n = sorted.size();
+    if (n < 2) {
+        return -1;
+    }
+    if (value <= sorted.first()) {
+        return 0;
+    }
+    if (value >= sorted.last()) {
+        return n - 2;
+    }
+    for (int i = 0; i < n - 1; ++i) {
+        if (value >= sorted[i] && value <= sorted[i + 1]) {
+            return i;
+        }
+    }
+    return n - 2;
+}
+} // namespace
+
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+Weather::WindFieldProvider::WindFieldProvider(QObject* parent)
+    : QObject(parent)
+{
+}
+
+Weather::WindFieldProvider* Weather::WindFieldProvider::create(QQmlEngine*, QJSEngine*)
+{
+    return instance();
+}
+
+Weather::WindFieldProvider* Weather::WindFieldProvider::instance()
+{
+    static WindFieldProvider theInstance;
+    return &theInstance;
+}
+
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+bool Weather::WindFieldProvider::isStale() const
+{
+    if (m_grid.isEmpty() || !m_validTime.isValid()) {
+        return true;
+    }
+    return m_validTime.secsTo(QDateTime::currentDateTimeUtc()) > staleSeconds;
+}
+
+QString Weather::WindFieldProvider::validTimeLabel() const
+{
+    if (!m_validTime.isValid()) {
+        return {};
+    }
+    return m_validTime.toUTC().toString(u"dd MMM HH:mm'Z'"_s);
+}
+
+
+// ---------------------------------------------------------------------------
+// Refresh
+// ---------------------------------------------------------------------------
+
+void Weather::WindFieldProvider::refresh()
+{
+    const QString serverUrl = ForecastMapProvider::instance()->serverUrl();
+    if (serverUrl.isEmpty()) {
+        return;
+    }
+
+    const QUrl base(serverUrl);
+    if (base.isLocalFile()) {
+        QFile f(base.toLocalFile() + u"/wind.json"_s);
+        if (f.open(QIODevice::ReadOnly)) {
+            parse(f.readAll());
+        }
+        return;
+    }
+
+    auto* reply = m_nam.get(QNetworkRequest(QUrl(serverUrl + u"/wind.json"_s)));
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() == QNetworkReply::NoError) {
+            parse(reply->readAll());
+        }
+    });
+}
+
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+void Weather::WindFieldProvider::parse(const QByteArray& bytes)
+{
+    const auto doc = QJsonDocument::fromJson(bytes);
+    if (!doc.isObject()) {
+        return;
+    }
+    const auto root = doc.object();
+
+    QDateTime validTime = QDateTime::fromString(root[u"valid_time"_s].toString(), Qt::ISODate);
+
+    QList<int> levels;
+    for (const auto& v : root[u"levels_ft"_s].toArray()) {
+        levels << v.toInt();
+    }
+
+    QList<GridPoint> grid;
+    QList<double> lats;
+    QList<double> lons;
+    for (const auto& v : root[u"grid"_s].toArray()) {
+        const auto o = v.toObject();
+        GridPoint p;
+        p.lat = o[u"lat"_s].toDouble();
+        p.lon = o[u"lon"_s].toDouble();
+        for (const auto& uu : o[u"u"_s].toArray()) {
+            p.u << uu.toDouble();
+        }
+        for (const auto& vv : o[u"v"_s].toArray()) {
+            p.v << vv.toDouble();
+        }
+        grid << p;
+        if (!lats.contains(p.lat)) {
+            lats << p.lat;
+        }
+        if (!lons.contains(p.lon)) {
+            lons << p.lon;
+        }
+    }
+
+    if (grid.isEmpty() || levels.isEmpty()) {
+        return;
+    }
+
+    std::sort(lats.begin(), lats.end());
+    std::sort(lons.begin(), lons.end());
+
+    m_validTime = validTime;
+    m_levelsFt  = levels;
+    m_grid      = grid;
+    m_lats      = lats;
+    m_lons      = lons;
+
+    emit dataChanged();
+}
+
+
+// ---------------------------------------------------------------------------
+// Interpolation
+// ---------------------------------------------------------------------------
+
+QPointF Weather::WindFieldProvider::uvAtLevelInterp(const GridPoint& p, double altFt) const
+{
+    const int nLev = m_levelsFt.size();
+    if (nLev == 0 || p.u.isEmpty()) {
+        return {qQNaN(), qQNaN()};
+    }
+    if (nLev == 1) {
+        return {p.u.value(0), p.v.value(0)};
+    }
+
+    // Bracket altitude between two levels (levels are ascending)
+    QList<double> levelsD;
+    levelsD.reserve(nLev);
+    for (int lvl : m_levelsFt) {
+        levelsD << double(lvl);
+    }
+    const int i = bracket(levelsD, altFt);
+    if (i < 0) {
+        return {p.u.value(0), p.v.value(0)};
+    }
+
+    const double a0 = levelsD[i];
+    const double a1 = levelsD[i + 1];
+    const double t  = (a1 > a0) ? qBound(0.0, (altFt - a0) / (a1 - a0), 1.0) : 0.0;
+
+    const double u = p.u.value(i) * (1 - t) + p.u.value(i + 1) * t;
+    const double v = p.v.value(i) * (1 - t) + p.v.value(i + 1) * t;
+    return {u, v};
+}
+
+QPointF Weather::WindFieldProvider::uvKnotsAt(double lat, double lon, double altFt) const
+{
+    if (!isUsable()) {
+        return {qQNaN(), qQNaN()};
+    }
+
+    const int iLat = bracket(m_lats, lat);
+    const int iLon = bracket(m_lons, lon);
+    if (iLat < 0 || iLon < 0) {
+        return {qQNaN(), qQNaN()};
+    }
+
+    const double lat0 = m_lats[iLat];
+    const double lat1 = m_lats[iLat + 1];
+    const double lon0 = m_lons[iLon];
+    const double lon1 = m_lons[iLon + 1];
+
+    // Look up the 4 corner grid points
+    auto corner = [this](double la, double lo) -> const GridPoint* {
+        for (const auto& p : m_grid) {
+            if (qFuzzyCompare(p.lat, la) && qFuzzyCompare(p.lon, lo)) {
+                return &p;
+            }
+        }
+        return nullptr;
+    };
+    const GridPoint* c00 = corner(lat0, lon0);
+    const GridPoint* c01 = corner(lat0, lon1);
+    const GridPoint* c10 = corner(lat1, lon0);
+    const GridPoint* c11 = corner(lat1, lon1);
+    if ((c00 == nullptr) || (c01 == nullptr) || (c10 == nullptr) || (c11 == nullptr)) {
+        return {qQNaN(), qQNaN()};
+    }
+
+    const double tx = (lon1 > lon0) ? qBound(0.0, (lon - lon0) / (lon1 - lon0), 1.0) : 0.0;
+    const double ty = (lat1 > lat0) ? qBound(0.0, (lat - lat0) / (lat1 - lat0), 1.0) : 0.0;
+
+    const QPointF uv00 = uvAtLevelInterp(*c00, altFt);
+    const QPointF uv01 = uvAtLevelInterp(*c01, altFt);
+    const QPointF uv10 = uvAtLevelInterp(*c10, altFt);
+    const QPointF uv11 = uvAtLevelInterp(*c11, altFt);
+
+    // Bilinear blend (m/s)
+    const QPointF top = uv00 * (1 - tx) + uv01 * tx;
+    const QPointF bot = uv10 * (1 - tx) + uv11 * tx;
+    const QPointF uv  = top * (1 - ty) + bot * ty;
+
+    return {uv.x() * MPS_TO_KN, uv.y() * MPS_TO_KN};
+}
+
+Weather::Wind Weather::WindFieldProvider::windFromUV(double uKnots, double vKnots)
+{
+    Weather::Wind w;
+    if (!qIsFinite(uKnots) || !qIsFinite(vKnots)) {
+        return w;
+    }
+
+    const double speedKn = std::hypot(uKnots, vKnots);
+    // Meteorological "direction from": atan2(-u, -v), 0° = from north
+    double dirDeg = qRadiansToDegrees(std::atan2(-uKnots, -vKnots));
+    if (dirDeg < 0) {
+        dirDeg += 360.0;
+    }
+
+    w.setSpeed(Units::Speed::fromKN(speedKn));
+    w.setDirectionFrom(Units::Angle::fromDEG(dirDeg));
+    return w;
+}
+
+Weather::Wind Weather::WindFieldProvider::windAt(double lat, double lon, double altFt) const
+{
+    const QPointF uv = uvKnotsAt(lat, lon, altFt);
+    return windFromUV(uv.x(), uv.y());
+}

--- a/src/weather/WindFieldProvider.h
+++ b/src/weather/WindFieldProvider.h
@@ -111,6 +111,13 @@ public:
     /*! \brief As windAt(), using the time nearest "now" (for the map layer) */
     [[nodiscard]] Q_INVOKABLE Weather::Wind windAt(double lat, double lon, double altFt) const;
 
+    /*! \brief Wind at the nearest forecast time STEP (no time interpolation).
+     *
+     *  Used by the map layer, where the wind steps share the forecast model's
+     *  time grid: the requested time is snapped to the closest step.
+     */
+    [[nodiscard]] Q_INVOKABLE Weather::Wind windAtStep(double lat, double lon, double altFt, const QDateTime& time) const;
+
     /*! \brief Interpolated (u, v) wind components in KNOTS at a location/altitude/time.
      *
      *  Meteorological convention: u eastward, v northward. Returns a point with
@@ -137,6 +144,9 @@ private:
     };
 
     void parse(const QByteArray& bytes);
+
+    // Nearest forecast step to a given time (invalid if no data)
+    [[nodiscard]] QDateTime nearestStep(const QDateTime& time) const;
 
     // Path of the on-disk cache copy of wind.json (survives restarts/offline)
     [[nodiscard]] static QString cacheFilePath();

--- a/src/weather/WindFieldProvider.h
+++ b/src/weather/WindFieldProvider.h
@@ -23,6 +23,7 @@
 #include <QList>
 #include <QNetworkAccessManager>
 #include <QObject>
+#include <QHash>
 #include <QPointF>
 #include <QQmlEngine>
 #include <QVariantList>
@@ -154,6 +155,10 @@ private:
     // Grid geometry (assumes a regular lat/lon grid)
     QList<double> m_lats;           // sorted unique, ascending
     QList<double> m_lons;           // sorted unique, ascending
+
+    // O(1) lookup from a quantized (lat, lon) key to the index in m_grid
+    QHash<qint64, int> m_index;
+    [[nodiscard]] static qint64 cellKey(double lat, double lon);
 };
 
 } // namespace Weather

--- a/src/weather/WindFieldProvider.h
+++ b/src/weather/WindFieldProvider.h
@@ -36,13 +36,17 @@ namespace Weather {
  * exposes interpolated wind at any (lat, lon, altitude). Falls back to invalid
  * wind when the grid is empty or stale, so callers can revert to manual wind.
  *
- * JSON schema:
+ * JSON schema (time-indexed):
  *   {
- *     "valid_time": "2026-06-15T12:00Z",
- *     "levels_ft": [2000, 5000, 10000],
- *     "grid": [ { "lat":48.0, "lon":7.5, "u":[...], "v":[...] }, ... ]
+ *     "reference_time": "2026-06-15T12:00:00Z",
+ *     "times": ["2026-06-15T12:00:00Z", ...],
+ *     "levels_ft": [0, 3300, 6500, 10000],
+ *     "grid": [ { "lat":48.0, "lon":7.5,
+ *                 "u":[[u_t0_l0,...],...],   // [time][level]
+ *                 "v":[[...],...] }, ... ]
  *   }
- * u/v are wind components in m/s (meteorological convention), indexed by levels_ft.
+ * u/v are wind components in m/s (meteorological convention). Lookups
+ * interpolate trilinearly: bilinear in lat/lon, linear in altitude and time.
  */
 class WindFieldProvider : public QObject {
     Q_OBJECT
@@ -88,19 +92,22 @@ public:
     // Wind lookup
     //
 
-    /*! \brief Interpolated wind at a location and altitude.
+    /*! \brief Interpolated wind at a location, altitude and time.
      *
-     *  Bilinear interpolation in lat/lon, linear in altitude (clamped to the
-     *  available level range). Returns an invalid Wind when no usable data.
+     *  Bilinear in lat/lon, linear in altitude and time (each clamped to the
+     *  available range). Returns an invalid Wind when no usable data.
      */
+    [[nodiscard]] Q_INVOKABLE Weather::Wind windAt(double lat, double lon, double altFt, const QDateTime& time) const;
+
+    /*! \brief As windAt(), using the time nearest "now" (for the map layer) */
     [[nodiscard]] Q_INVOKABLE Weather::Wind windAt(double lat, double lon, double altFt) const;
 
-    /*! \brief Interpolated (u, v) wind components in KNOTS at a location/altitude.
+    /*! \brief Interpolated (u, v) wind components in KNOTS at a location/altitude/time.
      *
      *  Meteorological convention: u eastward, v northward. Returns a point with
      *  NaN components when no usable data. Used for vector averaging.
      */
-    [[nodiscard]] QPointF uvKnotsAt(double lat, double lon, double altFt) const;
+    [[nodiscard]] QPointF uvKnotsAt(double lat, double lon, double altFt, const QDateTime& time) const;
 
     /*! \brief Construct a Weather::Wind from (u, v) components in knots */
     [[nodiscard]] static Weather::Wind windFromUV(double uKnots, double vKnots);
@@ -116,26 +123,25 @@ private:
     struct GridPoint {
         double lat {};
         double lon {};
-        QList<double> u; // m/s, per level
-        QList<double> v; // m/s, per level
+        QList<QList<double>> u; // m/s, [time][level]
+        QList<QList<double>> v; // m/s, [time][level]
     };
 
     void parse(const QByteArray& bytes);
 
-    // Linear-in-altitude interpolation of a single grid point's u/v (m/s)
-    [[nodiscard]] QPointF uvAtLevelInterp(const GridPoint& p, double altFt) const;
+    // (u, v) in m/s for one grid point, interpolated in time then altitude
+    [[nodiscard]] QPointF uvAtCorner(const GridPoint& p, int ti, double tFrac, double altFt) const;
 
     QNetworkAccessManager m_nam;
 
-    QDateTime    m_validTime;
-    QList<int>   m_levelsFt;        // ascending
+    QDateTime        m_referenceTime;
+    QList<QDateTime> m_times;        // ascending
+    QList<int>       m_levelsFt;     // ascending
     QList<GridPoint> m_grid;
 
     // Grid geometry (assumes a regular lat/lon grid)
     QList<double> m_lats;           // sorted unique, ascending
     QList<double> m_lons;           // sorted unique, ascending
-
-    static constexpr qint64 staleSeconds = 2 * 60 * 60; // 2 h
 };
 
 } // namespace Weather

--- a/src/weather/WindFieldProvider.h
+++ b/src/weather/WindFieldProvider.h
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <QPointF>
 #include <QQmlEngine>
+#include <QVariantList>
 
 #include "weather/Wind.h"
 
@@ -76,6 +77,12 @@ public:
     /*! \brief Available altitude levels in feet, ascending */
     Q_PROPERTY(QList<int> levelsFt READ levelsFt NOTIFY dataChanged)
 
+    /*! \brief Grid point coordinates as a model for the map wind-barb layer.
+     *
+     *  Each entry is a map with "lat" and "lon" (degrees). Empty when no data.
+     */
+    Q_PROPERTY(QVariantList gridPoints READ gridPoints NOTIFY dataChanged)
+
     //
     // Getters
     //
@@ -84,6 +91,7 @@ public:
     [[nodiscard]] bool hasData() const { return !m_grid.isEmpty(); }
     [[nodiscard]] QString validTimeLabel() const;
     [[nodiscard]] QList<int> levelsFt() const { return m_levelsFt; }
+    [[nodiscard]] QVariantList gridPoints() const;
 
     /*! \brief Returns true when usable (non-empty, non-stale) data is present */
     [[nodiscard]] bool isUsable() const { return hasData() && !isStale(); }

--- a/src/weather/WindFieldProvider.h
+++ b/src/weather/WindFieldProvider.h
@@ -1,0 +1,141 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Quentin Bossard                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QDateTime>
+#include <QList>
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QPointF>
+#include <QQmlEngine>
+
+#include "weather/Wind.h"
+
+namespace Weather {
+
+/*! \brief Spatially- and altitude-resolved wind field from the local forecast server.
+ *
+ * Fetches a JSON wind grid from the same server as ForecastMapProvider and
+ * exposes interpolated wind at any (lat, lon, altitude). Falls back to invalid
+ * wind when the grid is empty or stale, so callers can revert to manual wind.
+ *
+ * JSON schema:
+ *   {
+ *     "valid_time": "2026-06-15T12:00Z",
+ *     "levels_ft": [2000, 5000, 10000],
+ *     "grid": [ { "lat":48.0, "lon":7.5, "u":[...], "v":[...] }, ... ]
+ *   }
+ * u/v are wind components in m/s (meteorological convention), indexed by levels_ft.
+ */
+class WindFieldProvider : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    explicit WindFieldProvider(QObject* parent = nullptr);
+    static Weather::WindFieldProvider* create(QQmlEngine*, QJSEngine*);
+
+    /*! \brief Application-wide singleton instance, for C++ callers */
+    static Weather::WindFieldProvider* instance();
+
+    //
+    // Properties
+    //
+
+    /*! \brief True when no valid (non-stale) wind field is loaded */
+    Q_PROPERTY(bool isStale READ isStale NOTIFY dataChanged)
+
+    /*! \brief True when a non-empty grid has been parsed (regardless of staleness) */
+    Q_PROPERTY(bool hasData READ hasData NOTIFY dataChanged)
+
+    /*! \brief Valid-time of the loaded field, e.g. "15 Jun 12:00Z", empty if none */
+    Q_PROPERTY(QString validTimeLabel READ validTimeLabel NOTIFY dataChanged)
+
+    /*! \brief Available altitude levels in feet, ascending */
+    Q_PROPERTY(QList<int> levelsFt READ levelsFt NOTIFY dataChanged)
+
+    //
+    // Getters
+    //
+
+    [[nodiscard]] bool isStale() const;
+    [[nodiscard]] bool hasData() const { return !m_grid.isEmpty(); }
+    [[nodiscard]] QString validTimeLabel() const;
+    [[nodiscard]] QList<int> levelsFt() const { return m_levelsFt; }
+
+    /*! \brief Returns true when usable (non-empty, non-stale) data is present */
+    [[nodiscard]] bool isUsable() const { return hasData() && !isStale(); }
+
+    //
+    // Wind lookup
+    //
+
+    /*! \brief Interpolated wind at a location and altitude.
+     *
+     *  Bilinear interpolation in lat/lon, linear in altitude (clamped to the
+     *  available level range). Returns an invalid Wind when no usable data.
+     */
+    [[nodiscard]] Q_INVOKABLE Weather::Wind windAt(double lat, double lon, double altFt) const;
+
+    /*! \brief Interpolated (u, v) wind components in KNOTS at a location/altitude.
+     *
+     *  Meteorological convention: u eastward, v northward. Returns a point with
+     *  NaN components when no usable data. Used for vector averaging.
+     */
+    [[nodiscard]] QPointF uvKnotsAt(double lat, double lon, double altFt) const;
+
+    /*! \brief Construct a Weather::Wind from (u, v) components in knots */
+    [[nodiscard]] static Weather::Wind windFromUV(double uKnots, double vKnots);
+
+public slots:
+    /*! \brief Fetch wind.json from the configured forecast server. */
+    void refresh();
+
+signals:
+    void dataChanged();
+
+private:
+    struct GridPoint {
+        double lat {};
+        double lon {};
+        QList<double> u; // m/s, per level
+        QList<double> v; // m/s, per level
+    };
+
+    void parse(const QByteArray& bytes);
+
+    // Linear-in-altitude interpolation of a single grid point's u/v (m/s)
+    [[nodiscard]] QPointF uvAtLevelInterp(const GridPoint& p, double altFt) const;
+
+    QNetworkAccessManager m_nam;
+
+    QDateTime    m_validTime;
+    QList<int>   m_levelsFt;        // ascending
+    QList<GridPoint> m_grid;
+
+    // Grid geometry (assumes a regular lat/lon grid)
+    QList<double> m_lats;           // sorted unique, ascending
+    QList<double> m_lons;           // sorted unique, ascending
+
+    static constexpr qint64 staleSeconds = 2 * 60 * 60; // 2 h
+};
+
+} // namespace Weather

--- a/src/weather/WindFieldProvider.h
+++ b/src/weather/WindFieldProvider.h
@@ -137,6 +137,10 @@ private:
 
     void parse(const QByteArray& bytes);
 
+    // Path of the on-disk cache copy of wind.json (survives restarts/offline)
+    [[nodiscard]] static QString cacheFilePath();
+    void saveToCache(const QByteArray& bytes) const;
+
     // (u, v) in m/s for one grid point, interpolated in time then altitude
     [[nodiscard]] QPointF uvAtCorner(const GridPoint& p, int ti, double tFrac, double altFt) const;
 


### PR DESCRIPTION
Replaces the single manual wind value with a spatially- and altitude-resolved wind field fetched from the local forecast server (wind.json), while keeping manual entry as an offline fallback.
What’s included
	•	WindFieldProvider — fetches the time-indexed wind.json, interpolates wind trilinearly (bilinear lat/lon + linear altitude + linear time), with O(1) grid lookup, on-disk caching (offline/restart), and stale-data detection.
	•	Map wind layer — client-drawn vector barbs replacing the server-rendered PNG. Altitude-selectable, zoom-thinned, driven by the layer-menu time slider. Displays native grid data (nearest forecast step, no interpolation).
	•	Route tab — per-leg wind effect computed by integrating ground speed along each leg in 4-D, with altitude ramping between waypoints’ planned altitudes and the clock advancing. Navlog shows ETA-aware ETE/GS/TH/W/V.
	•	Sideview — wind projected onto the route profile as a barb grid (distance × altitude); red = headwind, green = tailwind.
	•	Single global toggle (GlobalSettings.showWindLayer) drives wind on both the map and the sideview.
	•	Removed the now-dead server-side wind PNG plumbing from ForecastMapProvider.
Server side (separate repo): wind.json is generated from the AROME IP1 u/v field; wind PNG rendering dropped.