### PR TITLE
GDL90 Traffic: suppress "No GPS reception" warning when phone GNSS is primary source

### DIFF
--- a/src/traffic/TrafficDataSource_Abstract_GDL90.cpp
+++ b/src/traffic/TrafficDataSource_Abstract_GDL90.cpp
@@ -21,6 +21,7 @@
 #include <array>
 
 #include "GlobalObject.h"
+#include "GlobalSettings.h"
 #include "positioning/Geoid.h"
 #include "positioning/PositionProvider.h"
 #include "traffic/TrafficDataSource_Abstract.h"
@@ -257,9 +258,16 @@ void Traffic::TrafficDataSource_Abstract::processGDLMessage(const QByteArray& ra
         // Handle runtime errors
         QStringList results;
         auto status = static_cast<quint8>(message.at(0));
+        // Only report missing GPS when the traffic receiver is the primary position
+        // source. If the phone's built-in GNSS is used instead, a traffic-only
+        // receiver (without built-in GPS) legitimately sends this bit as 0.
         if ((status & 1<<7) == 0)
         {
-            results += tr("No GPS reception");
+            auto* gs = GlobalObject::globalSettings();
+            if (gs == nullptr || gs->positioningByTrafficDataReceiver())
+            {
+                results += tr("No GPS reception");
+            }
         }
         if ((status & 1<<6) != 0)
         {


### PR DESCRIPTION
Fixes issue #654.

A GDL90 traffic receiver without built-in GPS legitimately sets the GPS-valid bit (bit 7) to 0 in every heartbeat message. Previously, enroute treated this unconditionally as a runtime error and displayed "No GPS reception" to the user — even when the device's own built-in GNSS was selected as the primary position source.

Fix: only raise the "No GPS reception" error when setting positioningByTrafficDataReceiver is true, i.e. when the traffic receiver is actually expected to supply position data.

Tested with Flight Simulator and [fs2ff](https://github.com/jeffdamp-wave/fs2ff) where you can disable position reporting with GDL90 protocol.
